### PR TITLE
Enforce a fixed number of fractional digits per unit type.

### DIFF
--- a/LoopKit/HKUnit.swift
+++ b/LoopKit/HKUnit.swift
@@ -19,7 +19,7 @@ public extension HKUnit {
     }
 
     /// A formatting helper for determining the preferred decimal style for a given unit
-    var preferredMinimumFractionDigits: Int {
+    var preferredFractionDigits: Int {
         if self == HKUnit.milligramsPerDeciliterUnit() {
             return 0
         } else {

--- a/LoopKit/UI/DailyQuantityScheduleTableViewController.swift
+++ b/LoopKit/UI/DailyQuantityScheduleTableViewController.swift
@@ -18,8 +18,8 @@ public class DailyQuantityScheduleTableViewController: SingleValueScheduleTableV
         }
     }
 
-    override func preferredValueMinimumFractionDigits() -> Int {
-        return unit.preferredMinimumFractionDigits
+    override func preferredValueFractionDigits() -> Int {
+        return unit.preferredFractionDigits
     }
 
 }

--- a/LoopKit/UI/GlucoseRangeScheduleTableViewController.swift
+++ b/LoopKit/UI/GlucoseRangeScheduleTableViewController.swift
@@ -96,7 +96,8 @@ public class GlucoseRangeScheduleTableViewController: DailyValueScheduleTableVie
             cell.timeZone = timeZone
             cell.date = midnight.addingTimeInterval(item.startTime)
 
-            cell.valueNumberFormatter.minimumFractionDigits = unit.preferredMinimumFractionDigits
+            cell.valueNumberFormatter.minimumFractionDigits = unit.preferredFractionDigits
+            cell.valueNumberFormatter.maximumFractionDigits = unit.preferredFractionDigits
 
             cell.minValue = item.value.minValue
             cell.value = item.value.maxValue
@@ -121,7 +122,8 @@ public class GlucoseRangeScheduleTableViewController: DailyValueScheduleTableVie
         case .override:
             let cell = tableView.dequeueReusableCell(withIdentifier: GlucoseRangeOverrideTableViewCell.className, for: indexPath) as! GlucoseRangeOverrideTableViewCell
 
-            cell.valueNumberFormatter.minimumFractionDigits = unit.preferredMinimumFractionDigits
+            cell.valueNumberFormatter.minimumFractionDigits = unit.preferredFractionDigits
+            cell.valueNumberFormatter.maximumFractionDigits = unit.preferredFractionDigits
 
             if let workoutRange = workoutRange {
                 cell.minValue = workoutRange.minValue

--- a/LoopKit/UI/SingleValueScheduleTableViewController.swift
+++ b/LoopKit/UI/SingleValueScheduleTableViewController.swift
@@ -52,7 +52,7 @@ public class SingleValueScheduleTableViewController: DailyValueScheduleTableView
         return insertableIndices(for: scheduleItems, removing: row, with: timeInterval)
     }
 
-    func preferredValueMinimumFractionDigits() -> Int {
+    func preferredValueFractionDigits() -> Int {
         return 1
     }
 
@@ -71,7 +71,8 @@ public class SingleValueScheduleTableViewController: DailyValueScheduleTableView
         cell.timeZone = timeZone
         cell.date = midnight.addingTimeInterval(item.startTime)
 
-        cell.valueNumberFormatter.minimumFractionDigits = preferredValueMinimumFractionDigits()
+        cell.valueNumberFormatter.minimumFractionDigits = preferredValueFractionDigits()
+        cell.valueNumberFormatter.maximumFractionDigits = preferredValueFractionDigits()
 
         cell.value = item.value
         cell.unitString = unitDisplayString


### PR DESCRIPTION
At all times, we prefer:
  0 fractional digits for mg/dL
  1 fractional digit

eliminate the use of significant digits and use fixed a number of
fractional digits everywhere.

This is in service of:
  https://github.com/LoopKit/Loop/issues/324