### PR TITLE
Adjusting insulin math to rely on PumpEventType in all cases

### DIFF
--- a/CarbKitTests/CarbMathTests.swift
+++ b/CarbKitTests/CarbMathTests.swift
@@ -75,7 +75,7 @@ class CarbMathTests: XCTestCase {
 
         for (expected, calculated) in zip(output, effects) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
-            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), calculated.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), accuracy: pow(10, -11))
+            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), calculated.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), accuracy: Double(Float.ulpOfOne))
         }
     }
 
@@ -89,7 +89,7 @@ class CarbMathTests: XCTestCase {
 
         for (expected, calculated) in zip(output, cob) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
-            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: HKUnit.gram()), calculated.quantity.doubleValue(for: HKUnit.gram()), accuracy: pow(10, -11))
+            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: HKUnit.gram()), calculated.quantity.doubleValue(for: HKUnit.gram()), accuracy: Double(Float.ulpOfOne))
         }
     }
 

--- a/Extensions/NSTimeInterval.swift
+++ b/Extensions/NSTimeInterval.swift
@@ -10,6 +10,10 @@ import Foundation
 
 
 extension TimeInterval {
+    static func minutes(_ minutes: Double) -> TimeInterval {
+        return self.init(minutes: minutes)
+    }
+
     init(minutes: Double) {
         self.init(minutes * 60)
     }

--- a/GlucoseKitTests/GlucoseMathTests.swift
+++ b/GlucoseKitTests/GlucoseMathTests.swift
@@ -63,7 +63,7 @@ class GlucoseMathTests: XCTestCase {
 
         for (expected, calculated) in zip(output, effects) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
-            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: unit), calculated.quantity.doubleValue(for: unit), accuracy: pow(10, -14))
+            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: unit), calculated.quantity.doubleValue(for: unit), accuracy: Double(Float.ulpOfOne))
         }
     }
 
@@ -78,7 +78,7 @@ class GlucoseMathTests: XCTestCase {
 
         for (expected, calculated) in zip(output, effects) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
-            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: unit), calculated.quantity.doubleValue(for: unit), accuracy: pow(10, -14))
+            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: unit), calculated.quantity.doubleValue(for: unit), accuracy: Double(Float.ulpOfOne))
         }
     }
 
@@ -93,7 +93,7 @@ class GlucoseMathTests: XCTestCase {
 
         for (expected, calculated) in zip(output, effects) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
-            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: unit), calculated.quantity.doubleValue(for: unit), accuracy: pow(10, -14))
+            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: unit), calculated.quantity.doubleValue(for: unit), accuracy: Double(Float.ulpOfOne))
         }
     }
 
@@ -108,7 +108,7 @@ class GlucoseMathTests: XCTestCase {
 
         for (expected, calculated) in zip(output, effects) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
-            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: unit), calculated.quantity.doubleValue(for: unit), accuracy: pow(10, -14))
+            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: unit), calculated.quantity.doubleValue(for: unit), accuracy: Double(Float.ulpOfOne))
         }
     }
 

--- a/InsulinKit/DoseEntry.swift
+++ b/InsulinKit/DoseEntry.swift
@@ -15,7 +15,7 @@ public struct DoseEntry: TimelineValue {
     public let type: PumpEventType
     public let startDate: Date
     public let endDate: Date
-    public let value: Double
+    internal let value: Double
     public let unit: DoseUnit
     public let description: String?
     let managedObjectID: NSManagedObjectID?
@@ -25,11 +25,11 @@ public struct DoseEntry: TimelineValue {
     }
 
     public init(suspendDate: Date) {
-        self.init(type: .suspend, startDate: suspendDate, value: 0, unit: .unitsPerHour)
+        self.init(type: .suspend, startDate: suspendDate, value: 0, unit: .units)
     }
 
     public init(resumeDate: Date) {
-        self.init(type: .resume, startDate: resumeDate, value: 0, unit: .unitsPerHour)
+        self.init(type: .resume, startDate: resumeDate, value: 0, unit: .units)
     }
 
     init(type: PumpEventType, startDate: Date, endDate: Date? = nil, value: Double, unit: DoseUnit, description: String? = nil, managedObjectID: NSManagedObjectID?) {
@@ -40,5 +40,26 @@ public struct DoseEntry: TimelineValue {
         self.unit = unit
         self.description = description
         self.managedObjectID = managedObjectID
+    }
+}
+
+
+extension DoseEntry {
+    public var units: Double {
+        switch unit {
+        case .units:
+            return value
+        case .unitsPerHour:
+            return value * endDate.timeIntervalSince(startDate).hours
+        }
+    }
+
+    public var unitsPerHour: Double {
+        switch unit {
+        case .units:
+            return value / endDate.timeIntervalSince(startDate).hours
+        case .unitsPerHour:
+            return value
+        }
     }
 }

--- a/InsulinKit/PumpEventType.swift
+++ b/InsulinKit/PumpEventType.swift
@@ -11,6 +11,7 @@ import Foundation
 
 /// A subset of pump event types, with raw values matching decocare's strings
 public enum PumpEventType: String {
+    case basal     = "BasalProfileStart"
     case bolus     = "Bolus"
     case prime     = "Prime"
     case resume    = "PumpResume"

--- a/InsulinKitTests/Fixtures/reservoir_history_with_rewind_and_prime_output.json
+++ b/InsulinKitTests/Fixtures/reservoir_history_with_rewind_and_prime_output.json
@@ -1,154 +1,154 @@
 [
   {
-    "amount": 0.9060402684565818,
+    "amount": 0.075,
     "start_at": "2016-01-30T20:30:43",
     "description": "Reservoir decreased 0.075U over 4.97min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T20:35:41"
   },
   {
-    "amount": 0.8970099667772726,
+    "amount": 0.075,
     "start_at": "2016-01-30T20:25:42",
     "description": "Reservoir decreased 0.075U over 5.02min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T20:30:43"
   },
   {
-    "amount": 0.6000000000001364,
+    "amount": 0.05,
     "start_at": "2016-01-30T20:20:42",
     "description": "Reservoir decreased 0.05U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T20:25:42"
   },
   {
-    "amount": 14.352159468438403,
+    "amount": 1.2,
     "start_at": "2016-01-30T20:15:41",
     "description": "Reservoir decreased 1.2U over 5.02min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T20:20:42"
   },
   {
-    "amount": 3.0100334448160533,
+    "amount": 0.25,
     "start_at": "2016-01-30T20:10:42",
     "description": "Reservoir decreased 0.25U over 4.98min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T20:15:41"
   },
   {
-    "amount": 2.3999999999998636,
+    "amount": 0.2,
     "start_at": "2016-01-30T20:05:42",
     "description": "Reservoir decreased 0.2U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T20:10:42"
   },
   {
-    "amount": 2.990033222591362,
+    "amount": 0.25,
     "start_at": "2016-01-30T20:00:41",
     "description": "Reservoir decreased 0.25U over 5.02min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T20:05:42"
   },
   {
-    "amount": 1.8000000000000682,
+    "amount": 0.15,
     "start_at": "2016-01-30T19:55:41",
     "description": "Reservoir decreased 0.15U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T20:00:41"
   },
   {
-    "amount": 2.4000000000002046,
+    "amount": 0.2,
     "start_at": "2016-01-30T19:50:41",
     "description": "Reservoir decreased 0.2U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T19:55:41"
   },
   {
-    "amount": 1.1999999999999318,
+    "amount": 0.1,
     "start_at": "2016-01-30T19:45:41",
     "description": "Reservoir decreased 0.1U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T19:50:41"
   },
   {
-    "amount": 0.8999999999998636,
+    "amount": 0.075,
     "start_at": "2016-01-30T19:40:41",
     "description": "Reservoir decreased 0.075U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T19:45:41"
   },
   {
-    "amount": 9.632107023411509,
+    "amount": 0.80,
     "start_at": "2016-01-30T19:35:42",
-    "description": "Reservoir decreased 0.8U over 4.98min",
+    "description": "Reservoir decreased 0.80U over 4.98min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T19:40:41"
   },
   {
-    "amount": 4.199999999999932,
+    "amount": 0.7,
     "start_at": "2016-01-30T19:25:42",
     "description": "Reservoir decreased 0.7U over 10.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T19:35:42"
   },
   {
-    "amount": 0.6000000000001364,
+    "amount": 0.05,
     "start_at": "2016-01-30T19:20:42",
     "description": "Reservoir decreased 0.05U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T19:25:42"
   },
   {
-    "amount": 0.8999999999998636,
+    "amount": 0.075,
     "start_at": "2016-01-30T19:15:42",
     "description": "Reservoir decreased 0.075U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T19:20:42"
   },
   {
-    "amount": 0.8970099667776126,
+    "amount": 0.075,
     "start_at": "2016-01-30T19:10:41",
     "description": "Reservoir decreased 0.075U over 5.02min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T19:15:42"
   },
   {
-    "amount": 0.6020066889630054,
+    "amount": 0.05,
     "start_at": "2016-01-30T19:05:42",
     "description": "Reservoir decreased 0.05U over 4.98min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T19:10:41"
   },
   {
-    "amount": 0.9000000000002046,
+    "amount": 0.075,
     "start_at": "2016-01-30T19:00:42",
     "description": "Reservoir decreased 0.075U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T19:05:42"
   },
   {
-    "amount": 0.8970099667772726,
+    "amount": 0.075,
     "start_at": "2016-01-30T18:55:41",
     "description": "Reservoir decreased 0.075U over 5.02min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T19:00:42"
   },
   {
@@ -156,7 +156,7 @@
     "start_at": "2016-01-30T18:50:41",
     "description": "Reservoir decreased 0.0U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T18:55:41"
   },
   {
@@ -164,47 +164,47 @@
     "start_at": "2016-01-30T18:45:41",
     "description": "Reservoir decreased 0.0U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T18:50:41"
   },
   {
-    "amount": 0.3020134228188606,
+    "amount": 0.025,
     "start_at": "2016-01-30T18:40:43",
     "description": "Reservoir decreased 0.025U over 4.97min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T18:45:41"
   },
   {
-    "amount": 0.5960264900660219,
+    "amount": 0.05,
     "start_at": "2016-01-30T18:35:41",
     "description": "Reservoir decreased 0.05U over 5.03min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T18:40:43"
   },
   {
-    "amount": 0.9030100334450214,
+    "amount": 0.075,
     "start_at": "2016-01-30T18:30:42",
     "description": "Reservoir decreased 0.075U over 4.98min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T18:35:41"
   },
   {
-    "amount": 0.9030100334446791,
+    "amount": 0.075,
     "start_at": "2016-01-30T18:25:43",
     "description": "Reservoir decreased 0.075U over 4.98min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T18:30:42"
   },
   {
-    "amount": 0.897009966777613,
+    "amount": 0.075,
     "start_at": "2016-01-30T18:20:42",
-    "description": "Reservoir decreased 0.05U over 5.02min",
+    "description": "Reservoir decreased 0.075U over 5.02min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T18:25:43"
   },
   {
@@ -212,199 +212,199 @@
     "start_at": "2016-01-30T18:10:42",
     "description": "Reservoir decreased 0.0U over 5.03min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T18:15:44"
   },
   {
-    "amount": 0.3000000000000682,
+    "amount": 0.025,
     "start_at": "2016-01-30T18:05:42",
     "description": "Reservoir decreased 0.025U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T18:10:42"
   },
   {
-    "amount": 16.5,
+    "amount": 1.375,
     "start_at": "2016-01-30T18:00:42",
     "description": "Reservoir decreased 1.375U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T18:05:42"
   },
   {
-    "amount": 0.8999999999998636,
+    "amount": 0.075,
     "start_at": "2016-01-30T17:55:42",
     "description": "Reservoir decreased 0.075U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T18:00:42"
   },
   {
-    "amount": 0.6040268456377212,
+    "amount": 0.05,
     "start_at": "2016-01-30T17:50:44",
     "description": "Reservoir decreased 0.05U over 4.97min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T17:55:42"
   },
   {
-    "amount": 0.8999999999998636,
+    "amount": 0.075,
     "start_at": "2016-01-30T17:45:44",
     "description": "Reservoir decreased 0.075U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T17:50:44"
   },
   {
-    "amount": 1.7880794701987432,
+    "amount": 0.15,
     "start_at": "2016-01-30T17:40:42",
     "description": "Reservoir decreased 0.15U over 5.03min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T17:45:44"
   },
   {
-    "amount": 1.1999999999999318,
+    "amount": 0.1,
     "start_at": "2016-01-30T17:35:42",
     "description": "Reservoir decreased 0.1U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T17:40:42"
   },
   {
-    "amount": 1.7940199335548852,
+    "amount": 0.15,
     "start_at": "2016-01-30T17:30:41",
     "description": "Reservoir decreased 0.15U over 5.02min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T17:35:42"
   },
   {
-    "amount": 1.8120805369128203,
+    "amount": 0.15,
     "start_at": "2016-01-30T17:25:43",
     "description": "Reservoir decreased 0.15U over 4.97min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T17:30:41"
   },
   {
-    "amount": 0.6020066889630054,
+    "amount": 0.05,
     "start_at": "2016-01-30T17:20:44",
     "description": "Reservoir decreased 0.05U over 4.98min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T17:25:43"
   },
   {
-    "amount": 0.894039735099541,
+    "amount": 0.075,
     "start_at": "2016-01-30T17:15:42",
     "description": "Reservoir decreased 0.075U over 5.03min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T17:20:44"
   },
   {
-    "amount": 0.8970099667772726,
+    "amount": 0.075,
     "start_at": "2016-01-30T17:10:41",
     "description": "Reservoir decreased 0.075U over 5.02min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T17:15:42"
   },
   {
-    "amount": 0.6020066889633475,
+    "amount": 0.05,
     "start_at": "2016-01-30T17:05:42",
     "description": "Reservoir decreased 0.05U over 4.98min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T17:10:41"
   },
   {
-    "amount": 46.96969696969697,
+    "amount": 3.875,
     "start_at": "2016-01-30T17:00:45",
     "description": "Reservoir decreased 3.875U over 4.95min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T17:05:42"
   },
   {
-    "amount": 2.9850746268656714,
+    "amount": 0.5,
     "start_at": "2016-01-30T16:50:42",
     "description": "Reservoir decreased 0.5U over 10.05min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T17:00:45"
   },
   {
-    "amount": 2.3999999999998636,
+    "amount": 0.2,
     "start_at": "2016-01-30T16:45:42",
     "description": "Reservoir decreased 0.2U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T16:50:42"
   },
   {
-    "amount": 2.3999999999998636,
+    "amount": 0.2,
     "start_at": "2016-01-30T16:40:42",
     "description": "Reservoir decreased 0.2U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T16:45:42"
   },
   {
-    "amount": 3.0100334448160533,
+    "amount": 0.25,
     "start_at": "2016-01-30T16:35:43",
     "description": "Reservoir decreased 0.25U over 4.98min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T16:40:42"
   },
   {
-    "amount": 1.7940199335548852,
+    "amount": 0.15,
     "start_at": "2016-01-30T16:30:42",
     "description": "Reservoir decreased 0.15U over 5.02min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T16:35:43"
   },
   {
-    "amount": 1.8000000000000682,
+    "amount": 0.15,
     "start_at": "2016-01-30T16:25:42",
     "description": "Reservoir decreased 0.15U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T16:30:42"
   },
   {
-    "amount": 0.5980066445184083,
+    "amount": 0.05,
     "start_at": "2016-01-30T16:20:41",
     "description": "Reservoir decreased 0.05U over 5.02min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T16:25:42"
   },
   {
-    "amount": 0.9030100334446791,
+    "amount": 0.075,
     "start_at": "2016-01-30T16:15:42",
     "description": "Reservoir decreased 0.075U over 4.98min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T16:20:41"
   },
   {
-    "amount": 0.8999999999998636,
+    "amount": 0.075,
     "start_at": "2016-01-30T16:10:42",
     "description": "Reservoir decreased 0.075U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T16:15:42"
   },
   {
-    "amount": 0.6000000000001364,
+    "amount": 0.05,
     "start_at": "2016-01-30T16:05:42",
     "description": "Reservoir decreased 0.05U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T16:10:42"
   },
   {
@@ -412,7 +412,7 @@
     "start_at": "2016-01-30T16:00:42",
     "description": "Reservoir decreased 0.0U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T16:05:42"
   },
   {
@@ -420,15 +420,15 @@
     "start_at": "2016-01-30T15:45:42",
     "description": "Reservoir decreased 0.0U over 5.00min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T15:50:42"
   },
   {
-    "amount": 2.457337883959044,
+    "amount": 0.2,
     "start_at": "2016-01-30T15:40:49",
     "description": "Reservoir decreased 0.2U over 4.88min",
     "type": "TempBasal",
-    "unit": "U/hour",
+    "unit": "U",
     "end_at": "2016-01-30T15:45:42"
   }
 ]

--- a/InsulinKitTests/InsulinMathTests.swift
+++ b/InsulinKitTests/InsulinMathTests.swift
@@ -95,7 +95,7 @@ class InsulinMathTests: XCTestCase {
         for (expected, calculated) in zip(output, doses) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
             XCTAssertEqual(expected.endDate, calculated.endDate)
-            XCTAssertEqualWithAccuracy(expected.value, calculated.value, accuracy: pow(10, -14))
+            XCTAssertEqualWithAccuracy(expected.value, calculated.value, accuracy: Double(Float.ulpOfOne))
             XCTAssertEqual(expected.unit, calculated.unit)
         }
     }
@@ -178,7 +178,7 @@ class InsulinMathTests: XCTestCase {
 
             for (expected, calculated) in zip(output, iob) {
                 XCTAssertEqual(expected.startDate, calculated.startDate)
-                XCTAssertEqualWithAccuracy(expected.value, calculated.value, accuracy: pow(10, -14))
+                XCTAssertEqualWithAccuracy(expected.value, calculated.value, accuracy: Double(Float.ulpOfOne))
             }
         }
     }
@@ -218,7 +218,7 @@ class InsulinMathTests: XCTestCase {
         for (expected, calculated) in zip(output, doses) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
             XCTAssertEqual(expected.endDate, calculated.endDate)
-            XCTAssertEqualWithAccuracy(expected.value, calculated.value, accuracy: pow(10, -14))
+            XCTAssertEqualWithAccuracy(expected.value, calculated.value, accuracy: Double(Float.ulpOfOne))
             XCTAssertEqual(expected.unit, calculated.unit)
         }
     }
@@ -295,7 +295,7 @@ class InsulinMathTests: XCTestCase {
 
         for (expected, calculated) in zip(output, effects) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
-            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: .milligramsPerDeciliter()), calculated.quantity.doubleValue(for: .milligramsPerDeciliter()), accuracy: pow(10, -14))
+            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: .milligramsPerDeciliter()), calculated.quantity.doubleValue(for: .milligramsPerDeciliter()), accuracy: Double(Float.ulpOfOne))
         }
     }
 
@@ -350,7 +350,7 @@ class InsulinMathTests: XCTestCase {
         let input = loadDoseFixture("normalize_edge_case_doses_input")
         let output = InsulinMath.totalDeliveryForDoses(input)
 
-        XCTAssertEqualWithAccuracy(18.8, output, accuracy: pow(10, -2))
+        XCTAssertEqualWithAccuracy(18.8, output, accuracy: 0.01)
     }
 
     func testTrimContinuingDoses() {

--- a/LoopKit/BasalRateSchedule.swift
+++ b/LoopKit/BasalRateSchedule.swift
@@ -30,7 +30,7 @@ public class BasalRateSchedule: DailyValueSchedule<Double> {
                 endTime = items[index + 1].startTime
             }
 
-            total += (endTime - item.startTime) / TimeInterval(hours: 1) * item.value
+            total += (endTime - item.startTime).hours * item.value
         }
         
         return total

--- a/LoopKit/UI/GlucoseRangeOverrideTableViewCell.xib
+++ b/LoopKit/UI/GlucoseRangeOverrideTableViewCell.xib
@@ -1,9 +1,13 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -19,13 +23,13 @@
                         <rect key="frame" x="8" y="0.0" width="30" height="43.5"/>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="248" verticalHuggingPriority="251" horizontalCompressionResistancePriority="752" text="Workout" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vj3-UD-z09">
-                        <rect key="frame" x="46" y="8" width="113.5" height="28"/>
+                        <rect key="frame" x="46" y="8" width="109.5" height="28"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="min" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="e6a-FR-F1s">
-                        <rect key="frame" x="167" y="8" width="35" height="28"/>
+                        <rect key="frame" x="163" y="8" width="36" height="28"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
                         <connections>
@@ -33,13 +37,13 @@
                         </connections>
                     </textField>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="–" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pXd-Eo-nXg">
-                        <rect key="frame" x="205" y="8" width="9" height="27"/>
+                        <rect key="frame" x="202" y="8" width="9" height="27"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="max" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="yNd-og-d4r">
-                        <rect key="frame" x="217" y="8" width="35" height="27.5"/>
+                        <rect key="frame" x="214" y="8" width="36" height="27.5"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
                         <connections>
@@ -47,9 +51,9 @@
                         </connections>
                     </textField>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="U/hour" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xmj-pp-6GS">
-                        <rect key="frame" x="255" y="8" width="50" height="27"/>
+                        <rect key="frame" x="253" y="8" width="52" height="27"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                        <color key="textColor" white="0.56000000000000005" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="textColor" red="0.56000000238418579" green="0.56000000238418579" blue="0.56000000238418579" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>

--- a/LoopKitTests/LoopMathTests.swift
+++ b/LoopKitTests/LoopMathTests.swift
@@ -71,7 +71,7 @@ class LoopMathTests: XCTestCase {
 
         for (expected, calculated) in zip(expected, calculated) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
-            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), calculated.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), accuracy: pow(10, -11))
+            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), calculated.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), accuracy: Double(Float.ulpOfOne))
         }
     }
 
@@ -86,7 +86,7 @@ class LoopMathTests: XCTestCase {
 
         for (expected, calculated) in zip(expected, calculated) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
-            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), calculated.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), accuracy: pow(10, -11))
+            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), calculated.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), accuracy: Double(Float.ulpOfOne))
         }
     }
 
@@ -101,7 +101,7 @@ class LoopMathTests: XCTestCase {
 
         for (expected, calculated) in zip(expected, calculated) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
-            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), calculated.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), accuracy: pow(10, -11))
+            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), calculated.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), accuracy: Double(Float.ulpOfOne))
         }
     }
 
@@ -116,7 +116,7 @@ class LoopMathTests: XCTestCase {
 
         for (expected, calculated) in zip(expected, calculated) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
-            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), calculated.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), accuracy: pow(10, -11))
+            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), calculated.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), accuracy: Double(Float.ulpOfOne))
         }
     }
 
@@ -132,7 +132,7 @@ class LoopMathTests: XCTestCase {
 
         for (expected, calculated) in zip(expected, calculated) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
-            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), calculated.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), accuracy: pow(10, -11))
+            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), calculated.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), accuracy: Double(Float.ulpOfOne))
         }
     }
 
@@ -156,7 +156,7 @@ class LoopMathTests: XCTestCase {
 
         for (expected, calculated) in zip(expected, calculated) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
-            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), calculated.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), accuracy: pow(10, -11))
+            XCTAssertEqualWithAccuracy(expected.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), calculated.quantity.doubleValue(for: HKUnit.milligramsPerDeciliter()), accuracy: Double(Float.ulpOfOne))
         }
     }
 
@@ -169,7 +169,7 @@ class LoopMathTests: XCTestCase {
 
         var startingEffect = HKQuantity(unit: unit.unitDivided(by: HKUnit.minute()), doubleValue: 2)
 
-        var effects = LoopMath.decayEffect(from: glucose, atRate: startingEffect, for: TimeInterval(30 * 60))
+        var effects = LoopMath.decayEffect(from: glucose, atRate: startingEffect, for: .minutes(30))
 
         XCTAssertEqual([100, 110, 118, 124, 128, 130, 130], effects.map { $0.quantity.doubleValue(for: unit) })
 
@@ -177,7 +177,7 @@ class LoopMathTests: XCTestCase {
         XCTAssertEqual([0, 5, 10, 15, 20, 25, 30], effects.map { $0.startDate.timeIntervalSince(startDate).minutes })
 
         startingEffect = HKQuantity(unit: unit.unitDivided(by: HKUnit.minute()), doubleValue: -0.5)
-        effects = LoopMath.decayEffect(from: glucose, atRate: startingEffect, for: TimeInterval(30 * 60))
+        effects = LoopMath.decayEffect(from: glucose, atRate: startingEffect, for: .minutes(30))
         XCTAssertEqual([100, 97.5, 95.5, 94, 93, 92.5, 92.5], effects.map { $0.quantity.doubleValue(for: unit) })
     }
 
@@ -190,7 +190,7 @@ class LoopMathTests: XCTestCase {
 
         var startingEffect = HKQuantity(unit: unit.unitDivided(by: HKUnit.minute()), doubleValue: 2)
 
-        var effects = LoopMath.decayEffect(from: glucose, atRate: startingEffect, for: TimeInterval(30 * 60))
+        var effects = LoopMath.decayEffect(from: glucose, atRate: startingEffect, for: .minutes(30))
 
         XCTAssertEqual([100, 110, 118, 124, 128, 130], effects.map { $0.quantity.doubleValue(for: unit) })
 
@@ -198,7 +198,7 @@ class LoopMathTests: XCTestCase {
         XCTAssertEqual([0, 5, 10, 15, 20, 25], effects.map { $0.startDate.timeIntervalSince(startDate).minutes })
 
         startingEffect = HKQuantity(unit: unit.unitDivided(by: HKUnit.minute()), doubleValue: -0.5)
-        effects = LoopMath.decayEffect(from: glucose, atRate: startingEffect, for: TimeInterval(30 * 60))
+        effects = LoopMath.decayEffect(from: glucose, atRate: startingEffect, for: .minutes(30))
         XCTAssertEqual([100, 97.5, 95.5, 94, 93, 92.5], effects.map { $0.quantity.doubleValue(for: unit) })
     }
 }


### PR DESCRIPTION
... rather than inferring from the unit.

* Replacing magic accuracy numbers for JSON fixture tests with Float.ulpOfOne
* Adding a new pump event for scheduled basal
