### PR TITLE
Feature/disregard primes using event history

### DIFF
--- a/InsulinKit/DoseStore.swift
+++ b/InsulinKit/DoseStore.swift
@@ -600,13 +600,14 @@ public final class DoseStore {
             } else {
                 self.pumpEventQueryAfterDate = self.recentValuesStartDate ?? .distantPast
             }
-            
-            self.invalidateLastPrimeEvent()
 
             self.persistenceController.save { (error) in
                 completion(DoseStoreError(error: error))
                 NotificationCenter.default.post(name: .DoseStoreValuesDidChange, object: self)
             }
+            
+            self.invalidateLastPrimeEvent()
+            self.validateReservoirContinuity()
         }
     }
 

--- a/InsulinKit/DoseStore.swift
+++ b/InsulinKit/DoseStore.swift
@@ -539,10 +539,8 @@ public final class DoseStore {
 
             // There is no guarantee of event ordering, so we must search the entire array to find key date boundaries.
             for event in events {
-                if let dose = event.dose {
-                    if dose.type == PumpEventType.prime {
-                        primeValueAdded = true
-                    }
+                if event.type == PumpEventType.prime {
+                    primeValueAdded = true
                 }
 
                 if event.isMutable {

--- a/InsulinKit/DoseStore.swift
+++ b/InsulinKit/DoseStore.swift
@@ -147,9 +147,6 @@ public final class DoseStore {
                         self.pumpEventQueryAfterDate = lastEvent.date
                     }
 
-                    // Warm the state of pump event data, looking for prime events, before validating reservoir continuity
-                    //self.lastPrimeEventDate = self.getLastPrimeEventDateFromStore()
-
                     // Warm the state of the reservoir data.
                     // These are in reverse-chronological order
                     // To populate `lastReservoirVolumeDrop`, we set the most recent 2 in-order.

--- a/InsulinKit/DoseStore.swift
+++ b/InsulinKit/DoseStore.swift
@@ -539,6 +539,7 @@ public final class DoseStore {
             var lastFinalDate: Date?
             var firstMutableDate: Date?
             var primeValueAdded = false
+            var typeDetected: PumpEventType?
 
             var mutablePumpEventDoses: [DoseEntry] = []
 
@@ -546,6 +547,7 @@ public final class DoseStore {
             for event in events {
                 if event.type == PumpEventType.prime {
                     primeValueAdded = true
+                    typeDetected = .prime
                 }
                 
                 if event.isMutable {
@@ -563,6 +565,10 @@ public final class DoseStore {
                     object.raw = event.raw
                     object.dose = event.dose
                     object.title = event.title
+                    
+                    if let type = typeDetected {
+                        object.type = type
+                    }
                 }
             }
 

--- a/InsulinKit/DoseStore.swift
+++ b/InsulinKit/DoseStore.swift
@@ -540,15 +540,10 @@ public final class DoseStore {
 
             // There is no guarantee of event ordering, so we must search the entire array to find key date boundaries.
             for event in events {
-                var newPumpEventType: PumpEventType?
-                
                 if let eventType = event.type {
-                    
                     if eventType == .prime {
                         primeValueAdded = true
                     }
-                    
-                    newPumpEventType = eventType
                 }
                 
                 if event.isMutable {

--- a/InsulinKit/DoseStore.swift
+++ b/InsulinKit/DoseStore.swift
@@ -549,8 +549,10 @@ public final class DoseStore {
 
             // There is no guarantee of event ordering, so we must search the entire array to find key date boundaries.
             for event in events {
-                if case .prime? = event.type {
-                    lastPrimeEventDate = max(event.date, lastPrimeEventDate ?? event.date)
+                if let dose = event.dose {
+                    if dose.type == PumpEventType.prime {
+                        lastPrimeEventDate = max(event.date, lastPrimeEventDate ?? event.date)
+                    }
                 }
 
                 if event.isMutable {

--- a/InsulinKit/DoseStore.swift
+++ b/InsulinKit/DoseStore.swift
@@ -535,12 +535,13 @@ public final class DoseStore {
             var lastFinalDate: Date?
             var firstMutableDate: Date?
             var primeValueAdded = false
-            var typeOverride: PumpEventType?
 
             var mutablePumpEventDoses: [DoseEntry] = []
 
             // There is no guarantee of event ordering, so we must search the entire array to find key date boundaries.
             for event in events {
+                var typeOverride: PumpEventType?
+                
                 if event.type == PumpEventType.prime {
                     primeValueAdded = true
                     typeOverride = .prime
@@ -1093,7 +1094,7 @@ public final class DoseStore {
             "* areReservoirValuesContinuous: \(areReservoirValuesContinuous)",
             "* primeEventExistsWithinInsulinOnboardTime: \(primeEventExistsWithinInsulinOnboardTime)",
             "* totalDeliveryCache: \(String(describing: totalDeliveryCache))",
-            "* lastPrimeEventDate: \(_lastRecordedPrimeEventDate)",
+            "* lastPrimeEventDate: \(String(describing: _lastRecordedPrimeEventDate))",
         ]
 
         getReservoirValues(since: Date.distantPast) { (result) in

--- a/InsulinKit/DoseStore.swift
+++ b/InsulinKit/DoseStore.swift
@@ -566,21 +566,7 @@ public final class DoseStore {
                     object.raw = event.raw
                     object.title = event.title
                     
-                    if let dose = event.dose {
-                        object.type = dose.type
-                        object.startDate = dose.startDate as Date
-                        object.endDate = dose.endDate as Date
-                        object.value = dose.value
-                        object.unit = dose.unit
-                    }
-                    
-                    // NewEventType.type takes precedence over the Dose.type if they conflict
-                    if let newPumpEventType = newPumpEventType {
-                        object.type = newPumpEventType
-                    }
-
-                    
-                    
+                    object.setValuesWith(pumpEventType: event.type, dose: event.dose)
                 }
             }
 

--- a/InsulinKit/DoseStore.swift
+++ b/InsulinKit/DoseStore.swift
@@ -600,6 +600,8 @@ public final class DoseStore {
             } else {
                 self.pumpEventQueryAfterDate = self.recentValuesStartDate ?? .distantPast
             }
+            
+            self.invalidateLastPrimeEvent()
 
             self.persistenceController.save { (error) in
                 completion(DoseStoreError(error: error))

--- a/InsulinKit/DoseStore.swift
+++ b/InsulinKit/DoseStore.swift
@@ -539,8 +539,10 @@ public final class DoseStore {
 
             // There is no guarantee of event ordering, so we must search the entire array to find key date boundaries.
             for event in events {
-                if event.type == PumpEventType.prime {
-                    primeValueAdded = true
+                if let dose = event.dose {
+                    if dose.type == PumpEventType.prime {
+                        primeValueAdded = true
+                    }
                 }
 
                 if event.isMutable {

--- a/InsulinKit/DoseStore.swift
+++ b/InsulinKit/DoseStore.swift
@@ -539,7 +539,7 @@ public final class DoseStore {
             var lastFinalDate: Date?
             var firstMutableDate: Date?
             var primeValueAdded = false
-            var typeDetected: PumpEventType?
+            var typeOverride: PumpEventType?
 
             var mutablePumpEventDoses: [DoseEntry] = []
 
@@ -547,7 +547,7 @@ public final class DoseStore {
             for event in events {
                 if event.type == PumpEventType.prime {
                     primeValueAdded = true
-                    typeDetected = .prime
+                    typeOverride = .prime
                 }
                 
                 if event.isMutable {
@@ -566,8 +566,8 @@ public final class DoseStore {
                     object.dose = event.dose
                     object.title = event.title
                     
-                    if let type = typeDetected {
-                        object.type = type
+                    if let typeOverride = typeOverride {
+                        object.type = typeOverride
                     }
                 }
             }
@@ -613,10 +613,10 @@ public final class DoseStore {
             self.persistenceController.save { (error) in
                 completion(DoseStoreError(error: error))
                 NotificationCenter.default.post(name: .DoseStoreValuesDidChange, object: self)
+                
+                self.invalidateLastPrimeEvent()
+                self.validateReservoirContinuity()
             }
-            
-            self.invalidateLastPrimeEvent()
-            self.validateReservoirContinuity()
         }
     }
 

--- a/InsulinKit/DoseStore.swift
+++ b/InsulinKit/DoseStore.swift
@@ -273,11 +273,7 @@ public final class DoseStore {
                 )
                 
                 // also make sure prime events don't exist withing the Insulin On Board time
-                if let lastPrimeEventData = getLastPrimeEventDate() {
-                    self.primeEventExistsWithinInsulinOnboardTime = lastPrimeEventData >= oldestRelevantReservoirObject.startDate
-                } else {
-                    self.primeEventExistsWithinInsulinOnboardTime = false
-                }
+                self.primeEventExistsWithinInsulinOnboardTime = getLastPrimeEventDate() >= oldestRelevantReservoirObject.startDate
 
                 return recentReservoirObjects
             }
@@ -1157,7 +1153,7 @@ public final class DoseStore {
     /// Get the date of the last prime event. Updates from CoreData if value is invalid
     ///
     /// - Returns: Date of the last Prime Event, or nil if none found
-    private func getLastPrimeEventDate() -> Date? {
+    private func getLastPrimeEventDate() -> Date {
         if _lastRecordedPrimeEventDate == nil {
             if let pumpEvents = try? self.getPumpEventObjects(
                 matching: NSPredicate(format: "type = %@", PumpEventType.prime.rawValue),
@@ -1165,9 +1161,11 @@ public final class DoseStore {
                 ),
                 let firstEvent = pumpEvents.first {
                 _lastRecordedPrimeEventDate =  firstEvent.date
+            } else {
+                _lastRecordedPrimeEventDate = Date.distantPast
             }
         }
         
-        return _lastRecordedPrimeEventDate
+        return _lastRecordedPrimeEventDate ?? Date.distantPast
     }
 }

--- a/InsulinKit/DoseStore.swift
+++ b/InsulinKit/DoseStore.swift
@@ -540,11 +540,15 @@ public final class DoseStore {
 
             // There is no guarantee of event ordering, so we must search the entire array to find key date boundaries.
             for event in events {
-                var typeOverride: PumpEventType?
+                var newPumpEventType: PumpEventType?
                 
-                if event.type == PumpEventType.prime {
-                    primeValueAdded = true
-                    typeOverride = .prime
+                if let eventType = event.type {
+                    
+                    if eventType == .prime {
+                        primeValueAdded = true
+                    }
+                    
+                    newPumpEventType = eventType
                 }
                 
                 if event.isMutable {
@@ -560,12 +564,23 @@ public final class DoseStore {
 
                     object.date = event.date
                     object.raw = event.raw
-                    object.dose = event.dose
                     object.title = event.title
                     
-                    if let typeOverride = typeOverride {
-                        object.type = typeOverride
+                    if let dose = event.dose {
+                        object.type = dose.type
+                        object.startDate = dose.startDate as Date
+                        object.endDate = dose.endDate as Date
+                        object.value = dose.value
+                        object.unit = dose.unit
                     }
+                    
+                    // NewEventType.type takes precedence over the Dose.type if they conflict
+                    if let newPumpEventType = newPumpEventType {
+                        object.type = newPumpEventType
+                    }
+
+                    
+                    
                 }
             }
 

--- a/InsulinKit/InsulinMath.swift
+++ b/InsulinKit/InsulinMath.swift
@@ -318,6 +318,8 @@ struct InsulinMath {
                 }
 
                 lastSuspend = dose
+            case .prime:
+                break
             }
         }
 

--- a/InsulinKit/NewPumpEvent.swift
+++ b/InsulinKit/NewPumpEvent.swift
@@ -18,14 +18,17 @@ public struct NewPumpEvent {
     public let isMutable: Bool
     /// The opaque raw data representing the event
     public let raw: Data?
+    /// The type of pump event
+    public let type: PumpEventType?
     /// A human-readable title to describe the event
     public let title: String
 
-    public init(date: Date, dose: DoseEntry?, isMutable: Bool, raw: Data, title: String) {
+    public init(date: Date, dose: DoseEntry?, isMutable: Bool, raw: Data, title: String, type: PumpEventType? = nil) {
         self.date = date
         self.dose = dose
         self.isMutable = isMutable
         self.raw = raw
         self.title = title
+        self.type = type
     }
 }

--- a/InsulinKit/PersistedPumpEvent.swift
+++ b/InsulinKit/PersistedPumpEvent.swift
@@ -23,4 +23,6 @@ public protocol PersistedPumpEvent {
     var raw: Data? { get }
     /// A human-readable short description of the event
     var title: String? { get }
+    /// The type of pump event
+    var type: PumpEventType? { get }
 }

--- a/InsulinKit/PumpEvent.swift
+++ b/InsulinKit/PumpEvent.swift
@@ -119,17 +119,17 @@ extension PumpEvent {
 
             return DoseEntry(type: type, startDate: startDate, endDate: endDate, value: value, unit: unit, managedObjectID: objectID)
         }
-        set {
-            guard let entry = newValue else {
-                return
-            }
-
-            type = entry.type
-            startDate = entry.startDate as Date
-            endDate = entry.endDate as Date
-            value = entry.value
-            unit = entry.unit
-        }
+//        set {
+//            guard let entry = newValue else {
+//                return
+//            }
+//
+//            type = entry.type
+//            startDate = entry.startDate as Date
+//            endDate = entry.endDate as Date
+//            value = entry.value
+//            unit = entry.unit
+//        }
     }
 
     var isUploaded: Bool {

--- a/InsulinKit/PumpEvent.swift
+++ b/InsulinKit/PumpEvent.swift
@@ -119,17 +119,23 @@ extension PumpEvent {
 
             return DoseEntry(type: type, startDate: startDate, endDate: endDate, value: value, unit: unit, managedObjectID: objectID)
         }
-//        set {
-//            guard let entry = newValue else {
-//                return
-//            }
-//
-//            type = entry.type
-//            startDate = entry.startDate as Date
-//            endDate = entry.endDate as Date
-//            value = entry.value
-//            unit = entry.unit
-//        }
+    }
+    
+    func setValuesWith(pumpEventType: PumpEventType?, dose: DoseEntry?) {
+        // This could also be done inline in DoseStore.addPumpEvents
+        // I'm OK with either place since it's only used once
+        if let dose = dose {
+            type = dose.type
+            startDate = dose.startDate as Date
+            endDate = dose.endDate as Date
+            value = dose.value
+            unit = dose.unit
+        }
+        
+        // PumpEventType takes precedence over the Dose.type if they conflict
+        if let pumpEventType = pumpEventType {
+            type = pumpEventType
+        }
     }
 
     var isUploaded: Bool {

--- a/InsulinKit/PumpEventType.swift
+++ b/InsulinKit/PumpEventType.swift
@@ -12,6 +12,7 @@ import Foundation
 /// A subset of pump event types, with raw values matching decocare's strings
 public enum PumpEventType: String {
     case bolus     = "Bolus"
+    case prime     = "Prime"
     case resume    = "PumpResume"
     case suspend   = "PumpSuspend"
     case tempBasal = "TempBasal"

--- a/InsulinKit/UI/InsulinDeliveryTableViewController.swift
+++ b/InsulinKit/UI/InsulinDeliveryTableViewController.swift
@@ -334,7 +334,7 @@ public final class InsulinDeliveryTableViewController: UITableViewController {
     }
 
     public override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        return true
+        return false
     }
 
     public override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {


### PR DESCRIPTION
Don't use reservoir values if a Prime Pump Event has been detected during the Insulin On Board time.