### PR TITLE
Fix BasalProfileStart and Resume reconciliation

### DIFF
--- a/LoopKit/InsulinKit/InsulinMath.swift
+++ b/LoopKit/InsulinKit/InsulinMath.swift
@@ -322,7 +322,7 @@ extension Collection where Iterator.Element == DoseEntry {
                     lastSuspend = nil
 
                     // Continue temp basals that may have started before suspending
-                    if let last = lastBasal, last.type == .tempBasal {
+                    if let last = lastBasal {
                         if last.endDate > dose.endDate {
                             lastBasal = DoseEntry(
                                 type: last.type,


### PR DESCRIPTION
This doesn't have an effect on IOB (thankfully) because BasalProfileStart events are always net 0 glucose effect, but it does result in incorrect total daily dose values in HealthKit.