### PR TITLE
Trim current basals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ xcode_scheme:
     - InsulinKit
     - GlucoseKit
 script:
-   - xcodebuild -project LoopKit.xcodeproj -scheme LoopKit -sdk iphonesimulator10.2 build -destination 'id=DB794781-65A7-4884-8D00-AAC3CBD39A44' test
-   - xcodebuild -project LoopKit.xcodeproj -scheme CarbKit -sdk iphonesimulator10.2 build -destination 'id=DB794781-65A7-4884-8D00-AAC3CBD39A44' test
-   - xcodebuild -project LoopKit.xcodeproj -scheme InsulinKit -sdk iphonesimulator10.2 build -destination 'id=DB794781-65A7-4884-8D00-AAC3CBD39A44' test
-   - xcodebuild -project LoopKit.xcodeproj -scheme GlucoseKit -sdk iphonesimulator10.2 build -destination 'id=DB794781-65A7-4884-8D00-AAC3CBD39A44' test
+   - xcodebuild -project LoopKit.xcodeproj -scheme LoopKit -sdk iphonesimulator10.2 build -destination 'name=iPhone SE' test
+   - xcodebuild -project LoopKit.xcodeproj -scheme CarbKit -sdk iphonesimulator10.2 build -destination 'name=iPhone SE' test
+   - xcodebuild -project LoopKit.xcodeproj -scheme InsulinKit -sdk iphonesimulator10.2 build -destination 'name=iPhone SE' test
+   - xcodebuild -project LoopKit.xcodeproj -scheme GlucoseKit -sdk iphonesimulator10.2 build -destination 'name=iPhone SE' test

--- a/InsulinKit/DoseStore.swift
+++ b/InsulinKit/DoseStore.swift
@@ -987,9 +987,10 @@ public final class DoseStore {
     /// - Parameters:
     ///   - start: The earliest date of values to retrieve
     ///   - end: The latest date of values to retrieve, if provided
+    ///   - parameter basalDosingEnd: The date at which continuing doses should be assumed to be cancelled
     ///   - completionHandler: A closure called once the values have been retrieved
     ///   - result: An array of insulin values, in chronological order
-    public func getInsulinOnBoardValues(start: Date, end: Date? = nil, completionHandler: @escaping (_ result: DoseStoreResult<[InsulinValue]>) -> Void) {
+    public func getInsulinOnBoardValues(start: Date, end: Date? = nil, basalDosingEnd: Date? = nil,completionHandler: @escaping (_ result: DoseStoreResult<[InsulinValue]>) -> Void) {
         guard let insulinActionDuration = self.insulinActionDuration else {
             completionHandler(.failure(.configurationError))
             return
@@ -1002,7 +1003,8 @@ public final class DoseStore {
             case .failure(let error):
                 completionHandler(.failure(error))
             case .success(let doses):
-                let insulinOnBoard = InsulinMath.insulinOnBoardForDoses(doses, actionDuration: insulinActionDuration)
+                let trimmedDoses = InsulinMath.trimContinuingDoses(doses, endDate: basalDosingEnd)
+                let insulinOnBoard = InsulinMath.insulinOnBoardForDoses(trimmedDoses, actionDuration: insulinActionDuration)
                 completionHandler(.success(insulinOnBoard.filterDateRange(start, end)))
             }
         }
@@ -1015,13 +1017,14 @@ public final class DoseStore {
 
      - parameter startDate:     The earliest date of effects to retrieve. The earliest supported value is the previous midnight in the current time zone.
      - parameter endDate:       The latest date of effects to retrieve. Defaults to the distant future.
+     - parameter basalDosingEnd: The date at which continuing doses should be assumed to be cancelled
      - parameter resultHandler: A closure called once the effects have been retrieved. The closure takes two arguments:
         - effects: The retrieved timeline of effects
         - error:   An error object explaining why the retrieval failed
      */
     @available(*, deprecated, message: "Use getGlucoseEffects(start:end:completionHandler:) instead")
-    public func getGlucoseEffects(startDate: Date, endDate: Date? = nil, resultHandler: @escaping (_ effects: [GlucoseEffect], _ error: DoseStoreError?) -> Void) {
-        getGlucoseEffects(start: startDate, end: endDate) { (result) in
+    public func getGlucoseEffects(startDate: Date, endDate: Date? = nil, basalDosingEnd: Date? = Date(), resultHandler: @escaping (_ effects: [GlucoseEffect], _ error: DoseStoreError?) -> Void) {
+        getGlucoseEffects(start: startDate, end: endDate, basalDosingEnd: basalDosingEnd) { (result) in
             switch result {
             case .failure(let error):
                 resultHandler([], error)
@@ -1038,9 +1041,10 @@ public final class DoseStore {
     /// - Parameters:
     ///   - start: The earliest date of effects to retrieve
     ///   - end: The latest date of effects to retrieve, if provided
+    ///   - parameter basalDosingEnd: The date at which continuing doses should be assumed to be cancelled
     ///   - completionHandler: A closure called once the effects have been retrieved
     ///   - result: An array of effects, in chronological order
-    public func getGlucoseEffects(start: Date, end: Date? = nil, completionHandler: @escaping (_ result: DoseStoreResult<[GlucoseEffect]>) -> Void) {
+    public func getGlucoseEffects(start: Date, end: Date? = nil, basalDosingEnd: Date? = Date(), completionHandler: @escaping (_ result: DoseStoreResult<[GlucoseEffect]>) -> Void) {
         guard let insulinActionDuration = self.insulinActionDuration,
               let insulinSensitivitySchedule = self.insulinSensitivitySchedule
         else {
@@ -1055,7 +1059,8 @@ public final class DoseStore {
             case .failure(let error):
                 completionHandler(.failure(error))
             case .success(let doses):
-                let glucoseEffects = InsulinMath.glucoseEffectsForDoses(doses, actionDuration: insulinActionDuration, insulinSensitivity: insulinSensitivitySchedule)
+                let trimmedDoses = InsulinMath.trimContinuingDoses(doses, endDate: basalDosingEnd)
+                let glucoseEffects = InsulinMath.glucoseEffectsForDoses(trimmedDoses, actionDuration: insulinActionDuration, insulinSensitivity: insulinSensitivitySchedule)
                 completionHandler(.success(glucoseEffects.filterDateRange(start, end)))
             }
         }

--- a/InsulinKit/DoseStore.swift
+++ b/InsulinKit/DoseStore.swift
@@ -987,7 +987,7 @@ public final class DoseStore {
     /// - Parameters:
     ///   - start: The earliest date of values to retrieve
     ///   - end: The latest date of values to retrieve, if provided
-    ///   - parameter basalDosingEnd: The date at which continuing doses should be assumed to be cancelled
+    ///   - basalDosingEnd: The date at which continuing doses should be assumed to be cancelled
     ///   - completionHandler: A closure called once the values have been retrieved
     ///   - result: An array of insulin values, in chronological order
     public func getInsulinOnBoardValues(start: Date, end: Date? = nil, basalDosingEnd: Date? = nil,completionHandler: @escaping (_ result: DoseStoreResult<[InsulinValue]>) -> Void) {
@@ -1041,7 +1041,7 @@ public final class DoseStore {
     /// - Parameters:
     ///   - start: The earliest date of effects to retrieve
     ///   - end: The latest date of effects to retrieve, if provided
-    ///   - parameter basalDosingEnd: The date at which continuing doses should be assumed to be cancelled
+    ///   - basalDosingEnd: The date at which continuing doses should be assumed to be cancelled
     ///   - completionHandler: A closure called once the effects have been retrieved
     ///   - result: An array of effects, in chronological order
     public func getGlucoseEffects(start: Date, end: Date? = nil, basalDosingEnd: Date? = Date(), completionHandler: @escaping (_ result: DoseStoreResult<[GlucoseEffect]>) -> Void) {

--- a/InsulinKit/DoseStore.swift
+++ b/InsulinKit/DoseStore.swift
@@ -1017,14 +1017,13 @@ public final class DoseStore {
 
      - parameter startDate:     The earliest date of effects to retrieve. The earliest supported value is the previous midnight in the current time zone.
      - parameter endDate:       The latest date of effects to retrieve. Defaults to the distant future.
-     - parameter basalDosingEnd: The date at which continuing doses should be assumed to be cancelled
      - parameter resultHandler: A closure called once the effects have been retrieved. The closure takes two arguments:
         - effects: The retrieved timeline of effects
         - error:   An error object explaining why the retrieval failed
      */
     @available(*, deprecated, message: "Use getGlucoseEffects(start:end:completionHandler:) instead")
-    public func getGlucoseEffects(startDate: Date, endDate: Date? = nil, basalDosingEnd: Date? = Date(), resultHandler: @escaping (_ effects: [GlucoseEffect], _ error: DoseStoreError?) -> Void) {
-        getGlucoseEffects(start: startDate, end: endDate, basalDosingEnd: basalDosingEnd) { (result) in
+    public func getGlucoseEffects(startDate: Date, endDate: Date? = nil, resultHandler: @escaping (_ effects: [GlucoseEffect], _ error: DoseStoreError?) -> Void) {
+        getGlucoseEffects(start: startDate, end: endDate) { (result) in
             switch result {
             case .failure(let error):
                 resultHandler([], error)

--- a/InsulinKit/InsulinMath.swift
+++ b/InsulinKit/InsulinMath.swift
@@ -495,7 +495,6 @@ struct InsulinMath {
     static func trimContinuingDoses<T: Collection>(_ doses: T, endDate: Date?) -> [DoseEntry] where T.Iterator.Element == DoseEntry {
 
         return doses.map {
-
             if let endDate = endDate, $0.type == .tempBasal, $0.endDate > endDate {
                 return DoseEntry(
                     type: $0.type,
@@ -508,6 +507,5 @@ struct InsulinMath {
                 return $0
             }
         }
-
     }
 }

--- a/InsulinKit/InsulinMath.swift
+++ b/InsulinKit/InsulinMath.swift
@@ -491,4 +491,34 @@ struct InsulinMath {
 
         return values
     }
+
+    static func trimContinuingDoses<T: Collection>(_ doses: T, endDate: Date?) -> [DoseEntry] where T.Iterator.Element == DoseEntry {
+
+        guard let endDate = endDate else {
+            return doses as! [DoseEntry]
+        }
+
+        var trimmed: [DoseEntry] = []
+
+        for dose in doses {
+            switch dose.type {
+            case .tempBasal:
+                if dose.endDate > endDate {
+                    trimmed.append(DoseEntry(
+                        type: dose.type,
+                        startDate: dose.startDate,
+                        endDate: endDate,
+                        value: dose.value,
+                        unit: dose.unit,
+                        description: dose.description
+                    ))
+                } else {
+                    trimmed.append(dose)
+                }
+            default:
+                trimmed.append(dose)
+            }
+        }
+        return trimmed
+    }
 }

--- a/InsulinKit/InsulinMath.swift
+++ b/InsulinKit/InsulinMath.swift
@@ -494,31 +494,20 @@ struct InsulinMath {
 
     static func trimContinuingDoses<T: Collection>(_ doses: T, endDate: Date?) -> [DoseEntry] where T.Iterator.Element == DoseEntry {
 
-        guard let endDate = endDate else {
-            return doses as! [DoseEntry]
-        }
+        return doses.map {
 
-        var trimmed: [DoseEntry] = []
-
-        for dose in doses {
-            switch dose.type {
-            case .tempBasal:
-                if dose.endDate > endDate {
-                    trimmed.append(DoseEntry(
-                        type: dose.type,
-                        startDate: dose.startDate,
-                        endDate: endDate,
-                        value: dose.value,
-                        unit: dose.unit,
-                        description: dose.description
-                    ))
-                } else {
-                    trimmed.append(dose)
-                }
-            default:
-                trimmed.append(dose)
+            if let endDate = endDate, $0.type == .tempBasal, $0.endDate > endDate {
+                return DoseEntry(
+                    type: $0.type,
+                    startDate: $0.startDate,
+                    endDate: endDate,
+                    value: $0.value,
+                    unit: $0.unit,
+                    description: $0.description)
+            } else {
+                return $0
             }
         }
-        return trimmed
+
     }
 }

--- a/InsulinKitTests/InsulinMathTests.swift
+++ b/InsulinKitTests/InsulinMathTests.swift
@@ -362,6 +362,7 @@ class InsulinMathTests: XCTestCase {
         let trimmed = InsulinMath.trimContinuingDoses(input, endDate: endDate)
 
         XCTAssertEqual(endDate, trimmed.last!.endDate)
+        XCTAssertEqual(input.count, trimmed.count)
     }
 
 }

--- a/InsulinKitTests/InsulinMathTests.swift
+++ b/InsulinKitTests/InsulinMathTests.swift
@@ -352,4 +352,16 @@ class InsulinMathTests: XCTestCase {
 
         XCTAssertEqualWithAccuracy(18.8, output, accuracy: pow(10, -2))
     }
+
+    func testTrimContinuingDoses() {
+        let dateFormatter = DateFormatter.ISO8601LocalTime()
+        let input = loadDoseFixture("normalized_doses")
+
+        // Last temp ends at 2015-10-15T18:14:35
+        let endDate = dateFormatter.date(from: "2015-10-15T18:00:00")!
+        let trimmed = InsulinMath.trimContinuingDoses(input, endDate: endDate)
+
+        XCTAssertEqual(endDate, trimmed.last!.endDate)
+    }
+
 }


### PR DESCRIPTION
Allow caller to pass in a basalDosingEnd date to avoid including ongoing temp basals in forecast