### PR TITLE
Read Insulin Delivery from HealthKit

### DIFF
--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -116,6 +116,17 @@
 		433BC7AB20538D4C000B1200 /* CachedGlucoseObject+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433BC7A920538D4C000B1200 /* CachedGlucoseObject+CoreDataProperties.swift */; };
 		433BC7AD20538FCA000B1200 /* StoredGlucoseSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433BC7AC20538FCA000B1200 /* StoredGlucoseSample.swift */; };
 		433BC7B120562705000B1200 /* UpdateSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433BC7B020562705000B1200 /* UpdateSource.swift */; };
+		434113AA20F171CB00D05747 /* CachedInsulinDeliveryObject+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434113A820F171CB00D05747 /* CachedInsulinDeliveryObject+CoreDataClass.swift */; };
+		434113AB20F171CB00D05747 /* CachedInsulinDeliveryObject+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434113A920F171CB00D05747 /* CachedInsulinDeliveryObject+CoreDataProperties.swift */; };
+		434113AD20F287DC00D05747 /* NSManagedObjectContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434113AC20F287DC00D05747 /* NSManagedObjectContext.swift */; };
+		434113AF20F2885300D05747 /* NSManagedObjectContext+CachedInsulinDeliveryObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434113AE20F2885300D05747 /* NSManagedObjectContext+CachedInsulinDeliveryObject.swift */; };
+		434113B120F2888100D05747 /* NSManagedObjectContext+CachedGlucoseObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434113B020F2888100D05747 /* NSManagedObjectContext+CachedGlucoseObject.swift */; };
+		434113B320F2890800D05747 /* PersistenceControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434113B220F2890800D05747 /* PersistenceControllerTests.swift */; };
+		434113B520F2BDB500D05747 /* CachedInsulinDeliveryObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434113B420F2BDB500D05747 /* CachedInsulinDeliveryObjectTests.swift */; };
+		434113B820F2BDE800D05747 /* PersistenceControllerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434113B720F2BDE800D05747 /* PersistenceControllerTestCase.swift */; };
+		434113BA20F2C41C00D05747 /* DeletedCarbObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434113B920F2C41C00D05747 /* DeletedCarbObjectTests.swift */; };
+		434113BC20F2C56100D05747 /* CachedGlucoseObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434113BB20F2C56100D05747 /* CachedGlucoseObjectTests.swift */; };
+		434113BE20F2C72000D05747 /* CachedCarbObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434113BD20F2C72000D05747 /* CachedCarbObjectTests.swift */; };
 		4343951F205EED1F0056DC37 /* counteraction_effect_falling_glucose_output.json in Resources */ = {isa = PBXBuildFile; fileRef = 4343951E205EED1F0056DC37 /* counteraction_effect_falling_glucose_output.json */; };
 		43439521205F2D910056DC37 /* counteraction_effect_falling_glucose_input.json in Resources */ = {isa = PBXBuildFile; fileRef = 43439520205F2D910056DC37 /* counteraction_effect_falling_glucose_input.json */; };
 		434570441FE605E30089C4DC /* OSLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434570431FE605E30089C4DC /* OSLog.swift */; };
@@ -479,6 +490,17 @@
 		433BC7AC20538FCA000B1200 /* StoredGlucoseSample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredGlucoseSample.swift; sourceTree = "<group>"; };
 		433BC7B020562705000B1200 /* UpdateSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateSource.swift; sourceTree = "<group>"; };
 		433D705D1EFB29700004EB9F /* FoodTypeShortcutCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoodTypeShortcutCell.swift; sourceTree = "<group>"; };
+		434113A820F171CB00D05747 /* CachedInsulinDeliveryObject+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CachedInsulinDeliveryObject+CoreDataClass.swift"; sourceTree = "<group>"; };
+		434113A920F171CB00D05747 /* CachedInsulinDeliveryObject+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CachedInsulinDeliveryObject+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		434113AC20F287DC00D05747 /* NSManagedObjectContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSManagedObjectContext.swift; sourceTree = "<group>"; };
+		434113AE20F2885300D05747 /* NSManagedObjectContext+CachedInsulinDeliveryObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+CachedInsulinDeliveryObject.swift"; sourceTree = "<group>"; };
+		434113B020F2888100D05747 /* NSManagedObjectContext+CachedGlucoseObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+CachedGlucoseObject.swift"; sourceTree = "<group>"; };
+		434113B220F2890800D05747 /* PersistenceControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceControllerTests.swift; sourceTree = "<group>"; };
+		434113B420F2BDB500D05747 /* CachedInsulinDeliveryObjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedInsulinDeliveryObjectTests.swift; sourceTree = "<group>"; };
+		434113B720F2BDE800D05747 /* PersistenceControllerTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceControllerTestCase.swift; sourceTree = "<group>"; };
+		434113B920F2C41C00D05747 /* DeletedCarbObjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletedCarbObjectTests.swift; sourceTree = "<group>"; };
+		434113BB20F2C56100D05747 /* CachedGlucoseObjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedGlucoseObjectTests.swift; sourceTree = "<group>"; };
+		434113BD20F2C72000D05747 /* CachedCarbObjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedCarbObjectTests.swift; sourceTree = "<group>"; };
 		4343951E205EED1F0056DC37 /* counteraction_effect_falling_glucose_output.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = counteraction_effect_falling_glucose_output.json; sourceTree = "<group>"; };
 		43439520205F2D910056DC37 /* counteraction_effect_falling_glucose_input.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = counteraction_effect_falling_glucose_input.json; sourceTree = "<group>"; };
 		434570431FE605E30089C4DC /* OSLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLog.swift; sourceTree = "<group>"; };
@@ -825,6 +847,19 @@
 			path = "View Controllers";
 			sourceTree = "<group>";
 		};
+		434113B620F2BDB900D05747 /* Persistence */ = {
+			isa = PBXGroup;
+			children = (
+				434113BD20F2C72000D05747 /* CachedCarbObjectTests.swift */,
+				434113BB20F2C56100D05747 /* CachedGlucoseObjectTests.swift */,
+				434113B420F2BDB500D05747 /* CachedInsulinDeliveryObjectTests.swift */,
+				434113B920F2C41C00D05747 /* DeletedCarbObjectTests.swift */,
+				434113B220F2890800D05747 /* PersistenceControllerTests.swift */,
+				434113B720F2BDE800D05747 /* PersistenceControllerTestCase.swift */,
+			);
+			path = Persistence;
+			sourceTree = "<group>";
+		};
 		435F355C1C9CD14E00C204D2 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -869,6 +904,7 @@
 			isa = PBXGroup;
 			children = (
 				43D8FEE01C7294D50073BE78 /* Model.xcdatamodeld */,
+				434113AC20F287DC00D05747 /* NSManagedObjectContext.swift */,
 				43D8FEE21C7294D50073BE78 /* PersistenceController.swift */,
 				43CF0B3E2030FD0D002A66DE /* UploadState.swift */,
 				433BC7B020562705000B1200 /* UpdateSource.swift */,
@@ -1024,6 +1060,7 @@
 		43D8FDD91C728FDF0073BE78 /* LoopKitTests */ = {
 			isa = PBXGroup;
 			children = (
+				434113B620F2BDB900D05747 /* Persistence */,
 				437AFF1B203A45CF008C4892 /* Extensions */,
 				43D988911C87FEFF00DA4467 /* Fixtures */,
 				43D8FDDC1C728FDF0073BE78 /* Info.plist */,
@@ -1099,6 +1136,7 @@
 				432CF86E20D76CCF0066B889 /* GlucoseTrend.swift */,
 				43FADDFA1C89679200DDE013 /* HKQuantitySample+GlucoseKit.swift */,
 				433BC7A620523DB7000B1200 /* NewGlucoseSample.swift */,
+				434113B020F2888100D05747 /* NSManagedObjectContext+CachedGlucoseObject.swift */,
 				432CF87020D76D5A0066B889 /* SensorDisplayable.swift */,
 				433BC7AC20538FCA000B1200 /* StoredGlucoseSample.swift */,
 			);
@@ -1134,6 +1172,8 @@
 		43D8FEB21C7294520073BE78 /* InsulinKit */ = {
 			isa = PBXGroup;
 			children = (
+				434113A820F171CB00D05747 /* CachedInsulinDeliveryObject+CoreDataClass.swift */,
+				434113A920F171CB00D05747 /* CachedInsulinDeliveryObject+CoreDataProperties.swift */,
 				43D8FEDC1C7294D50073BE78 /* DoseEntry.swift */,
 				43D8FEDD1C7294D50073BE78 /* DoseStore.swift */,
 				43A0670E1F23CAC700E9E90F /* DoseType.swift */,
@@ -1145,6 +1185,7 @@
 				C12EE16B1F2964B3007DB9F1 /* InsulinModel.swift */,
 				43DFE2811CB1FB8500EFBE95 /* InsulinValue.swift */,
 				4302F4EA1D50670500F0FCAF /* NewPumpEvent.swift */,
+				434113AE20F2885300D05747 /* NSManagedObjectContext+CachedInsulinDeliveryObject.swift */,
 				4302F4EC1D5068CE00F0FCAF /* PersistedPumpEvent.swift */,
 				43DFE27B1CB1D6A600EFBE95 /* PumpEvent+CoreDataClass.swift */,
 				43DFE27C1CB1D6A600EFBE95 /* PumpEvent+CoreDataProperties.swift */,
@@ -1653,9 +1694,11 @@
 				437AFEED2036A156008C4892 /* CachedCarbObject+CoreDataClass.swift in Sources */,
 				43D8FDF71C7290350073BE78 /* DailyValueSchedule.swift in Sources */,
 				4322B77D202FA2AF0002837D /* NewPumpEvent.swift in Sources */,
+				434113AA20F171CB00D05747 /* CachedInsulinDeliveryObject+CoreDataClass.swift in Sources */,
 				432CF86F20D76CCF0066B889 /* GlucoseTrend.swift in Sources */,
 				43FB60E920DCBE64002B996B /* PumpManagerStatus.swift in Sources */,
 				4322B774202FA2790002837D /* CarbMath.swift in Sources */,
+				434113B120F2888100D05747 /* NSManagedObjectContext+CachedGlucoseObject.swift in Sources */,
 				4322B78B202FA2B30002837D /* ExponentialInsulinModel.swift in Sources */,
 				43D8FE011C7290350073BE78 /* NSTimeInterval.swift in Sources */,
 				43D8FDF61C7290350073BE78 /* DailyQuantitySchedule.swift in Sources */,
@@ -1665,6 +1708,7 @@
 				4322B77F202FA2AF0002837D /* PersistenceController.swift in Sources */,
 				4322B78D202FA2B30002837D /* InsulinDeliveryStore.swift in Sources */,
 				4322B78A202FA2B30002837D /* DoseUnit.swift in Sources */,
+				434113AF20F2885300D05747 /* NSManagedObjectContext+CachedInsulinDeliveryObject.swift in Sources */,
 				432762741D60505F0083215A /* HKQuantitySample.swift in Sources */,
 				43D8FDF81C7290350073BE78 /* Double.swift in Sources */,
 				432CF87320D774220066B889 /* PumpManager.swift in Sources */,
@@ -1686,6 +1730,7 @@
 				437AFEEE2036A156008C4892 /* CachedCarbObject+CoreDataProperties.swift in Sources */,
 				4322B772202FA2790002837D /* AbsorbedCarbValue.swift in Sources */,
 				1F5DAB1F2118C95700048054 /* LocalizedString.swift in Sources */,
+				434113AD20F287DC00D05747 /* NSManagedObjectContext.swift in Sources */,
 				4322B77B202FA2790002837D /* StoredCarbEntry.swift in Sources */,
 				4322B790202FA2B30002837D /* InsulinValue.swift in Sources */,
 				434C5F9E209938CD00B2FD1A /* NumberFormatter.swift in Sources */,
@@ -1698,6 +1743,7 @@
 				43B17C89208EEC0B00AC27E9 /* HealthStoreUnitCache.swift in Sources */,
 				4322B775202FA2790002837D /* CarbStatus.swift in Sources */,
 				4322B787202FA2B30002837D /* DoseEntry.swift in Sources */,
+				434113AB20F171CB00D05747 /* CachedInsulinDeliveryObject+CoreDataProperties.swift in Sources */,
 				43CF0B3F2030FD0D002A66DE /* UploadState.swift in Sources */,
 				433BC7AD20538FCA000B1200 /* StoredGlucoseSample.swift in Sources */,
 				43D8FDF91C7290350073BE78 /* GlucoseEffect.swift in Sources */,
@@ -1730,6 +1776,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1F5DAB202118C95700048054 /* LocalizedString.swift in Sources */,
+				434113B820F2BDE800D05747 /* PersistenceControllerTestCase.swift in Sources */,
 				437874B6202FDD1500A3D8B9 /* InsulinMathTests.swift in Sources */,
 				437AFF21203AA740008C4892 /* NSManagedObjectContext.swift in Sources */,
 				434C5FA1209AC4EE00B2FD1A /* HKUnit.swift in Sources */,
@@ -1737,16 +1784,21 @@
 				434C5FA0209ABD4700B2FD1A /* QuantityFormatterTests.swift in Sources */,
 				43D8FE1E1C72906E0073BE78 /* NSDateTests.swift in Sources */,
 				43D9888D1C87EBE400DA4467 /* LoopMathTests.swift in Sources */,
+				434113BA20F2C41C00D05747 /* DeletedCarbObjectTests.swift in Sources */,
 				437874B5202FDD1200A3D8B9 /* DoseStoreTests.swift in Sources */,
 				4322B76C202F9ECD0002837D /* CarbMathTests.swift in Sources */,
+				434113B520F2BDB500D05747 /* CachedInsulinDeliveryObjectTests.swift in Sources */,
 				43D8FE1F1C72906E0073BE78 /* QuantityScheduleTests.swift in Sources */,
 				437AFF1A2039F149008C4892 /* CarbStoreTests.swift in Sources */,
 				43D8FE1D1C72906E0073BE78 /* BasalRateScheduleTests.swift in Sources */,
+				434113B320F2890800D05747 /* PersistenceControllerTests.swift in Sources */,
+				434113BE20F2C72000D05747 /* CachedCarbObjectTests.swift in Sources */,
 				4303C4941E2D665F00ADEDC8 /* TimeZone.swift in Sources */,
 				4322B76D202F9EF20002837D /* GlucoseMathTests.swift in Sources */,
 				43025DAF1D5AB2E300106C28 /* NSTimeInterval.swift in Sources */,
 				43D8FDDB1C728FDF0073BE78 /* LoopKitTests.swift in Sources */,
 				437AFF1D203A45DB008C4892 /* CacheStore.swift in Sources */,
+				434113BC20F2C56100D05747 /* CachedGlucoseObjectTests.swift in Sources */,
 				430059241CCDD08C00C861EA /* NSDateFormatter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -265,6 +265,14 @@ extension CarbStore {
     ///   - completion: A closure called once the samples have been retrieved
     ///   - samples: An array of samples, in chronological order by startDate
     public func getCachedCarbSamples(start: Date, end: Date? = nil, completion: @escaping (_ samples: [StoredCarbEntry]) -> Void) {
+        // If we're within our cache duration, skip the HealthKit query
+        guard start <= earliestCacheDate else {
+            self.queue.async {
+                completion(self.getCachedCarbEntries().filterDateRange(start, end))
+            }
+            return
+        }
+
         getCarbSamples(start: start, end: end) { (result) in
             switch result {
             case .success(let samples):

--- a/LoopKit/CarbKit/DeletedCarbObject+CoreDataProperties.swift
+++ b/LoopKit/CarbKit/DeletedCarbObject+CoreDataProperties.swift
@@ -18,6 +18,6 @@ extension DeletedCarbObject {
 
     @NSManaged public var externalID: String?
     @NSManaged public var primitiveUploadState: NSNumber?
-    @NSManaged public var startDate: NSDate?
+    @NSManaged public var startDate: Date?
 
 }

--- a/LoopKit/GlucoseKit/GlucoseStore.swift
+++ b/LoopKit/GlucoseKit/GlucoseStore.swift
@@ -190,7 +190,18 @@ extension GlucoseStore {
             return
         }
 
-        let glucose = values.map { $0.quantitySample }
+        var glucose: [HKQuantitySample] = []
+
+        cacheStore.managedObjectContext.performAndWait {
+            glucose = values.compactMap {
+                guard self.cacheStore.managedObjectContext.cachedGlucoseObjectsWithSyncIdentifier($0.syncIdentifier, fetchLimit: 1).count == 0 else {
+                    log.default("Skipping adding dose due to existing cached syncIdentifier: %{public}@", $0.syncIdentifier)
+                    return nil
+                }
+
+                return $0.quantitySample
+            }
+        }
 
         healthStore.save(glucose) { (completed, error) in
             self.dataAccessQueue.async {
@@ -241,15 +252,24 @@ extension GlucoseStore {
     ///   - start: The earliest date of values to retrieve
     ///   - end: The latest date of values to retrieve, if provided
     ///   - completion: A closure called once the values have been retrieved
-    ///   - values: An array of glucose values, in chronological order by startDate
+    ///   - samples: An array of glucose values, in chronological order by startDate
     public func getCachedGlucoseSamples(start: Date, end: Date? = nil, completion: @escaping (_ samples: [StoredGlucoseSample]) -> Void) {
+        // If we're within our cache duration, skip the HealthKit query
+        guard start <= earliestCacheDate else {
+            self.dataAccessQueue.async {
+                completion(self.getCachedGlucoseObjects(start: start, end: end))
+            }
+            return
+        }
+
         getGlucoseSamples(start: start, end: end) { (result) in
             switch result {
             case .success(let samples):
                 completion(samples)
             case .failure:
+                // Expected when database is inaccessible
                 self.dataAccessQueue.async {
-                    completion(self.getCachedGlucoseSamples().filterDateRange(start, end))
+                    completion(self.getCachedGlucoseObjects(start: start, end: end))
                 }
             }
         }
@@ -281,18 +301,6 @@ extension GlucoseStore {
 
 
 // MARK: - Core Data
-extension NSManagedObjectContext {
-    fileprivate func cachedGlucoseObjectsWithUUID(_ uuid: UUID, fetchLimit: Int? = nil) -> [CachedGlucoseObject] {
-        let request: NSFetchRequest<CachedGlucoseObject> = CachedGlucoseObject.fetchRequest()
-        if let limit = fetchLimit {
-            request.fetchLimit = limit
-        }
-        request.predicate = NSPredicate(format: "uuid == %@", uuid as NSUUID)
-
-        return (try? fetch(request)) ?? []
-    }
-}
-
 extension GlucoseStore {
     @discardableResult
     private func addCachedObjects(for samples: [HKQuantitySample]) -> Bool {
@@ -308,7 +316,6 @@ extension GlucoseStore {
         dispatchPrecondition(condition: .onQueue(dataAccessQueue))
 
         var created = false
-
         cacheStore.managedObjectContext.performAndWait {
             for sample in samples {
                 guard
@@ -331,18 +338,32 @@ extension GlucoseStore {
         return created
     }
 
+    private func getCachedGlucoseObjects(start: Date, end: Date? = nil) -> [StoredGlucoseSample] {
+        let predicate: NSPredicate
+
+        if let end = end {
+            predicate = NSPredicate(format: "startDate >= %@ AND startDate <= %@", start as NSDate, end as NSDate)
+        } else {
+            predicate = NSPredicate(format: "startDate >= %@", start as NSDate)
+        }
+
+        return getCachedGlucoseObjects(matching: predicate)
+    }
+
     /// Fetches glucose samples from the cache that match the given predicate
     ///
-    /// - Parameter predicate: The predicate to apply to the objects
-    /// - Returns: An array of glucose samples, in chronological order by startDate
-    private func getCachedGlucoseSamples(matching predicate: NSPredicate? = nil) -> [StoredGlucoseSample] {
+    /// - Parameters:
+    ///   - predicate: The predicate to apply to the objects
+    ///   - isChronological: The sort order of the objects by startDate
+    /// - Returns: An array of glucose samples, in order by startDate
+    private func getCachedGlucoseObjects(matching predicate: NSPredicate? = nil, isChronological: Bool = true) -> [StoredGlucoseSample] {
         dispatchPrecondition(condition: .onQueue(dataAccessQueue))
         var samples: [StoredGlucoseSample] = []
 
         cacheStore.managedObjectContext.performAndWait {
             let request: NSFetchRequest<CachedGlucoseObject> = CachedGlucoseObject.fetchRequest()
             request.predicate = predicate
-            request.sortDescriptors = [NSSortDescriptor(key: "startDate", ascending: true)]
+            request.sortDescriptors = [NSSortDescriptor(key: "startDate", ascending: isChronological)]
 
             do {
                 let objects = try self.cacheStore.managedObjectContext.fetch(request)
@@ -403,25 +424,9 @@ extension GlucoseStore {
         dispatchPrecondition(condition: .onQueue(dataAccessQueue))
 
         cacheStore.managedObjectContext.performAndWait {
-            let fetchRequest: NSFetchRequest<NSFetchRequestResult> = CachedGlucoseObject.fetchRequest()
-            fetchRequest.predicate = predicate
-
-            let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
-            deleteRequest.resultType = .resultTypeObjectIDs
-
             do {
-                let result = try cacheStore.managedObjectContext.execute(deleteRequest)
-                if  let deleteResult = result as? NSBatchDeleteResult,
-                    let objectIDs = deleteResult.result as? [NSManagedObjectID]
-                {
-                    self.log.info("Deleted %d CachedGlucoseObjects", objectIDs.count)
-
-                    if objectIDs.count > 0 {
-                        let changes = [NSDeletedObjectsKey: objectIDs]
-                        NSManagedObjectContext.mergeChanges(fromRemoteContextSave: changes, into: [cacheStore.managedObjectContext])
-                        cacheStore.managedObjectContext.refreshAllObjects()
-                    }
-                }
+                let count = try cacheStore.managedObjectContext.purgeObjects(of: CachedGlucoseObject.self, matching: predicate)
+                self.log.default("Deleted %d CachedGlucoseObjects", count)
             } catch let error {
                 self.log.error("Unable to purge CachedGlucoseObjects: %@", String(describing: error))
             }
@@ -523,7 +528,7 @@ extension GlucoseStore {
                 "### cachedGlucoseSamples",
             ]
 
-            for sample in self.getCachedGlucoseSamples() {
+            for sample in self.getCachedGlucoseObjects() {
                 report.append(String(describing: sample))
             }
 

--- a/LoopKit/GlucoseKit/NSManagedObjectContext+CachedGlucoseObject.swift
+++ b/LoopKit/GlucoseKit/NSManagedObjectContext+CachedGlucoseObject.swift
@@ -1,0 +1,33 @@
+//
+//  NSManagedObjectContext+CachedGlucoseObject.swift
+//  LoopKit
+//
+//  Copyright © 2018 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+
+extension NSManagedObjectContext {
+    internal func cachedGlucoseObjectsWithUUID(_ uuid: UUID, fetchLimit: Int? = nil) -> [CachedGlucoseObject] {
+        let request: NSFetchRequest<CachedGlucoseObject> = CachedGlucoseObject.fetchRequest()
+        if let limit = fetchLimit {
+            request.fetchLimit = limit
+        }
+        request.predicate = NSPredicate(format: "uuid == %@", uuid as NSUUID)
+        request.sortDescriptors = [NSSortDescriptor(key: "uuid", ascending: true)]
+
+        return (try? fetch(request)) ?? []
+    }
+
+    internal func cachedGlucoseObjectsWithSyncIdentifier(_ syncIdentifier: String, fetchLimit: Int? = nil) -> [CachedGlucoseObject] {
+        let request: NSFetchRequest<CachedGlucoseObject> = CachedGlucoseObject.fetchRequest()
+        if let limit = fetchLimit {
+            request.fetchLimit = limit
+        }
+        request.predicate = NSPredicate(format: "syncIdentifier == %@", syncIdentifier)
+
+        return (try? fetch(request)) ?? []
+    }
+}

--- a/LoopKit/InsulinKit/CachedInsulinDeliveryObject+CoreDataClass.swift
+++ b/LoopKit/InsulinKit/CachedInsulinDeliveryObject+CoreDataClass.swift
@@ -1,0 +1,115 @@
+//
+//  CachedInsulinDeliveryObject+CoreDataClass.swift
+//  LoopKit
+//
+//  Copyright © 2018 LoopKit Authors. All rights reserved.
+//
+//
+
+import Foundation
+import CoreData
+import HealthKit
+
+
+class CachedInsulinDeliveryObject: NSManagedObject {
+
+    var reason: HKInsulinDeliveryReason! {
+        get {
+            willAccessValue(forKey: "reason")
+            defer { didAccessValue(forKey: "reason") }
+
+            guard let value = primitiveReason?.intValue else {
+                return nil
+            }
+
+            return HKInsulinDeliveryReason(rawValue: value)
+        }
+        set {
+            willChangeValue(forKey: "reason")
+            defer { didChangeValue(forKey: "reason") }
+
+            guard let value = newValue?.rawValue else {
+                primitiveReason = nil
+                return
+            }
+
+            primitiveReason = NSNumber(value: value)
+        }
+    }
+
+    var scheduledBasalRate: HKQuantity? {
+        get {
+            willAccessValue(forKey: "scheduledBasalRate")
+            defer { didAccessValue(forKey: "scheduledBasalRate") }
+
+            guard let rate = primitiveScheduledBasalRate else {
+                return nil
+            }
+
+            return HKQuantity(unit: DoseEntry.unitsPerHour, doubleValue: rate.doubleValue)
+        }
+        set {
+            willChangeValue(forKey: "scheduledBasalRate")
+            defer { didChangeValue(forKey: "scheduledBasalRate") }
+
+            guard let rate = newValue?.doubleValue(for: DoseEntry.unitsPerHour) else {
+                primitiveScheduledBasalRate = nil
+                return
+            }
+
+            primitiveScheduledBasalRate = NSNumber(value: rate)
+        }
+    }
+
+    override func awakeFromInsert() {
+        super.awakeFromInsert()
+
+        createdAt = Date()
+    }
+}
+
+
+extension CachedInsulinDeliveryObject {
+    var dose: DoseEntry! {
+        guard let startDate = startDate else {
+            return nil
+        }
+
+        let type: DoseType
+
+        switch reason! {
+        case .basal:
+            if scheduledBasalRate == nil {
+                type = .basal
+            } else {
+                type = .tempBasal
+            }
+        case .bolus:
+            type = .bolus
+        }
+
+        return DoseEntry(
+            type: type,
+            startDate: startDate,
+            endDate: endDate,
+            value: value,
+            unit: .units,
+            description: nil,
+            syncIdentifier: syncIdentifier,
+            scheduledBasalRate: scheduledBasalRate
+        )
+    }
+
+    func update(from sample: HKQuantitySample) {
+        uuid = sample.uuid
+        startDate = sample.startDate
+        endDate = sample.endDate
+        reason = sample.insulinDeliveryReason
+        // External doses might not have a syncIdentifier, so use the UUID
+        syncIdentifier = sample.metadata?[HKMetadataKeySyncIdentifier] as? String ?? sample.uuid.uuidString
+        scheduledBasalRate = sample.scheduledBasalRate
+        hasLoopKitOrigin = sample.hasLoopKitOrigin
+        value = sample.quantity.doubleValue(for: .internationalUnit())
+        provenanceIdentifier = sample.provenanceIdentifier
+    }
+}

--- a/LoopKit/InsulinKit/CachedInsulinDeliveryObject+CoreDataProperties.swift
+++ b/LoopKit/InsulinKit/CachedInsulinDeliveryObject+CoreDataProperties.swift
@@ -1,0 +1,30 @@
+//
+//  CachedInsulinDeliveryObject+CoreDataProperties.swift
+//  LoopKit
+//
+//  Copyright © 2018 LoopKit Authors. All rights reserved.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension CachedInsulinDeliveryObject {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<CachedInsulinDeliveryObject> {
+        return NSFetchRequest<CachedInsulinDeliveryObject>(entityName: "CachedInsulinDeliveryObject")
+    }
+
+    @NSManaged public var uuid: UUID?
+    @NSManaged public var provenanceIdentifier: String?
+    @NSManaged public var hasLoopKitOrigin: Bool
+    @NSManaged public var startDate: Date?
+    @NSManaged public var endDate: Date?
+    @NSManaged public var syncIdentifier: String?
+    @NSManaged public var value: Double
+    @NSManaged public var primitiveScheduledBasalRate: NSNumber?
+    @NSManaged public var primitiveReason: NSNumber?
+    @NSManaged public var createdAt: Date?
+
+}

--- a/LoopKit/InsulinKit/HKQuantitySample+InsulinKit.swift
+++ b/LoopKit/InsulinKit/HKQuantitySample+InsulinKit.swift
@@ -61,12 +61,24 @@ extension HKQuantitySample {
         )
     }
 
+    var hasLoopKitOrigin: Bool {
+        guard let hasLoopKitOrigin = metadata?[MetadataKeyHasLoopKitOrigin] as? Bool else {
+            return false
+        }
+
+        return hasLoopKitOrigin
+    }
+
     var insulinDeliveryReason: HKInsulinDeliveryReason? {
         guard let reason = metadata?[HKMetadataKeyInsulinDeliveryReason] as? HKInsulinDeliveryReason.RawValue else {
             return nil
         }
 
         return HKInsulinDeliveryReason(rawValue: reason)
+    }
+
+    var scheduledBasalRate: HKQuantity? {
+        return metadata?[MetadataKeyScheduledBasalRate] as? HKQuantity
     }
 
     /// Returns a DoseEntry representation of the sample.
@@ -77,7 +89,7 @@ extension HKQuantitySample {
         }
 
         let type: DoseType
-        let scheduledBasalRate = metadata?[MetadataKeyScheduledBasalRate] as? HKQuantity
+        let scheduledBasalRate = self.scheduledBasalRate
 
         switch reason {
         case .basal:
@@ -86,22 +98,24 @@ extension HKQuantitySample {
             } else {
                 type = .tempBasal
             }
+
+            // We can't properly trust non-LoopKit-provided basal insulin
+            guard hasLoopKitOrigin else {
+                return nil
+            }
         case .bolus:
             type = .bolus
         }
 
-        var entry = DoseEntry(
+        return DoseEntry(
             type: type,
             startDate: startDate,
             endDate: endDate,
             value: quantity.doubleValue(for: .internationalUnit()),
             unit: .units,
             description: nil,
-            syncIdentifier: metadata?[HKMetadataKeySyncIdentifier] as? String
+            syncIdentifier: metadata?[HKMetadataKeySyncIdentifier] as? String,
+            scheduledBasalRate: scheduledBasalRate
         )
-
-        entry.scheduledBasalRate = scheduledBasalRate
-
-        return entry
     }
 }

--- a/LoopKit/InsulinKit/InsulinDeliveryStore.swift
+++ b/LoopKit/InsulinKit/InsulinDeliveryStore.swift
@@ -6,6 +6,8 @@
 //
 
 import HealthKit
+import CoreData
+import os.log
 
 enum InsulinDeliveryStoreResult<T> {
     case success(T)
@@ -24,26 +26,72 @@ enum InsulinDeliveryStoreResult<T> {
 public class InsulinDeliveryStore: HealthKitSampleStore {
     private let insulinType = HKQuantityType.quantityType(forIdentifier: .insulinDelivery)!
 
-    private let dataAccessQueue = DispatchQueue(label: "com.loopkit.InsulinKit.InsulinDeliveryStoreQueue", qos: .utility)
+    private let queue = DispatchQueue(label: "com.loopkit.InsulinKit.InsulinDeliveryStore.queue", qos: .utility)
 
-    private enum LoadableDate {
-        case none
-        case loading
-        case some(Date)
-    }
+    private let log = OSLog(category: "InsulinDeliveryStore")
 
     /// The most-recent end date for a basal sample written by LoopKit
     /// Should only be accessed on dataAccessQueue
-    private var lastBasalEndDate: LoadableDate = .none
+    private var lastBasalEndDate: Date?
 
-    public init(healthStore: HKHealthStore, effectDuration: TimeInterval, observationEnabled: Bool) {
-        super.init(healthStore: healthStore, type: insulinType, observationStart: Date(timeIntervalSinceNow: -effectDuration), observationEnabled: observationEnabled)
+    /// The interval of insulin delivery data to keep in cache
+    public let cacheLength: TimeInterval
+
+    public let cacheStore: PersistenceController
+
+    public init(
+        healthStore: HKHealthStore,
+        cacheStore: PersistenceController,
+        observationEnabled: Bool = true,
+        cacheLength: TimeInterval = 24 /* hours */ * 60 /* minutes */ * 60 /* seconds */
+    ) {
+        self.cacheStore = cacheStore
+        self.cacheLength = cacheLength
+
+        super.init(
+            healthStore: healthStore,
+            type: insulinType,
+            observationStart: Date(timeIntervalSinceNow: -cacheLength),
+            observationEnabled: observationEnabled
+        )
+
+        cacheStore.onReady { (error) in
+            // Should we do something here?
+        }
     }
 
     public override func processResults(from query: HKAnchoredObjectQuery, added: [HKSample], deleted: [HKDeletedObject], error: Error?) {
-        // New data not written by LoopKit (see `MetadataKeyHasLoopKitOrigin`) should be assumed external to what could be fetched as PumpEvent data.
-        // That external data could be factored into dose computation with some modification:
-        // An example might be supplemental injections in cases of extended exercise periods without a pump
+        guard error == nil else {
+            return
+        }
+
+        queue.async {
+            // Added samples
+            let samples = ((added as? [HKQuantitySample]) ?? []).filterDateRange(self.earliestCacheDate, nil)
+            var cacheChanged = false
+
+            if self.addCachedObjects(for: samples) {
+                cacheChanged = true
+            }
+
+            // Deleted samples
+            for sample in deleted {
+                if self.deleteCachedObject(forSampleUUID: sample.uuid) {
+                    cacheChanged = true
+                }
+            }
+
+            let cachePredicate = NSPredicate(format: "startDate < %@", self.earliestCacheDate as NSDate)
+            self.purgeCachedObjects(matching: cachePredicate)
+
+            if cacheChanged || self.lastBasalEndDate == nil {
+                self.updateLastBasalEndDate()
+            }
+
+            // New data not written by LoopKit (see `MetadataKeyHasLoopKitOrigin`) should be assumed external to what could be fetched as PumpEvent data.
+            // That external data could be factored into dose computation with some modification:
+            // An example might be supplemental injections in cases of extended exercise periods without a pump
+        }
     }
 
     public override var preferredUnit: HKUnit! {
@@ -55,21 +103,28 @@ public class InsulinDeliveryStore: HealthKitSampleStore {
 // MARK: - Adding data
 extension InsulinDeliveryStore {
     func addReconciledDoses(_ doses: [DoseEntry], from device: HKDevice?, completion: @escaping (_ result: InsulinDeliveryStoreResult<Bool>) -> Void) {
-        var latestBasalEndDate: Date?
         let unit = HKUnit.internationalUnit()
-        let samples = doses.compactMap { (dose) -> HKQuantitySample? in
-            let sample = HKQuantitySample(
-                type: insulinType,
-                unit: unit,
-                dose: dose,
-                device: device
-            )
+        var samples: [HKQuantitySample] = []
 
-            if case .basal? = sample?.insulinDeliveryReason, let endDate = sample?.endDate {
-                latestBasalEndDate = max(endDate, latestBasalEndDate ?? .distantPast)
+        cacheStore.managedObjectContext.performAndWait {
+            samples = doses.compactMap { (dose) -> HKQuantitySample? in
+                guard let syncIdentifier = dose.syncIdentifier else {
+                    log.error("Attempted to add a dose with no syncIdentifier: %{public}@", String(reflecting: dose))
+                    return nil
+                }
+
+                guard self.cacheStore.managedObjectContext.cachedInsulinDeliveryObjectsWithSyncIdentifier(syncIdentifier, fetchLimit: 1).count == 0 else {
+                    log.default("Skipping adding dose due to existing cached syncIdentifier: %{public}@", syncIdentifier)
+                    return nil
+                }
+
+                return HKQuantitySample(
+                    type: insulinType,
+                    unit: unit,
+                    dose: dose,
+                    device: device
+                )
             }
-
-            return sample
         }
 
         guard samples.count > 0 else {
@@ -81,10 +136,15 @@ extension InsulinDeliveryStore {
             if let error = error {
                 completion(.failure(error))
             } else {
-                self.dataAccessQueue.async {
-                    if let latestBasalEndDate = latestBasalEndDate {
-                        self.setLastBasalEndDate(latestBasalEndDate)
+                self.queue.async {
+                    if samples.count > 0 {
+                        self.addCachedObjects(for: samples)
+
+                        if self.lastBasalEndDate != nil {
+                            self.updateLastBasalEndDate()
+                        }
                     }
+
                     completion(.success(true))
                 }
             }
@@ -93,72 +153,60 @@ extension InsulinDeliveryStore {
 }
 
 
-// MARK: - lastBasalEndDate management
 extension InsulinDeliveryStore {
     /// Returns the end date of the most recent basal sample
     ///
-    /// - Parameter completion: A closure to execute when
+    /// - Parameters:
+    ///   - completion: A closure called when the date has been retrieved
+    ///   - result: The date
     func getLastBasalEndDate(_ completion: @escaping (_ result: InsulinDeliveryStoreResult<Date>) -> Void) {
-        dataAccessQueue.async {
+        queue.async {
             switch self.lastBasalEndDate {
-            case .none:
-                self.lastBasalEndDate = .loading
-                self.getLastBasalEndDateFromHealthKit { (result) in
-                    self.dataAccessQueue.async {
-                        switch result {
-                        case .failure:
-                            self.lastBasalEndDate = .none
-                        case .success(let date):
-                            self.lastBasalEndDate = .some(date)
-                        }
-
-                        completion(result)
-                    }
-                }
             case .some(let date):
                 completion(.success(date))
-            case .loading:
+            case .none:
                 // TODO: send a proper error
                 completion(.failure(DoseStore.DoseStoreError.configurationError))
             }
         }
     }
 
-    fileprivate func setLastBasalEndDate(_ endDate: Date) {
-        dispatchPrecondition(condition: .onQueue(dataAccessQueue))
-
-        switch lastBasalEndDate {
-        case .none, .loading:
-            lastBasalEndDate = .some(endDate)
-        case .some(let date):
-            lastBasalEndDate = .some(max(date, endDate))
+    /// Returns doses from HealthKit, or the Core Data cache if unavailable
+    ///
+    /// - Parameters:
+    ///   - start: The earliest dose startDate to include
+    ///   - end: The latest dose startDate to include
+    ///   - isChronological: Whether the doses should be returned in chronological order
+    ///   - completion: A closure called when the doses have been retrieved
+    ///   - doses: An ordered array of doses
+    func getCachedDoses(start: Date, end: Date? = nil, isChronological: Bool = true, _ completion: @escaping (_ doses: [DoseEntry]) -> Void) {
+        // If we were asked for an unbounded query, or we're within our cache duration, only return what's in the cache
+        guard start > .distantPast, start <= earliestCacheDate else {
+            self.queue.async {
+                completion(self.getCachedDoseEntries(start: start, end: end, isChronological: isChronological))
+            }
+            return
         }
-    }
 
-    private func getLastBasalEndDateFromHealthKit(_ completion: @escaping (_ result: InsulinDeliveryStoreResult<Date>) -> Void) {
-        let basalPredicate = HKQuery.predicateForObjects(withMetadataKey: HKMetadataKeyInsulinDeliveryReason, operatorType: .equalTo, value: HKInsulinDeliveryReason.basal.rawValue)
-        let sourcePredicate = HKQuery.predicateForObjects(withMetadataKey: MetadataKeyHasLoopKitOrigin, operatorType: .equalTo, value: true)
-        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [basalPredicate, sourcePredicate])
-        let sort = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)
-
-        let query = HKSampleQuery(sampleType: insulinType, predicate: predicate, limit: 1, sortDescriptors: [sort]) { (query, samples, error) in
-            if let error = error {
-                completion(.failure(error))
-            } else {
-                let date = samples?.first?.endDate ?? self.healthStore.earliestPermittedSampleDate()
-
-                completion(.success(date))
+        getDoses(start: start, end: end, isChronological: isChronological) { (result) in
+            switch result {
+            case .success(let doses):
+                completion(doses)
+            case .failure:
+                // Expected when database is inaccessible
+                self.queue.async {
+                    completion(self.getCachedDoseEntries(start: start, end: end, isChronological: isChronological))
+                }
             }
         }
-
-        healthStore.execute(query)
     }
 }
 
 
+// MARK: - HealthKit
 extension InsulinDeliveryStore {
-    private func getDoses(since start: Date, _ completion: @escaping (_ result: InsulinDeliveryStoreResult<[DoseEntry]>) -> Void) {
-        getSamples(since: start) { (result) in
+    private func getDoses(start: Date, end: Date? = nil, isChronological: Bool = true, _ completion: @escaping (_ result: InsulinDeliveryStoreResult<[DoseEntry]>) -> Void) {
+        getSamples(start: start, end: end, isChronological: isChronological) { (result) in
             switch result {
             case .failure(let error):
                 completion(.failure(error))
@@ -168,13 +216,13 @@ extension InsulinDeliveryStore {
         }
     }
 
-    private func getSamples(since start: Date, _ completion: @escaping (_ result: InsulinDeliveryStoreResult<[HKQuantitySample]>) -> Void) {
-        let predicate = HKQuery.predicateForSamples(withStart: start, end: nil, options: [])
-        getSamples(matching: predicate, chronological: true, completion)
+    private func getSamples(start: Date, end: Date? = nil, isChronological: Bool = true, _ completion: @escaping (_ result: InsulinDeliveryStoreResult<[HKQuantitySample]>) -> Void) {
+        let predicate = HKQuery.predicateForSamples(withStart: start, end: end, options: [])
+        getSamples(matching: predicate, isChronological: isChronological, completion)
     }
 
-    private func getSamples(matching predicate: NSPredicate, chronological: Bool, _ completion: @escaping (_ result: InsulinDeliveryStoreResult<[HKQuantitySample]>) -> Void) {
-        let sort = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: chronological)
+    private func getSamples(matching predicate: NSPredicate, isChronological: Bool, _ completion: @escaping (_ result: InsulinDeliveryStoreResult<[HKQuantitySample]>) -> Void) {
+        let sort = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: isChronological)
         let query = HKSampleQuery(sampleType: insulinType, predicate: predicate, limit: HKObjectQueryNoLimit, sortDescriptors: [sort]) { (query, samples, error) in
             if let error = error {
                 completion(.failure(error))
@@ -190,6 +238,162 @@ extension InsulinDeliveryStore {
 }
 
 
+// MARK: - Core Data
+extension InsulinDeliveryStore {
+    private var earliestCacheDate: Date {
+        return Date(timeIntervalSinceNow: -cacheLength)
+    }
+
+    /// Creates new cached insulin delivery objects from samples if they're not already cached and within the date interval
+    ///
+    /// - Parameter samples: The samples to cache
+    /// - Returns: Whether new cached objects were created
+    @discardableResult
+    private func addCachedObjects(for samples: [
+        HKQuantitySample]) -> Bool {
+        dispatchPrecondition(condition: .onQueue(queue))
+
+        var created = false
+        cacheStore.managedObjectContext.performAndWait {
+            for sample in samples {
+                guard
+                    sample.startDate.timeIntervalSinceNow > -self.cacheLength,
+                    self.cacheStore.managedObjectContext.cachedInsulinDeliveryObjectsWithUUID(sample.uuid, fetchLimit: 1).count == 0
+                else {
+                    continue
+                }
+
+                let object = CachedInsulinDeliveryObject(context: self.cacheStore.managedObjectContext)
+                object.update(from: sample)
+                created = true
+            }
+
+            if created {
+                self.cacheStore.save()
+            }
+        }
+
+        return created
+    }
+
+    private func updateLastBasalEndDate() {
+        dispatchPrecondition(condition: .onQueue(queue))
+
+        var endDate: Date?
+
+        cacheStore.managedObjectContext.performAndWait {
+            let request: NSFetchRequest<CachedInsulinDeliveryObject> = CachedInsulinDeliveryObject.fetchRequest()
+
+            let basalPredicate = NSPredicate(format: "reason == %d", HKInsulinDeliveryReason.basal.rawValue)
+            let sourcePredicate = NSPredicate(format: "hasLoopKitOrigin == true")
+            let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [basalPredicate, sourcePredicate])
+
+            request.predicate = predicate
+            request.sortDescriptors = [NSSortDescriptor(key: "endDate", ascending: false)]
+            request.fetchLimit = 1
+
+            do {
+                let objects = try self.cacheStore.managedObjectContext.fetch(request)
+
+                endDate = objects.first?.endDate
+            } catch let error {
+                self.log.error("Unable to fetch latest glucose object: %@", String(describing: error))
+            }
+        }
+
+        self.lastBasalEndDate = endDate ?? healthStore.earliestPermittedSampleDate()
+    }
+
+    /// Fetches doses from the cache that occur on or after a given start date
+    ///
+    /// - Parameters:
+    ///   - start: The earliest endDate to retrieve
+    ///   - end: The latest startDate to retrieve
+    ///   - isChronological: Whether the sort order is ascending by start date
+    /// - Returns: An ordered array of dose entries
+    private func getCachedDoseEntries(start: Date, end: Date? = nil, isChronological: Bool = true) -> [DoseEntry] {
+        dispatchPrecondition(condition: .onQueue(queue))
+
+        let startPredicate = NSPredicate(format: "endDate >= %@", start as NSDate)
+        let predicate: NSPredicate
+
+        if let end = end {
+            let endPredicate = NSPredicate(format: "startDate <= %@", end as NSDate)
+            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [startPredicate, endPredicate])
+        } else {
+            predicate = startPredicate
+        }
+
+        return getCachedDoseEntries(matching: predicate, isChronological: isChronological)
+    }
+
+    /// Fetches doses from the cache that match the given predicate
+    ///
+    /// - Parameters:
+    ///   - predicate: The predicate to apply to the objects
+    ///   - isChronological: Whether the sort order is ascending by start date
+    /// - Returns: An ordered array of dose entries
+    private func getCachedDoseEntries(matching predicate: NSPredicate? = nil, isChronological: Bool = true) -> [DoseEntry] {
+        dispatchPrecondition(condition: .onQueue(queue))
+
+        var doses: [DoseEntry] = []
+
+        cacheStore.managedObjectContext.performAndWait {
+            let request: NSFetchRequest<CachedInsulinDeliveryObject> = CachedInsulinDeliveryObject.fetchRequest()
+            request.predicate = predicate
+            request.sortDescriptors = [NSSortDescriptor(key: "startDate", ascending: isChronological)]
+
+            do {
+                let objects = try self.cacheStore.managedObjectContext.fetch(request)
+                doses = objects.compactMap { $0.dose }
+            } catch let error {
+                self.log.error("Error fetching CachedInsulinDeliveryObjects: %{public}@", String(describing: error))
+            }
+        }
+
+        return doses
+    }
+
+    /// Deletes objects from the cache that match the given sample UUID
+    ///
+    /// - Parameter uuid: The UUID of the sample to delete
+    /// - Returns: Whether the deletion was made
+    private func deleteCachedObject(forSampleUUID uuid: UUID) -> Bool {
+        dispatchPrecondition(condition: .onQueue(queue))
+
+        var deleted = false
+
+        cacheStore.managedObjectContext.performAndWait {
+            for object in self.cacheStore.managedObjectContext.cachedInsulinDeliveryObjectsWithUUID(uuid) {
+
+                self.cacheStore.managedObjectContext.delete(object)
+                self.log.default("Deleted CachedInsulinDeliveryObject with UUID %{public}@", uuid.uuidString)
+                deleted = true
+            }
+
+            if deleted {
+                self.cacheStore.save()
+            }
+        }
+
+        return deleted
+    }
+
+    private func purgeCachedObjects(matching predicate: NSPredicate) {
+        dispatchPrecondition(condition: .onQueue(queue))
+
+        cacheStore.managedObjectContext.performAndWait {
+            do {
+                let count = try cacheStore.managedObjectContext.purgeObjects(of: CachedInsulinDeliveryObject.self, matching: predicate)
+                self.log.default("Purged %d CachedInsulinDeliveryObjects", count)
+            } catch let error {
+                self.log.error("Unable to purge CachedInsulinDeliveryObjects: %@", String(describing: error))
+            }
+        }
+    }
+}
+
+
 extension InsulinDeliveryStore {
     /// Generates a diagnostic report about the current state
     ///
@@ -197,19 +401,20 @@ extension InsulinDeliveryStore {
     ///
     /// - parameter completion: The closure takes a single argument of the report string.
     public func generateDiagnosticReport(_ completion: @escaping (_ report: String) -> Void) {
-        getLastBasalEndDate { (result) in
+        self.queue.async {
             var report: [String] = [
                 "### InsulinDeliveryStore",
+                "* cacheLength: \(self.cacheLength)",
                 super.debugDescription,
-                ""
+                "* lastBasalEndDate: \(String(describing: self.lastBasalEndDate))",
+                "",
+                "#### cachedDoseEntries",
             ]
 
-            switch result {
-            case .success(let lastBasalEndDate):
-                report.append("* lastBasalEndDate: \(lastBasalEndDate)")
-            case .failure(let error):
-                report.append("* error: \(String(reflecting: error))")
+            for sample in self.getCachedDoseEntries() {
+                report.append(String(describing: sample))
             }
+
             report.append("")
             completion(report.joined(separator: "\n"))
         }

--- a/LoopKit/InsulinKit/InsulinMath.swift
+++ b/LoopKit/InsulinKit/InsulinMath.swift
@@ -84,19 +84,23 @@ extension DoseEntry {
         }
     }
 
-    func trim(to end: Date?) -> DoseEntry {
-        if let end = end, unit == .unitsPerHour, endDate > end {
-            return DoseEntry(
-                type: type,
-                startDate: startDate,
-                endDate: end,
-                value: value,
-                unit: unit,
-                description: description
-            )
-        } else {
+    func trim(from start: Date? = nil, to end: Date? = nil) -> DoseEntry {
+        guard unit == .unitsPerHour else {
             return self
         }
+
+        let startDate = max(start ?? .distantPast, self.startDate)
+
+        return DoseEntry(
+            type: type,
+            startDate: startDate,
+            endDate: max(startDate, min(end ?? .distantFuture, self.endDate)),
+            value: value,
+            unit: unit,
+            description: description,
+            syncIdentifier: nil,
+            scheduledBasalRate: scheduledBasalRate
+        )
     }
 }
 
@@ -541,5 +545,41 @@ extension Collection where Iterator.Element == DoseEntry {
         }
 
         return newEntries
+    }
+
+    /// Creates an array of DoseEntry values by unioning another array, de-duplicating by syncIdentifier
+    ///
+    /// - Parameter otherDoses: An array of doses to union
+    /// - Returns: A new array of doses
+    func appendedUnion(with otherDoses: [DoseEntry]) -> [DoseEntry] {
+        var union: [DoseEntry] = []
+        var syncIdentifiers: Set<String> = []
+
+        for dose in (self + otherDoses) {
+            if let syncIdentifier = dose.syncIdentifier {
+                let (inserted, _) = syncIdentifiers.insert(syncIdentifier)
+                if !inserted {
+                    continue
+                }
+            }
+
+            union.append(dose)
+        }
+
+        return union
+    }
+}
+
+
+extension BidirectionalCollection where Element == DoseEntry {
+    /// The endDate of the last basal dose in the collection
+    var lastBasalEndDate: Date? {
+        for dose in self.reversed() {
+            if dose.type == .basal || dose.type == .tempBasal || dose.type == .resume {
+                return dose.endDate
+            }
+        }
+
+        return nil
     }
 }

--- a/LoopKit/InsulinKit/InsulinValue.swift
+++ b/LoopKit/InsulinKit/InsulinValue.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 
-public struct InsulinValue: TimelineValue {
+public struct InsulinValue: TimelineValue, Equatable {
     public let startDate: Date
     public let value: Double
 

--- a/LoopKit/InsulinKit/NSManagedObjectContext+CachedInsulinDeliveryObject.swift
+++ b/LoopKit/InsulinKit/NSManagedObjectContext+CachedInsulinDeliveryObject.swift
@@ -1,0 +1,33 @@
+//
+//  NSManagedObjectContext+CachedInsulinDeliveryObject.swift
+//  LoopKit
+//
+//  Copyright © 2018 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+
+extension NSManagedObjectContext {
+    internal func cachedInsulinDeliveryObjectsWithUUID(_ uuid: UUID, fetchLimit: Int? = nil) -> [CachedInsulinDeliveryObject] {
+        let request: NSFetchRequest<CachedInsulinDeliveryObject> = CachedInsulinDeliveryObject.fetchRequest()
+        if let limit = fetchLimit {
+            request.fetchLimit = limit
+        }
+        request.predicate = NSPredicate(format: "uuid == %@", uuid as NSUUID)
+        request.sortDescriptors = [NSSortDescriptor(key: "uuid", ascending: true)]
+
+        return (try? fetch(request)) ?? []
+    }
+
+    internal func cachedInsulinDeliveryObjectsWithSyncIdentifier(_ syncIdentifier: String, fetchLimit: Int? = nil) -> [CachedInsulinDeliveryObject] {
+        let request: NSFetchRequest<CachedInsulinDeliveryObject> = CachedInsulinDeliveryObject.fetchRequest()
+        if let limit = fetchLimit {
+            request.fetchLimit = limit
+        }
+        request.predicate = NSPredicate(format: "syncIdentifier == %@", syncIdentifier)
+
+        return (try? fetch(request)) ?? []
+    }
+}

--- a/LoopKit/InsulinKit/PumpEvent+CoreDataClass.swift
+++ b/LoopKit/InsulinKit/PumpEvent+CoreDataClass.swift
@@ -20,7 +20,7 @@ class PumpEvent: NSManagedObject {
         }
         set {
             willChangeValue(forKey: "doseType")
-            defer { willChangeValue(forKey: "doseType") }
+            defer { didChangeValue(forKey: "doseType") }
             primitiveDoseType = newValue?.rawValue
         }
     }

--- a/LoopKit/Persistence/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/LoopKit/Persistence/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="13772" systemVersion="17D102" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14135" systemVersion="17G65" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="CachedCarbObject" representedClassName=".CachedCarbObject" syncable="YES">
         <attribute name="absorptionTime" optional="YES" attributeType="Double" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="createdByCurrentApp" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
@@ -15,6 +15,9 @@
             <uniquenessConstraint>
                 <constraint value="uuid"/>
             </uniquenessConstraint>
+            <uniquenessConstraint>
+                <constraint value="syncIdentifier"/>
+            </uniquenessConstraint>
         </uniquenessConstraints>
     </entity>
     <entity name="CachedGlucoseObject" representedClassName=".CachedGlucoseObject" syncable="YES">
@@ -27,6 +30,48 @@
         <attribute name="uploadState" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="uuid" attributeType="UUID" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="value" attributeType="Double" usesScalarValueType="YES" syncable="YES"/>
+        <fetchIndex name="byUUIDIndex">
+            <fetchIndexElement property="uuid" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byStartDateDescendingIndex">
+            <fetchIndexElement property="startDate" type="Binary" order="descending"/>
+        </fetchIndex>
+        <fetchIndex name="byStartDateAscendingIndex">
+            <fetchIndexElement property="startDate" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="bySyncIdentifierIndex">
+            <fetchIndexElement property="syncIdentifier" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="uuid"/>
+            </uniquenessConstraint>
+            <uniquenessConstraint>
+                <constraint value="syncIdentifier"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="CachedInsulinDeliveryObject" representedClassName=".CachedInsulinDeliveryObject" syncable="YES">
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="endDate" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="hasLoopKitOrigin" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="provenanceIdentifier" attributeType="String" syncable="YES"/>
+        <attribute name="reason" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="scheduledBasalRate" optional="YES" attributeType="Double" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="startDate" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="syncIdentifier" attributeType="String" syncable="YES"/>
+        <attribute name="uuid" attributeType="UUID" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="value" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <fetchIndex name="byUUIDIndex">
+            <fetchIndexElement property="uuid" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byStartDateAscendingIndex">
+            <fetchIndexElement property="startDate" type="Binary" order="ascending"/>
+            <fetchIndexElement property="endDate" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="bySyncIdentifierIndex">
+            <fetchIndexElement property="syncIdentifier" type="Binary" order="ascending"/>
+        </fetchIndex>
         <uniquenessConstraints>
             <uniquenessConstraint>
                 <constraint value="uuid"/>
@@ -57,11 +102,14 @@
         <attribute name="unit" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="uploaded" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="value" optional="YES" attributeType="Double" usesScalarValueType="NO" syncable="YES"/>
-        <fetchIndex name="byCreatedAtIndex">
-            <fetchIndexElement property="createdAt" type="Binary" order="ascending"/>
-        </fetchIndex>
         <fetchIndex name="byDateIndex">
             <fetchIndexElement property="date" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byTypeIndex">
+            <fetchIndexElement property="type" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byUploadedIndex">
+            <fetchIndexElement property="uploaded" type="Binary" order="ascending"/>
         </fetchIndex>
         <uniquenessConstraints>
             <uniquenessConstraint>
@@ -75,12 +123,13 @@
         <attribute name="raw" optional="YES" attributeType="Binary" syncable="YES"/>
         <attribute name="volume" attributeType="Double" usesScalarValueType="NO" syncable="YES"/>
         <fetchIndex name="byDateIndex">
-            <fetchIndexElement property="date" type="Binary" order="ascending"/>
+            <fetchIndexElement property="date" type="Binary" order="descending"/>
         </fetchIndex>
     </entity>
     <elements>
         <element name="CachedCarbObject" positionX="-63" positionY="72" width="128" height="195"/>
         <element name="CachedGlucoseObject" positionX="-63" positionY="99" width="128" height="180"/>
+        <element name="CachedInsulinDeliveryObject" positionX="-63" positionY="108" width="128" height="195"/>
         <element name="DeletedCarbObject" positionX="-63" positionY="90" width="128" height="90"/>
         <element name="PumpEvent" positionX="-63" positionY="18" width="128" height="195"/>
         <element name="Reservoir" positionX="-63" positionY="-18" width="128" height="105"/>

--- a/LoopKit/Persistence/NSManagedObjectContext.swift
+++ b/LoopKit/Persistence/NSManagedObjectContext.swift
@@ -1,0 +1,43 @@
+//
+//  NSManagedObjectContext.swift
+//  LoopKit
+//
+//  Copyright © 2018 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+
+extension NSManagedObjectContext {
+
+    /// Deletes all saved objects matching the specified type and predicate from the context's persistent store
+    ///
+    /// - Parameters:
+    ///   - type: The object type to delete
+    ///   - predicate: The predicate to match
+    /// - Returns: The number of deleted objects
+    /// - Throws: NSBatchDeleteRequest exeuction errors
+    internal func purgeObjects<T: NSManagedObject>(of type: T.Type, matching predicate: NSPredicate) throws -> Int {
+        let fetchRequest: NSFetchRequest<NSFetchRequestResult> = T.fetchRequest()
+        fetchRequest.predicate = predicate
+
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+        deleteRequest.resultType = .resultTypeObjectIDs
+
+        let result = try execute(deleteRequest)
+        guard let deleteResult = result as? NSBatchDeleteResult,
+            let objectIDs = deleteResult.result as? [NSManagedObjectID]
+        else {
+            return 0
+        }
+
+        if objectIDs.count > 0 {
+            let changes = [NSDeletedObjectsKey: objectIDs]
+            NSManagedObjectContext.mergeChanges(fromRemoteContextSave: changes, into: [self])
+            self.refreshAllObjects()
+        }
+
+        return objectIDs.count
+    }
+}

--- a/LoopKit/SetBolusError.swift
+++ b/LoopKit/SetBolusError.swift
@@ -45,4 +45,13 @@ extension SetBolusError: LocalizedError {
             return LocalizedString("Check your pump before retrying", comment: "Recovery instruction for an uncertain bolus failure")
         }
     }
+
+    public var helpAnchor: String? {
+        switch self {
+        case .certain(let error):
+            return error.helpAnchor
+        case .uncertain(let error):
+            return error.helpAnchor
+        }
+    }
 }

--- a/LoopKitTests/CarbStoreTests.swift
+++ b/LoopKitTests/CarbStoreTests.swift
@@ -10,14 +10,14 @@ import HealthKit
 import CoreData
 @testable import LoopKit
 
-class CarbStoreTests: XCTestCase, CarbStoreSyncDelegate {
+class CarbStoreTests: PersistenceControllerTestCase, CarbStoreSyncDelegate {
 
     var carbStore: CarbStore!
     var healthStore: HKHealthStoreMock!
-    var cacheStore: PersistenceController!
 
     override func setUp() {
-        cacheStore = PersistenceController(directoryURL: URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true))
+        super.setUp()
+
         healthStore = HKHealthStoreMock()
         carbStore = CarbStore(healthStore: healthStore, cacheStore: cacheStore)
         carbStore.testQueryStore = healthStore
@@ -25,17 +25,16 @@ class CarbStoreTests: XCTestCase, CarbStoreSyncDelegate {
     }
 
     override func tearDown() {
-        cacheStore.tearDown()
-
         carbStore.syncDelegate = nil
         carbStore = nil
         healthStore = nil
-        cacheStore = nil
 
         uploadMessages = []
         deleteMessages = []
         uploadHandler = nil
         deleteHandler = nil
+
+        super.tearDown()
     }
 
     // MARK: - CarbStoreSyncDelegate

--- a/LoopKitTests/DoseStoreTests.swift
+++ b/LoopKitTests/DoseStoreTests.swift
@@ -9,31 +9,11 @@ import XCTest
 import CoreData
 @testable import LoopKit
 
-class DoseStoreTests: XCTestCase {
-
-    var controller: PersistenceController!
-
-    override func setUp() {
-        super.setUp()
-
-        controller = PersistenceController(directoryURL: URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true))
-    }
-
-    override func tearDown() {
-        if let coordinator = controller.managedObjectContext.persistentStoreCoordinator {
-            for store in coordinator.persistentStores {
-                if let url = store.url {
-                    try! coordinator.destroyPersistentStore(at: url, ofType: store.type, options: nil)
-                }
-            }
-        }
-
-        super.tearDown()
-    }
+class DoseStoreTests: PersistenceControllerTestCase {
 
     func testPumpEventTypeDoseMigration() {
-        controller.managedObjectContext.performAndWait {
-            let event = PumpEvent(entity: PumpEvent.entity(), insertInto: controller.managedObjectContext)
+        cacheStore.managedObjectContext.performAndWait {
+            let event = PumpEvent(entity: PumpEvent.entity(), insertInto: cacheStore.managedObjectContext)
 
             event.date = Date()
             event.duration = .minutes(30)
@@ -48,15 +28,15 @@ class DoseStoreTests: XCTestCase {
     }
 
     func testDeduplication() {
-        controller.managedObjectContext.performAndWait {
-            let bolus1 = PumpEvent(context: controller.managedObjectContext)
+        cacheStore.managedObjectContext.performAndWait {
+            let bolus1 = PumpEvent(context: cacheStore.managedObjectContext)
 
             bolus1.date = DateFormatter.descriptionFormatter.date(from: "2018-04-30 02:12:42 +0000")
             bolus1.raw = Data(hexadecimalString: "0100a600a6001b006a0c335d12")!
             bolus1.type = PumpEventType.bolus
             bolus1.dose = DoseEntry(type: .bolus, startDate: bolus1.date!, value: 4.15, unit: .units, syncIdentifier: bolus1.raw?.hexadecimalString)
 
-            let bolus2 = PumpEvent(context: controller.managedObjectContext)
+            let bolus2 = PumpEvent(context: cacheStore.managedObjectContext)
 
             bolus2.date = DateFormatter.descriptionFormatter.date(from: "2018-04-30 00:00:00 +0000")
             bolus2.raw = Data(hexadecimalString: "0100a600a6001b006a0c335d12")!
@@ -64,12 +44,12 @@ class DoseStoreTests: XCTestCase {
             bolus2.dose = DoseEntry(type: .bolus, startDate: bolus2.date!, value: 0.15, unit: .units, syncIdentifier: bolus1.raw?.hexadecimalString)
 
             let request: NSFetchRequest<PumpEvent> = PumpEvent.fetchRequest()
-            let eventsBeforeSave = try! controller.managedObjectContext.fetch(request)
+            let eventsBeforeSave = try! cacheStore.managedObjectContext.fetch(request)
             XCTAssertEqual(2, eventsBeforeSave.count)
 
-            try! controller.managedObjectContext.save()
+            try! cacheStore.managedObjectContext.save()
 
-            let eventsAfterSave = try! controller.managedObjectContext.fetch(request)
+            let eventsAfterSave = try! cacheStore.managedObjectContext.fetch(request)
             XCTAssertEqual(1, eventsAfterSave.count)
         }
     }

--- a/LoopKitTests/InsulinMathTests.swift
+++ b/LoopKitTests/InsulinMathTests.swift
@@ -529,11 +529,14 @@ class InsulinMathTests: XCTestCase {
 
     func testTrimContinuingDoses() {
         let dateFormatter = ISO8601DateFormatter.localTimeDate()
-        let input = loadDoseFixture("normalized_doses")
+        let input = loadDoseFixture("normalized_doses").reversed()
 
-        // Last temp ends at 2015-10-15T18:14:35
-        let endDate = dateFormatter.date(from: "2015-10-15T18:00:00")!
+        // Last temp ends at 2015-10-15T22:29:50
+        let endDate = dateFormatter.date(from: "2015-10-15T22:25:50")!
         let trimmed = input.map { $0.trim(to: endDate) }
+
+        print(input, "\n\n\n")
+        print(trimmed)
 
         XCTAssertEqual(endDate, trimmed.last!.endDate)
         XCTAssertEqual(input.count, trimmed.count)
@@ -709,5 +712,347 @@ class InsulinMathTests: XCTestCase {
         let basalSchedule = BasalRateSchedule(dailyItems: [RepeatingScheduleValue(startTime: 0, value: 1.2)])
 
         XCTAssertEqual(reconciledWithBasal, reconciled.overlayBasalSchedule(basalSchedule!, startingAt: f("2018-07-11 04:00:00 +0000"), endingAt: f("2018-07-11 05:32:15 +0000"), insertingBasalEntries: true))
+    }
+
+    func testAppendedUnionOfPumpEvents() {
+        let formatter = DateFormatter.descriptionFormatter
+        let f = { (input) in
+            return formatter.date(from: input)!
+        }
+        let unit = DoseEntry.unitsPerHour
+
+        let normalizedDoseEntries = [
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 03:34:29 +0000"), endDate: f("2018-07-15 03:54:29 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "16015de2144e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 03:54:29 +0000"), endDate: f("2018-07-15 04:14:31 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "16015df6144e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 04:14:31 +0000"), endDate: f("2018-07-15 04:29:28 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "16015fce154e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 04:29:28 +0000"), endDate: f("2018-07-15 04:44:28 +0000"), value: 1.2, unit: .unitsPerHour, syncIdentifier: "7b055cdd150e122a3000", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 04:44:28 +0000"), endDate: f("2018-07-15 04:49:29 +0000"), value: 3.6499999999999999, unit: .unitsPerHour, syncIdentifier: "16015cec154e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 04:49:29 +0000"), endDate: f("2018-07-15 04:54:28 +0000"), value: 3.8500000000000001, unit: .unitsPerHour, syncIdentifier: "16015df1154e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 04:54:28 +0000"), endDate: f("2018-07-15 04:59:28 +0000"), value: 3.5750000000000002, unit: .unitsPerHour, syncIdentifier: "16015cf6154e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .bolus, startDate: f("2018-07-15 05:00:01 +0000"), endDate: f("2018-07-15 05:00:01 +0000"), value: 3.0, unit: .units, syncIdentifier: "0100780078004c0041c0364e12", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 04:59:28 +0000"), endDate: f("2018-07-15 05:04:29 +0000"), value: 3.1000000000000001, unit: .unitsPerHour, syncIdentifier: "16015cfb154e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 05:04:29 +0000"), endDate: f("2018-07-15 05:24:29 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "16015dc4164e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 05:24:29 +0000"), endDate: f("2018-07-15 05:44:29 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "16015dd8164e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 05:44:29 +0000"), endDate: f("2018-07-15 05:59:29 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "16015dec164e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 05:59:29 +0000"), endDate: f("2018-07-15 06:04:29 +0000"), value: 0.625, unit: .unitsPerHour, syncIdentifier: "16015dfb164e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:04:29 +0000"), endDate: f("2018-07-15 06:09:29 +0000"), value: 0.17499999999999999, unit: .unitsPerHour, syncIdentifier: "16015dc4174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:09:29 +0000"), endDate: f("2018-07-15 06:14:29 +0000"), value: 1.95, unit: .unitsPerHour, syncIdentifier: "16015dc9174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:14:29 +0000"), endDate: f("2018-07-15 06:19:29 +0000"), value: 0.59999999999999998, unit: .unitsPerHour, syncIdentifier: "16015dce174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:19:29 +0000"), endDate: f("2018-07-15 06:24:29 +0000"), value: 1.8999999999999999, unit: .unitsPerHour, syncIdentifier: "16015dd3174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:24:29 +0000"), endDate: f("2018-07-15 06:29:29 +0000"), value: 3.9750000000000001, unit: .unitsPerHour, syncIdentifier: "16015dd8174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:29:29 +0000"), endDate: f("2018-07-15 06:34:28 +0000"), value: 4.0499999999999998, unit: .unitsPerHour, syncIdentifier: "16015ddd174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:34:28 +0000"), endDate: f("2018-07-15 06:39:28 +0000"), value: 3.0499999999999998, unit: .unitsPerHour, syncIdentifier: "16015ce2174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:39:28 +0000"), endDate: f("2018-07-15 06:44:29 +0000"), value: 3.625, unit: .unitsPerHour, syncIdentifier: "16015ce7174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:44:29 +0000"), endDate: f("2018-07-15 06:49:31 +0000"), value: 2.7999999999999998, unit: .unitsPerHour, syncIdentifier: "16015dec174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:49:31 +0000"), endDate: f("2018-07-15 06:54:30 +0000"), value: 1.9750000000000001, unit: .unitsPerHour, syncIdentifier: "16015ff1174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 06:54:30 +0000"), endDate: f("2018-07-15 07:00:00 +0000"), value: 1.2, unit: .unitsPerHour, syncIdentifier: "7b055ef6170e122a3000", scheduledBasalRate: nil),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 07:00:00 +0000"), endDate: f("2018-07-15 07:09:28 +0000"), value: 1.2, unit: .unitsPerHour, syncIdentifier: "7b0040c0000f12003000", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 07:09:28 +0000"), endDate: f("2018-07-15 07:14:28 +0000"), value: 0.45000000000000001, unit: .unitsPerHour, syncIdentifier: "16015cc9004f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 07:14:28 +0000"), endDate: f("2018-07-15 07:19:29 +0000"), value: 0.5, unit: .unitsPerHour, syncIdentifier: "16015cce004f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 07:19:29 +0000"), endDate: f("2018-07-15 07:24:29 +0000"), value: 1.2, unit: .unitsPerHour, syncIdentifier: "7b005dd3000f12003000", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 07:24:29 +0000"), endDate: f("2018-07-15 07:29:28 +0000"), value: 2.1499999999999999, unit: .unitsPerHour, syncIdentifier: "16015dd8004f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 07:29:29 +0000"), endDate: f("2018-07-15 07:34:29 +0000"), value: 1.2, unit: .unitsPerHour, syncIdentifier: "7b005ddd000f12003000", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 07:34:29 +0000"), endDate: f("2018-07-15 07:39:29 +0000"), value: 1.825, unit: .unitsPerHour, syncIdentifier: "16015de2004f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 07:39:29 +0000"), endDate: f("2018-07-15 07:44:28 +0000"), value: 2.5249999999999999, unit: .unitsPerHour, syncIdentifier: "16015de7004f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 07:44:28 +0000"), endDate: f("2018-07-15 07:49:28 +0000"), value: 2.5499999999999998, unit: .unitsPerHour, syncIdentifier: "16015cec004f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 07:49:28 +0000"), endDate: f("2018-07-15 07:54:28 +0000"), value: 2.6000000000000001, unit: .unitsPerHour, syncIdentifier: "16015cf1004f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 07:54:28 +0000"), endDate: f("2018-07-15 07:59:31 +0000"), value: 2.625, unit: .unitsPerHour, syncIdentifier: "16015cf6004f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 07:59:31 +0000"), endDate: f("2018-07-15 08:04:30 +0000"), value: 2.2250000000000001, unit: .unitsPerHour, syncIdentifier: "16015ffb004f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 08:04:30 +0000"), endDate: f("2018-07-15 08:09:28 +0000"), value: 2.3500000000000001, unit: .unitsPerHour, syncIdentifier: "16015ec4014f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 08:09:28 +0000"), endDate: f("2018-07-15 08:14:28 +0000"), value: 2.3250000000000002, unit: .unitsPerHour, syncIdentifier: "16015cc9014f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 08:14:28 +0000"), endDate: f("2018-07-15 08:19:28 +0000"), value: 1.925, unit: .unitsPerHour, syncIdentifier: "16015cce014f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 08:19:29 +0000"), endDate: f("2018-07-15 08:24:29 +0000"), value: 1.2, unit: .unitsPerHour, syncIdentifier: "7b005dd3010f12003000", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 08:24:29 +0000"), endDate: f("2018-07-15 08:29:29 +0000"), value: 1.8500000000000001, unit: .unitsPerHour, syncIdentifier: "16015dd8014f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 08:29:29 +0000"), endDate: f("2018-07-15 08:34:15 +0000"), value: 2.2250000000000001, unit: .unitsPerHour, syncIdentifier: "16015ddd014f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 08:34:15 +0000"), endDate: f("2018-07-15 08:49:14 +0000"), value: 1.2, unit: .unitsPerHour, syncIdentifier: "7b004fe2010f12003000", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 08:49:14 +0000"), endDate: f("2018-07-15 08:54:14 +0000"), value: 2.5, unit: .unitsPerHour, syncIdentifier: "16014ef1014f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 08:54:14 +0000"), endDate: f("2018-07-15 08:59:15 +0000"), value: 3.4500000000000002, unit: .unitsPerHour, syncIdentifier: "16014ef6014f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 08:59:15 +0000"), endDate: f("2018-07-15 09:04:14 +0000"), value: 3.5750000000000002, unit: .unitsPerHour, syncIdentifier: "16014ffb014f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 09:04:14 +0000"), endDate: f("2018-07-15 09:09:15 +0000"), value: 2.875, unit: .unitsPerHour, syncIdentifier: "16014ec4024f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 09:09:15 +0000"), endDate: f("2018-07-15 10:00:00 +0000"), value: 1.2, unit: .unitsPerHour, syncIdentifier: "7b004fc9020f12003000", scheduledBasalRate: nil),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 10:00:00 +0000"), endDate: f("2018-07-15 11:09:15 +0000"), value: 1.0, unit: .unitsPerHour, syncIdentifier: "7b0140c0030f12062800", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 11:09:15 +0000"), endDate: f("2018-07-15 11:14:14 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "16014fc9044f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 11:14:15 +0000"), endDate: f("2018-07-15 11:39:14 +0000"), value: 1.0, unit: .unitsPerHour, syncIdentifier: "7b014fce040f12062800", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 11:39:14 +0000"), endDate: f("2018-07-15 11:44:14 +0000"), value: 2.4750000000000001, unit: .unitsPerHour, syncIdentifier: "16014ee7044f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 11:44:14 +0000"), endDate: f("2018-07-15 11:49:15 +0000"), value: 2.3999999999999999, unit: .unitsPerHour, syncIdentifier: "16014eec044f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 11:49:15 +0000"), endDate: f("2018-07-15 11:54:14 +0000"), value: 2.3250000000000002, unit: .unitsPerHour, syncIdentifier: "16014ff1044f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 11:54:14 +0000"), endDate: f("2018-07-15 11:59:15 +0000"), value: 2.0499999999999998, unit: .unitsPerHour, syncIdentifier: "16014ef6044f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 11:59:15 +0000"), endDate: f("2018-07-15 14:00:00 +0000"), value: 1.0, unit: .unitsPerHour, syncIdentifier: "7b014ffb040f12062800", scheduledBasalRate: nil),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 14:00:00 +0000"), endDate: f("2018-07-15 14:09:48 +0000"), value: 0.90000000000000002, unit: .unitsPerHour, syncIdentifier: "7b0240c0070f120e2400", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 14:09:48 +0000"), endDate: f("2018-07-15 14:14:15 +0000"), value: 2.0499999999999998, unit: .unitsPerHour, syncIdentifier: "160170c9074f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 14:14:15 +0000"), endDate: f("2018-07-15 15:29:15 +0000"), value: 0.90000000000000002, unit: .unitsPerHour, syncIdentifier: "7b024fce070f120e2400", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 15:29:15 +0000"), endDate: f("2018-07-15 15:34:14 +0000"), value: 1.8999999999999999, unit: .unitsPerHour, syncIdentifier: "16014fdd084f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 15:34:15 +0000"), endDate: f("2018-07-15 15:39:14 +0000"), value: 0.90000000000000002, unit: .unitsPerHour, syncIdentifier: "7b024fe2080f120e2400", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 15:39:14 +0000"), endDate: f("2018-07-15 15:44:14 +0000"), value: 1.95, unit: .unitsPerHour, syncIdentifier: "16014ee7084f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 15:44:14 +0000"), endDate: f("2018-07-15 15:49:14 +0000"), value: 2.1499999999999999, unit: .unitsPerHour, syncIdentifier: "16014eec084f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .bolus, startDate: f("2018-07-15 15:49:33 +0000"), endDate: f("2018-07-15 15:49:33 +0000"), value: 2.4500000000000002, unit: .units, syncIdentifier: "010062006200000061f1284f12", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 15:49:14 +0000"), endDate: f("2018-07-15 15:54:16 +0000"), value: 1.95, unit: .unitsPerHour, syncIdentifier: "16014ef1084f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 15:54:16 +0000"), endDate: f("2018-07-15 16:14:15 +0000"), value: 0.90000000000000002, unit: .unitsPerHour, syncIdentifier: "7b0250f6080f120e2400", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 16:14:15 +0000"), endDate: f("2018-07-15 16:34:15 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "16014fce094f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 16:34:15 +0000"), endDate: f("2018-07-15 16:44:14 +0000"), value: 0.90000000000000002, unit: .unitsPerHour, syncIdentifier: "7b024fe2090f120e2400", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 16:44:14 +0000"), endDate: f("2018-07-15 17:14:14 +0000"), value: 4.6500000000000004, unit: .unitsPerHour, syncIdentifier: "16014eec094f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .bolus, startDate: f("2018-07-15 17:55:12 +0000"), endDate: f("2018-07-15 17:55:12 +0000"), value: 2.5499999999999998, unit: .units, syncIdentifier: "01006600660029004cf72a4f12", scheduledBasalRate: nil),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 17:14:15 +0000"), endDate: f("2018-07-15 18:30:00 +0000"), value: 0.90000000000000002, unit: .unitsPerHour, syncIdentifier: "7b024fce0a0f120e2400", scheduledBasalRate: nil),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 18:30:00 +0000"), endDate: f("2018-07-15 18:59:15 +0000"), value: 0.80000000000000004, unit: .unitsPerHour, syncIdentifier: "7b0340de0b0f12172000", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 18:59:15 +0000"), endDate: f("2018-07-15 19:04:15 +0000"), value: 4.6500000000000004, unit: .unitsPerHour, syncIdentifier: "16014ffb0b4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 19:04:15 +0000"), endDate: f("2018-07-15 19:09:14 +0000"), value: 3.9750000000000001, unit: .unitsPerHour, syncIdentifier: "16014fc40c4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 19:09:14 +0000"), endDate: f("2018-07-15 19:19:15 +0000"), value: 4.6500000000000004, unit: .unitsPerHour, syncIdentifier: "16014ec90c4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 19:19:15 +0000"), endDate: f("2018-07-15 19:24:15 +0000"), value: 0.80000000000000004, unit: .unitsPerHour, syncIdentifier: "7b034fd30c0f12172000", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 19:24:15 +0000"), endDate: f("2018-07-15 19:29:14 +0000"), value: 2.7749999999999999, unit: .unitsPerHour, syncIdentifier: "16014fd80c4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 19:29:14 +0000"), endDate: f("2018-07-15 19:34:14 +0000"), value: 4.6500000000000004, unit: .unitsPerHour, syncIdentifier: "16014edd0c4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 19:34:14 +0000"), endDate: f("2018-07-15 19:39:14 +0000"), value: 4.625, unit: .unitsPerHour, syncIdentifier: "16014ee20c4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 19:39:14 +0000"), endDate: f("2018-07-15 19:44:15 +0000"), value: 2.6000000000000001, unit: .unitsPerHour, syncIdentifier: "16014ee70c4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 19:44:15 +0000"), endDate: f("2018-07-15 20:04:15 +0000"), value: 0.80000000000000004, unit: .unitsPerHour, syncIdentifier: "7b034fec0c0f12172000", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 20:04:15 +0000"), endDate: f("2018-07-15 20:23:00 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "16014fc40d4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 20:23:00 +0000"), endDate: f("2018-07-15 20:29:15 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "160140d70d4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 20:29:15 +0000"), endDate: f("2018-07-15 20:49:14 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "16014fdd0d4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 20:49:14 +0000"), endDate: f("2018-07-15 21:09:14 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "16014ef10d4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 21:09:14 +0000"), endDate: f("2018-07-15 21:29:30 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "16014ec90e4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 21:29:31 +0000"), endDate: f("2018-07-15 21:30:00 +0000"), value: 0.80000000000000004, unit: .unitsPerHour, syncIdentifier: "7b035fdd0e0f12172000", scheduledBasalRate: nil),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 21:30:00 +0000"), endDate: f("2018-07-15 21:49:29 +0000"), value: 0.90000000000000002, unit: .unitsPerHour, syncIdentifier: "7b0440de0e0f121d2400", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 21:49:29 +0000"), endDate: f("2018-07-15 21:54:32 +0000"), value: 2.75, unit: .unitsPerHour, syncIdentifier: "16015df10e4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 21:54:32 +0000"), endDate: f("2018-07-15 21:59:29 +0000"), value: 3.0499999999999998, unit: .unitsPerHour, syncIdentifier: "160160f60e4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 21:59:29 +0000"), endDate: f("2018-07-15 22:04:31 +0000"), value: 3.2250000000000001, unit: .unitsPerHour, syncIdentifier: "16015dfb0e4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 22:04:31 +0000"), endDate: f("2018-07-15 22:09:31 +0000"), value: 4.5999999999999996, unit: .unitsPerHour, syncIdentifier: "16015fc40f4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 22:09:31 +0000"), endDate: f("2018-07-15 22:14:32 +0000"), value: 4.3250000000000002, unit: .unitsPerHour, syncIdentifier: "16015fc90f4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 22:14:32 +0000"), endDate: f("2018-07-15 22:19:30 +0000"), value: 3.875, unit: .unitsPerHour, syncIdentifier: "160160ce0f4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 22:19:30 +0000"), endDate: f("2018-07-15 22:24:29 +0000"), value: 3.5249999999999999, unit: .unitsPerHour, syncIdentifier: "16015ed30f4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 22:24:29 +0000"), endDate: f("2018-07-15 22:29:46 +0000"), value: 3.2000000000000002, unit: .unitsPerHour, syncIdentifier: "16015dd80f4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 22:29:46 +0000"), endDate: f("2018-07-15 22:34:45 +0000"), value: 2.1499999999999999, unit: .unitsPerHour, syncIdentifier: "16016edd0f4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 22:34:45 +0000"), endDate: f("2018-07-15 22:39:29 +0000"), value: 0.90000000000000002, unit: .unitsPerHour, syncIdentifier: "7b046de20f0f121d2400", scheduledBasalRate: nil),
+            DoseEntry(type: .bolus, startDate: f("2018-07-15 22:54:39 +0000"), endDate: f("2018-07-15 22:54:39 +0000"), value: 2.8500000000000001, unit: .units, syncIdentifier: "010072007200000067f62f4f12", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 22:39:29 +0000"), endDate: f("2018-07-15 23:01:42 +0000"), value: 0.40000000000000002, unit: .unitsPerHour, syncIdentifier: "16015de70f4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 23:01:42 +0000"), endDate: f("2018-07-15 23:24:29 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "16016ac1104f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 23:24:29 +0000"), endDate: f("2018-07-15 23:29:44 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "16015dd8104f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 23:29:44 +0000"), endDate: f("2018-07-15 23:34:28 +0000"), value: 1.55, unit: .unitsPerHour, syncIdentifier: "16016cdd104f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 23:34:28 +0000"), endDate: f("2018-07-15 23:39:29 +0000"), value: 1.625, unit: .unitsPerHour, syncIdentifier: "16015ce2104f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .bolus, startDate: f("2018-07-15 23:43:57 +0000"), endDate: f("2018-07-15 23:43:57 +0000"), value: 1.5, unit: .units, syncIdentifier: "01003c003c00620079eb304f12", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 23:39:29 +0000"), endDate: f("2018-07-15 23:49:29 +0000"), value: 1.55, unit: .unitsPerHour, syncIdentifier: "16015de7104f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .bolus, startDate: f("2018-07-16 00:02:37 +0000"), endDate: f("2018-07-16 00:02:37 +0000"), value: 2.6000000000000001, unit: .units, syncIdentifier: "010068006800910065c2314f12", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 23:49:29 +0000"), endDate: f("2018-07-16 00:04:42 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "16015df1104f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 00:04:42 +0000"), endDate: f("2018-07-16 00:09:29 +0000"), value: 0.025000000000000001, unit: .unitsPerHour, syncIdentifier: "16016ac4114f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .bolus, startDate: f("2018-07-16 00:20:20 +0000"), endDate: f("2018-07-16 00:20:20 +0000"), value: 1.1499999999999999, unit: .units, syncIdentifier: "01002e002e00e70054d4314f12", scheduledBasalRate: nil),
+            DoseEntry(type: .basal, startDate: f("2018-07-16 00:09:29 +0000"), endDate: f("2018-07-16 00:24:32 +0000"), value: 0.90000000000000002, unit: .unitsPerHour, syncIdentifier: "7b045dc9110f121d2400", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 00:24:32 +0000"), endDate: f("2018-07-16 00:44:28 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "160160d8114f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 00:44:28 +0000"), endDate: f("2018-07-16 01:04:29 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "16015cec114f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 01:04:29 +0000"), endDate: f("2018-07-16 01:27:16 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "16015dc4124f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 01:27:16 +0000"), endDate: f("2018-07-16 01:49:29 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "160150db124f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .bolus, startDate: f("2018-07-16 01:58:53 +0000"), endDate: f("2018-07-16 01:58:53 +0000"), value: 3.6499999999999999, unit: .units, syncIdentifier: "010092009200730075fa324f12", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 01:49:29 +0000"), endDate: f("2018-07-16 02:04:30 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "16015df1124f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 02:04:30 +0000"), endDate: f("2018-07-16 02:33:36 +0000"), value: 1.7250000000000001, unit: .unitsPerHour, syncIdentifier: "16015ec4134f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .suspend, startDate: f("2018-07-16 02:33:36 +0000"), endDate: f("2018-07-16 02:33:36 +0000"), value: 0.0, unit: .unitsPerHour, syncIdentifier: "1e0164e1130f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+        ]
+
+        let cachedDoseEntries = [
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 03:34:29 +0000"), endDate: f("2018-07-15 03:54:29 +0000"), value: 0.0, unit: .units, syncIdentifier: "16015de2144e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 03:54:29 +0000"), endDate: f("2018-07-15 04:14:31 +0000"), value: 0.0, unit: .units, syncIdentifier: "16015df6144e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 04:14:31 +0000"), endDate: f("2018-07-15 04:29:28 +0000"), value: 0.0, unit: .units, syncIdentifier: "16015fce154e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 04:29:28 +0000"), endDate: f("2018-07-15 04:44:28 +0000"), value: 0.29999999999999999, unit: .units, syncIdentifier: "7b055cdd150e122a3000", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 04:44:28 +0000"), endDate: f("2018-07-15 04:49:29 +0000"), value: 0.29999999999999999, unit: .units, syncIdentifier: "16015cec154e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 04:49:29 +0000"), endDate: f("2018-07-15 04:54:28 +0000"), value: 0.29999999999999999, unit: .units, syncIdentifier: "16015df1154e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 04:54:28 +0000"), endDate: f("2018-07-15 04:59:28 +0000"), value: 0.29999999999999999, unit: .units, syncIdentifier: "16015cf6154e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 04:59:28 +0000"), endDate: f("2018-07-15 05:04:29 +0000"), value: 0.25, unit: .units, syncIdentifier: "16015cfb154e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .bolus, startDate: f("2018-07-15 05:00:01 +0000"), endDate: f("2018-07-15 05:00:01 +0000"), value: 3.0, unit: .units, syncIdentifier: "0100780078004c0041c0364e12", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 05:04:29 +0000"), endDate: f("2018-07-15 05:24:29 +0000"), value: 0.0, unit: .units, syncIdentifier: "16015dc4164e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 05:24:29 +0000"), endDate: f("2018-07-15 05:44:29 +0000"), value: 0.0, unit: .units, syncIdentifier: "16015dd8164e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 05:44:29 +0000"), endDate: f("2018-07-15 05:59:29 +0000"), value: 0.0, unit: .units, syncIdentifier: "16015dec164e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 05:59:29 +0000"), endDate: f("2018-07-15 06:04:29 +0000"), value: 0.050000000000000003, unit: .units, syncIdentifier: "16015dfb164e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:04:29 +0000"), endDate: f("2018-07-15 06:09:29 +0000"), value: 0.0, unit: .units, syncIdentifier: "16015dc4174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:09:29 +0000"), endDate: f("2018-07-15 06:14:29 +0000"), value: 0.14999999999999999, unit: .units, syncIdentifier: "16015dc9174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:14:29 +0000"), endDate: f("2018-07-15 06:19:29 +0000"), value: 0.050000000000000003, unit: .units, syncIdentifier: "16015dce174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:19:29 +0000"), endDate: f("2018-07-15 06:24:29 +0000"), value: 0.14999999999999999, unit: .units, syncIdentifier: "16015dd3174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:24:29 +0000"), endDate: f("2018-07-15 06:29:29 +0000"), value: 0.34999999999999998, unit: .units, syncIdentifier: "16015dd8174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:29:29 +0000"), endDate: f("2018-07-15 06:34:28 +0000"), value: 0.34999999999999998, unit: .units, syncIdentifier: "16015ddd174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:34:28 +0000"), endDate: f("2018-07-15 06:39:28 +0000"), value: 0.25, unit: .units, syncIdentifier: "16015ce2174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:39:28 +0000"), endDate: f("2018-07-15 06:44:29 +0000"), value: 0.29999999999999999, unit: .units, syncIdentifier: "16015ce7174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:44:29 +0000"), endDate: f("2018-07-15 06:49:31 +0000"), value: 0.25, unit: .units, syncIdentifier: "16015dec174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 06:49:31 +0000"), endDate: f("2018-07-15 06:54:30 +0000"), value: 0.14999999999999999, unit: .units, syncIdentifier: "16015ff1174e12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 06:54:30 +0000"), endDate: f("2018-07-15 07:00:00 +0000"), value: 0.10000000000000001, unit: .units, syncIdentifier: "7b055ef6170e122a3000", scheduledBasalRate: nil),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 07:00:00 +0000"), endDate: f("2018-07-15 07:09:28 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "7b0040c0000f12003000", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 07:09:28 +0000"), endDate: f("2018-07-15 07:14:28 +0000"), value: 0.050000000000000003, unit: .units, syncIdentifier: "16015cc9004f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 07:14:28 +0000"), endDate: f("2018-07-15 07:19:29 +0000"), value: 0.050000000000000003, unit: .units, syncIdentifier: "16015cce004f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 07:19:29 +0000"), endDate: f("2018-07-15 07:24:29 +0000"), value: 0.10000000000000001, unit: .units, syncIdentifier: "7b005dd3000f12003000", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 07:24:29 +0000"), endDate: f("2018-07-15 07:29:28 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "16015dd8004f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 07:29:29 +0000"), endDate: f("2018-07-15 07:34:29 +0000"), value: 0.10000000000000001, unit: .units, syncIdentifier: "7b005ddd000f12003000", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 07:34:29 +0000"), endDate: f("2018-07-15 07:39:29 +0000"), value: 0.14999999999999999, unit: .units, syncIdentifier: "16015de2004f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 07:39:29 +0000"), endDate: f("2018-07-15 07:44:28 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "16015de7004f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 07:44:28 +0000"), endDate: f("2018-07-15 07:49:28 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "16015cec004f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 07:49:28 +0000"), endDate: f("2018-07-15 07:54:28 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "16015cf1004f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 07:54:28 +0000"), endDate: f("2018-07-15 07:59:31 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "16015cf6004f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 07:59:31 +0000"), endDate: f("2018-07-15 08:04:30 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "16015ffb004f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 08:04:30 +0000"), endDate: f("2018-07-15 08:09:28 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "16015ec4014f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 08:09:28 +0000"), endDate: f("2018-07-15 08:14:28 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "16015cc9014f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 08:14:28 +0000"), endDate: f("2018-07-15 08:19:28 +0000"), value: 0.14999999999999999, unit: .units, syncIdentifier: "16015cce014f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 08:19:29 +0000"), endDate: f("2018-07-15 08:24:29 +0000"), value: 0.10000000000000001, unit: .units, syncIdentifier: "7b005dd3010f12003000", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 08:24:29 +0000"), endDate: f("2018-07-15 08:29:29 +0000"), value: 0.14999999999999999, unit: .units, syncIdentifier: "16015dd8014f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 08:29:29 +0000"), endDate: f("2018-07-15 08:34:15 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "16015ddd014f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 08:34:15 +0000"), endDate: f("2018-07-15 08:49:14 +0000"), value: 0.29999999999999999, unit: .units, syncIdentifier: "7b004fe2010f12003000", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 08:49:14 +0000"), endDate: f("2018-07-15 08:54:14 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "16014ef1014f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 08:54:14 +0000"), endDate: f("2018-07-15 08:59:15 +0000"), value: 0.29999999999999999, unit: .units, syncIdentifier: "16014ef6014f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 08:59:15 +0000"), endDate: f("2018-07-15 09:04:14 +0000"), value: 0.29999999999999999, unit: .units, syncIdentifier: "16014ffb014f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 09:04:14 +0000"), endDate: f("2018-07-15 09:09:15 +0000"), value: 0.25, unit: .units, syncIdentifier: "16014ec4024f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 09:09:15 +0000"), endDate: f("2018-07-15 10:00:00 +0000"), value: 1.0, unit: .units, syncIdentifier: "7b004fc9020f12003000", scheduledBasalRate: nil),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 10:00:00 +0000"), endDate: f("2018-07-15 11:09:15 +0000"), value: 1.1499999999999999, unit: .units, syncIdentifier: "7b0140c0030f12062800", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 11:09:15 +0000"), endDate: f("2018-07-15 11:14:14 +0000"), value: 0.0, unit: .units, syncIdentifier: "16014fc9044f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 11:14:15 +0000"), endDate: f("2018-07-15 11:39:14 +0000"), value: 0.40000000000000002, unit: .units, syncIdentifier: "7b014fce040f12062800", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 11:39:14 +0000"), endDate: f("2018-07-15 11:44:14 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "16014ee7044f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 11:44:14 +0000"), endDate: f("2018-07-15 11:49:15 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "16014eec044f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 11:49:15 +0000"), endDate: f("2018-07-15 11:54:14 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "16014ff1044f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 11:54:14 +0000"), endDate: f("2018-07-15 11:59:15 +0000"), value: 0.14999999999999999, unit: .units, syncIdentifier: "16014ef6044f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 11:59:15 +0000"), endDate: f("2018-07-15 14:00:00 +0000"), value: 2.0, unit: .units, syncIdentifier: "7b014ffb040f12062800", scheduledBasalRate: nil),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 14:00:00 +0000"), endDate: f("2018-07-15 14:09:48 +0000"), value: 0.14999999999999999, unit: .units, syncIdentifier: "7b0240c0070f120e2400", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 14:09:48 +0000"), endDate: f("2018-07-15 14:14:15 +0000"), value: 0.14999999999999999, unit: .units, syncIdentifier: "160170c9074f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 14:14:15 +0000"), endDate: f("2018-07-15 15:29:15 +0000"), value: 1.1499999999999999, unit: .units, syncIdentifier: "7b024fce070f120e2400", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 15:29:15 +0000"), endDate: f("2018-07-15 15:34:14 +0000"), value: 0.14999999999999999, unit: .units, syncIdentifier: "16014fdd084f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 15:34:15 +0000"), endDate: f("2018-07-15 15:39:14 +0000"), value: 0.050000000000000003, unit: .units, syncIdentifier: "7b024fe2080f120e2400", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 15:39:14 +0000"), endDate: f("2018-07-15 15:44:14 +0000"), value: 0.14999999999999999, unit: .units, syncIdentifier: "16014ee7084f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 15:44:14 +0000"), endDate: f("2018-07-15 15:49:14 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "16014eec084f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 15:49:14 +0000"), endDate: f("2018-07-15 15:54:16 +0000"), value: 0.14999999999999999, unit: .units, syncIdentifier: "16014ef1084f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .bolus, startDate: f("2018-07-15 15:49:33 +0000"), endDate: f("2018-07-15 15:49:33 +0000"), value: 2.4500000000000002, unit: .units, syncIdentifier: "010062006200000061f1284f12", scheduledBasalRate: nil),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 15:54:16 +0000"), endDate: f("2018-07-15 16:14:15 +0000"), value: 0.29999999999999999, unit: .units, syncIdentifier: "7b0250f6080f120e2400", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 16:14:15 +0000"), endDate: f("2018-07-15 16:34:15 +0000"), value: 0.0, unit: .units, syncIdentifier: "16014fce094f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 16:34:15 +0000"), endDate: f("2018-07-15 16:44:14 +0000"), value: 0.14999999999999999, unit: .units, syncIdentifier: "7b024fe2090f120e2400", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 16:44:14 +0000"), endDate: f("2018-07-15 17:14:14 +0000"), value: 2.3500000000000001, unit: .units, syncIdentifier: "16014eec094f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 17:14:15 +0000"), endDate: f("2018-07-15 18:30:00 +0000"), value: 1.1499999999999999, unit: .units, syncIdentifier: "7b024fce0a0f120e2400", scheduledBasalRate: nil),
+            DoseEntry(type: .bolus, startDate: f("2018-07-15 17:55:12 +0000"), endDate: f("2018-07-15 17:55:12 +0000"), value: 2.5499999999999998, unit: .units, syncIdentifier: "01006600660029004cf72a4f12", scheduledBasalRate: nil),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 18:30:00 +0000"), endDate: f("2018-07-15 18:59:15 +0000"), value: 0.40000000000000002, unit: .units, syncIdentifier: "7b0340de0b0f12172000", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 18:59:15 +0000"), endDate: f("2018-07-15 19:04:15 +0000"), value: 0.40000000000000002, unit: .units, syncIdentifier: "16014ffb0b4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 19:04:15 +0000"), endDate: f("2018-07-15 19:09:14 +0000"), value: 0.34999999999999998, unit: .units, syncIdentifier: "16014fc40c4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 19:09:14 +0000"), endDate: f("2018-07-15 19:19:15 +0000"), value: 0.80000000000000004, unit: .units, syncIdentifier: "16014ec90c4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 19:19:15 +0000"), endDate: f("2018-07-15 19:24:15 +0000"), value: 0.050000000000000003, unit: .units, syncIdentifier: "7b034fd30c0f12172000", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 19:24:15 +0000"), endDate: f("2018-07-15 19:29:14 +0000"), value: 0.25, unit: .units, syncIdentifier: "16014fd80c4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 19:29:14 +0000"), endDate: f("2018-07-15 19:34:14 +0000"), value: 0.40000000000000002, unit: .units, syncIdentifier: "16014edd0c4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 19:34:14 +0000"), endDate: f("2018-07-15 19:39:14 +0000"), value: 0.40000000000000002, unit: .units, syncIdentifier: "16014ee20c4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 19:39:14 +0000"), endDate: f("2018-07-15 19:44:15 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "16014ee70c4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 19:44:15 +0000"), endDate: f("2018-07-15 20:04:15 +0000"), value: 0.25, unit: .units, syncIdentifier: "7b034fec0c0f12172000", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 20:04:15 +0000"), endDate: f("2018-07-15 20:23:00 +0000"), value: 0.0, unit: .units, syncIdentifier: "16014fc40d4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 20:23:00 +0000"), endDate: f("2018-07-15 20:29:15 +0000"), value: 0.0, unit: .units, syncIdentifier: "160140d70d4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 20:29:15 +0000"), endDate: f("2018-07-15 20:49:14 +0000"), value: 0.0, unit: .units, syncIdentifier: "16014fdd0d4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 20:49:14 +0000"), endDate: f("2018-07-15 21:09:14 +0000"), value: 0.0, unit: .units, syncIdentifier: "16014ef10d4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 21:09:14 +0000"), endDate: f("2018-07-15 21:29:30 +0000"), value: 0.0, unit: .units, syncIdentifier: "16014ec90e4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.8)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 21:29:31 +0000"), endDate: f("2018-07-15 21:30:00 +0000"), value: 0.0, unit: .units, syncIdentifier: "7b035fdd0e0f12172000", scheduledBasalRate: nil),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 21:30:00 +0000"), endDate: f("2018-07-15 21:49:29 +0000"), value: 0.29999999999999999, unit: .units, syncIdentifier: "7b0440de0e0f121d2400", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 21:49:29 +0000"), endDate: f("2018-07-15 21:54:32 +0000"), value: 0.25, unit: .units, syncIdentifier: "16015df10e4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 21:54:32 +0000"), endDate: f("2018-07-15 21:59:29 +0000"), value: 0.25, unit: .units, syncIdentifier: "160160f60e4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 21:59:29 +0000"), endDate: f("2018-07-15 22:04:31 +0000"), value: 0.25, unit: .units, syncIdentifier: "16015dfb0e4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 22:04:31 +0000"), endDate: f("2018-07-15 22:09:31 +0000"), value: 0.40000000000000002, unit: .units, syncIdentifier: "16015fc40f4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 22:09:31 +0000"), endDate: f("2018-07-15 22:14:32 +0000"), value: 0.34999999999999998, unit: .units, syncIdentifier: "16015fc90f4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 22:14:32 +0000"), endDate: f("2018-07-15 22:19:30 +0000"), value: 0.29999999999999999, unit: .units, syncIdentifier: "160160ce0f4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 22:19:30 +0000"), endDate: f("2018-07-15 22:24:29 +0000"), value: 0.29999999999999999, unit: .units, syncIdentifier: "16015ed30f4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 22:24:29 +0000"), endDate: f("2018-07-15 22:29:46 +0000"), value: 0.29999999999999999, unit: .units, syncIdentifier: "16015dd80f4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 22:29:46 +0000"), endDate: f("2018-07-15 22:34:45 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "16016edd0f4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .basal, startDate: f("2018-07-15 22:34:45 +0000"), endDate: f("2018-07-15 22:39:29 +0000"), value: 0.050000000000000003, unit: .units, syncIdentifier: "7b046de20f0f121d2400", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 22:39:29 +0000"), endDate: f("2018-07-15 23:01:42 +0000"), value: 0.14999999999999999, unit: .units, syncIdentifier: "16015de70f4f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .bolus, startDate: f("2018-07-15 22:54:39 +0000"), endDate: f("2018-07-15 22:54:39 +0000"), value: 2.8500000000000001, unit: .units, syncIdentifier: "010072007200000067f62f4f12", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 23:01:42 +0000"), endDate: f("2018-07-15 23:24:29 +0000"), value: 0.0, unit: .units, syncIdentifier: "16016ac1104f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 23:24:29 +0000"), endDate: f("2018-07-15 23:29:44 +0000"), value: 0.0, unit: .units, syncIdentifier: "16015dd8104f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 23:29:44 +0000"), endDate: f("2018-07-15 23:34:28 +0000"), value: 0.10000000000000001, unit: .units, syncIdentifier: "16016cdd104f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 23:34:28 +0000"), endDate: f("2018-07-15 23:39:29 +0000"), value: 0.14999999999999999, unit: .units, syncIdentifier: "16015ce2104f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 23:39:29 +0000"), endDate: f("2018-07-15 23:49:29 +0000"), value: 0.25, unit: .units, syncIdentifier: "16015de7104f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .bolus, startDate: f("2018-07-15 23:43:57 +0000"), endDate: f("2018-07-15 23:43:57 +0000"), value: 1.5, unit: .units, syncIdentifier: "01003c003c00620079eb304f12", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-15 23:49:29 +0000"), endDate: f("2018-07-16 00:04:42 +0000"), value: 0.0, unit: .units, syncIdentifier: "16015df1104f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .bolus, startDate: f("2018-07-16 00:02:37 +0000"), endDate: f("2018-07-16 00:02:37 +0000"), value: 2.6000000000000001, unit: .units, syncIdentifier: "010068006800910065c2314f12", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 00:04:42 +0000"), endDate: f("2018-07-16 00:09:29 +0000"), value: 0.0, unit: .units, syncIdentifier: "16016ac4114f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .basal, startDate: f("2018-07-16 00:09:29 +0000"), endDate: f("2018-07-16 00:24:32 +0000"), value: 0.25, unit: .units, syncIdentifier: "7b045dc9110f121d2400", scheduledBasalRate: nil),
+            DoseEntry(type: .bolus, startDate: f("2018-07-16 00:20:20 +0000"), endDate: f("2018-07-16 00:20:20 +0000"), value: 1.1499999999999999, unit: .units, syncIdentifier: "01002e002e00e70054d4314f12", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 00:24:32 +0000"), endDate: f("2018-07-16 00:44:28 +0000"), value: 0.0, unit: .units, syncIdentifier: "160160d8114f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 00:44:28 +0000"), endDate: f("2018-07-16 01:04:29 +0000"), value: 0.0, unit: .units, syncIdentifier: "16015cec114f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 01:04:29 +0000"), endDate: f("2018-07-16 01:27:16 +0000"), value: 0.0, unit: .units, syncIdentifier: "16015dc4124f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 01:27:16 +0000"), endDate: f("2018-07-16 01:49:29 +0000"), value: 0.0, unit: .units, syncIdentifier: "160150db124f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 01:49:29 +0000"), endDate: f("2018-07-16 02:04:30 +0000"), value: 0.0, unit: .units, syncIdentifier: "16015df1124f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 0.9)),
+            DoseEntry(type: .bolus, startDate: f("2018-07-16 01:58:53 +0000"), endDate: f("2018-07-16 01:58:53 +0000"), value: 3.6499999999999999, unit: .units, syncIdentifier: "010092009200730075fa324f12", scheduledBasalRate: nil),
+        ]
+
+        XCTAssertEqual(f("2018-07-16 02:04:30 +0000"), cachedDoseEntries.lastBasalEndDate!)
+
+        let appended = cachedDoseEntries.appendedUnion(with: normalizedDoseEntries)
+        XCTAssertEqual(appended.count, normalizedDoseEntries.count)
+        XCTAssertEqual(
+            appended,
+            cachedDoseEntries.appendedUnion(with: normalizedDoseEntries.filterDateRange(cachedDoseEntries.lastBasalEndDate, nil)),
+            "Filtering has the same outcome"
+        )
+
+        let insulinModel = ExponentialInsulinModel(actionDuration: TimeInterval(minutes: 360), peakActivityTime: TimeInterval(minutes: 75))
+        let date = f("2018-07-16 03:40:00 +0000")
+
+        XCTAssertEqual(
+            normalizedDoseEntries.insulinOnBoard(model: insulinModel, from: date, to: date).first!.value,
+            appended.insulinOnBoard(model: insulinModel, from: date, to: date).first!.value,
+            accuracy: 1.0/40
+        )
+
+        let emptyCacheAppended = ([DoseEntry]()).appendedUnion(with: normalizedDoseEntries)
+
+        XCTAssertEqual(
+            normalizedDoseEntries.insulinOnBoard(model: insulinModel, from: date, to: date).first!.value,
+            emptyCacheAppended.insulinOnBoard(model: insulinModel, from: date, to: date).first!.value,
+            accuracy: 1.0/40,
+            "Empty cache doesn't affect outcome"
+        )
+
+        let fullCache = cachedDoseEntries.appendedUnion(with: [])
+
+        XCTAssertEqual(
+            cachedDoseEntries.insulinOnBoard(model: insulinModel, from: date, to: date).first!.value,
+            fullCache.insulinOnBoard(model: insulinModel, from: date, to: date).first!.value,
+            accuracy: 1.0/40,
+            "Only cache doesn't affect outcome"
+        )
+    }
+
+    func testAppendedUnionOfReservoirEvents() {
+        let formatter = DateFormatter.descriptionFormatter
+        let f = { (input) in
+            return formatter.date(from: input)!
+        }
+        let unit = DoseEntry.unitsPerHour
+
+        let normalizedReservoirDoseEntries = [
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 03:59:00 +0000"), endDate: f("2018-07-16 04:04:00 +0000"), value: 2.4000000000000341, unit: .unitsPerHour, scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 04:04:00 +0000"), endDate: f("2018-07-16 04:09:00 +0000"), value: 2.3999999999998636, unit: .unitsPerHour, scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 04:09:00 +0000"), endDate: f("2018-07-16 04:14:00 +0000"), value: 1.2000000000001023, unit: .unitsPerHour, scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 04:14:00 +0000"), endDate: f("2018-07-16 04:19:00 +0000"), value: 2.4000000000000341, unit: .unitsPerHour, scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 04:19:00 +0000"), endDate: f("2018-07-16 04:24:00 +0000"), value: 2.3999999999998636, unit: .unitsPerHour, scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 04:24:00 +0000"), endDate: f("2018-07-16 04:29:00 +0000"), value: 1.2000000000001023, unit: .unitsPerHour, scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 04:29:00 +0000"), endDate: f("2018-07-16 04:34:00 +0000"), value: 0.0, unit: .unitsPerHour, scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 04:34:00 +0000"), endDate: f("2018-07-16 04:39:00 +0000"), value: 0.0, unit: .unitsPerHour, scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 04:39:00 +0000"), endDate: f("2018-07-16 04:44:00 +0000"), value: 0.0, unit: .unitsPerHour, scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 04:44:00 +0000"), endDate: f("2018-07-16 04:49:00 +0000"), value: 0.0, unit: .unitsPerHour, scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 04:49:00 +0000"), endDate: f("2018-07-16 04:54:00 +0000"), value: 0.0, unit: .unitsPerHour, scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 04:54:00 +0000"), endDate: f("2018-07-16 04:59:00 +0000"), value: 0.0, unit: .unitsPerHour, scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 04:59:00 +0000"), endDate: f("2018-07-16 05:04:00 +0000"), value: 0.0, unit: .unitsPerHour, scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 05:04:00 +0000"), endDate: f("2018-07-16 05:09:00 +0000"), value: 0.0, unit: .unitsPerHour, scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 05:09:00 +0000"), endDate: f("2018-07-16 05:14:00 +0000"), value: 0.0, unit: .unitsPerHour, scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 05:14:00 +0000"), endDate: f("2018-07-16 05:19:00 +0000"), value: 1.1999999999999318, unit: .unitsPerHour, scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 05:19:00 +0000"), endDate: f("2018-07-16 05:24:00 +0000"), value: 1.2000000000001023, unit: .unitsPerHour, scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 05:24:00 +0000"), endDate: f("2018-07-16 05:29:00 +0000"), value: 1.1999999999999318, unit: .unitsPerHour, scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+        ]
+
+        let cachedDoseEntries = [
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 03:59:15 +0000"), endDate: f("2018-07-16 04:04:14 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "16014ffb144f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 04:04:14 +0000"), endDate: f("2018-07-16 04:09:15 +0000"), value: 0.14999999999999999, unit: .units, syncIdentifier: "16014ec4154f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 04:09:15 +0000"), endDate: f("2018-07-16 04:14:14 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "16014fc9154f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 04:14:14 +0000"), endDate: f("2018-07-16 04:19:14 +0000"), value: 0.20000000000000001, unit: .units, syncIdentifier: "16014ece154f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 04:19:14 +0000"), endDate: f("2018-07-16 04:24:15 +0000"), value: 0.14999999999999999, unit: .units, syncIdentifier: "16014ed3154f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .basal, startDate: f("2018-07-16 04:24:15 +0000"), endDate: f("2018-07-16 04:29:14 +0000"), value: 0.10000000000000001, unit: .units, syncIdentifier: "7b054fd8150f122a3000", scheduledBasalRate: nil),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 04:29:14 +0000"), endDate: f("2018-07-16 04:49:15 +0000"), value: 0.0, unit: .units, syncIdentifier: "16014edd154f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 04:49:15 +0000"), endDate: f("2018-07-16 05:09:15 +0000"), value: 0.0, unit: .units, syncIdentifier: "16014ff1154f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+            DoseEntry(type: .tempBasal, startDate: f("2018-07-16 05:09:15 +0000"), endDate: f("2018-07-16 05:14:15 +0000"), value: 0.0, unit: .units, syncIdentifier: "16014fc9164f12", scheduledBasalRate: HKQuantity(unit: unit, doubleValue: 1.2)),
+        ]
+
+        XCTAssertEqual(f("2018-07-16 05:14:15 +0000"), cachedDoseEntries.lastBasalEndDate!)
+
+        let appended = cachedDoseEntries + normalizedReservoirDoseEntries.filterDateRange(cachedDoseEntries.lastBasalEndDate!, nil).map({ $0.trim(from: cachedDoseEntries.lastBasalEndDate!) })
+        XCTAssertEqual(appended.count, cachedDoseEntries.count + 3, "The last 4 reservoir doses should be appended")
+
+        let insulinModel = ExponentialInsulinModel(actionDuration: TimeInterval(minutes: 360), peakActivityTime: TimeInterval(minutes: 75))
+        let date = f("2018-07-16 05:30:00 +0000")
+
+        XCTAssertEqual(
+            normalizedReservoirDoseEntries.insulinOnBoard(model: insulinModel, from: date, to: date).first!.value,
+            appended.insulinOnBoard(model: insulinModel, from: date, to: date).first!.value,
+            accuracy: 1.0/40
+        )
     }
 }

--- a/LoopKitTests/Persistence/CachedCarbObjectTests.swift
+++ b/LoopKitTests/Persistence/CachedCarbObjectTests.swift
@@ -1,0 +1,102 @@
+//
+//  CachedCarbObjectTests.swift
+//  LoopKitTests
+//
+//  Copyright © 2018 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+@testable import LoopKit
+
+class CachedCarbObjectTests: PersistenceControllerTestCase {
+
+    func testUUIDUniqueConstraint() {
+        cacheStore.managedObjectContext.performAndWait {
+            let uuid = UUID()
+
+            let object1 = CachedCarbObject(context: cacheStore.managedObjectContext)
+            object1.setDefaultValues()
+            object1.uuid = uuid
+
+            try! cacheStore.managedObjectContext.save()
+
+            let object2 = CachedCarbObject(context: cacheStore.managedObjectContext)
+            object2.setDefaultValues()
+            object2.uuid = uuid
+
+            try! cacheStore.managedObjectContext.save()
+
+            let objects: [CachedCarbObject] = cacheStore.managedObjectContext.all()
+            XCTAssertEqual(1, objects.count)
+        }
+    }
+
+    func testSyncIdentifierUniqueConstraint() {
+        cacheStore.managedObjectContext.performAndWait {
+            let uuid = UUID()
+
+            let object1 = CachedCarbObject(context: cacheStore.managedObjectContext)
+            object1.setDefaultValues()
+            object1.syncIdentifier = uuid.uuidString
+
+            try! cacheStore.managedObjectContext.save()
+
+            let object2 = CachedCarbObject(context: cacheStore.managedObjectContext)
+            object2.setDefaultValues()
+            object2.syncIdentifier = uuid.uuidString
+
+            try! cacheStore.managedObjectContext.save()
+
+            let objects: [CachedCarbObject] = cacheStore.managedObjectContext.all()
+            XCTAssertEqual(1, objects.count)
+        }
+    }
+
+    func testAllUniqueConstraints() {
+        cacheStore.managedObjectContext.performAndWait {
+            let uuid = UUID()
+
+            let object1 = CachedCarbObject(context: cacheStore.managedObjectContext)
+            object1.setDefaultValues()
+            object1.uuid = uuid
+            object1.syncIdentifier = uuid.uuidString
+
+            try! cacheStore.managedObjectContext.save()
+
+            let object2 = CachedCarbObject(context: cacheStore.managedObjectContext)
+            object2.setDefaultValues()
+            object2.uuid = uuid
+            object2.syncIdentifier = uuid.uuidString
+
+            try! cacheStore.managedObjectContext.save()
+
+            let objects: [CachedCarbObject] = cacheStore.managedObjectContext.all()
+            XCTAssertEqual(1, objects.count)
+        }
+    }
+
+    func testSaveWithDefaultValues() {
+        cacheStore.managedObjectContext.performAndWait {
+            let object1 = CachedCarbObject(context: cacheStore.managedObjectContext)
+            object1.setDefaultValues()
+
+            try! cacheStore.managedObjectContext.save()
+
+            let object2 = CachedCarbObject(context: cacheStore.managedObjectContext)
+            object2.setDefaultValues()
+
+            try! cacheStore.managedObjectContext.save()
+
+            let objects: [CachedCarbObject] = cacheStore.managedObjectContext.all()
+            XCTAssertEqual(2, objects.count)
+        }
+    }
+}
+
+
+extension CachedCarbObject {
+    fileprivate func setDefaultValues() {
+        createdByCurrentApp = true
+        startDate = Date()
+    }
+}

--- a/LoopKitTests/Persistence/CachedGlucoseObjectTests.swift
+++ b/LoopKitTests/Persistence/CachedGlucoseObjectTests.swift
@@ -1,0 +1,107 @@
+//
+//  CachedGlucoseObjectTests.swift
+//  LoopKitTests
+//
+//  Copyright © 2018 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+@testable import LoopKit
+
+class CachedGlucoseObjectTests: PersistenceControllerTestCase {
+
+    func testUUIDUniqueConstraint() {
+        cacheStore.managedObjectContext.performAndWait {
+            let uuid = UUID()
+
+            let object1 = CachedGlucoseObject(context: cacheStore.managedObjectContext)
+            object1.setDefaultValues()
+            object1.uuid = uuid
+
+            try! cacheStore.managedObjectContext.save()
+
+            let object2 = CachedGlucoseObject(context: cacheStore.managedObjectContext)
+            object2.setDefaultValues()
+            object2.uuid = uuid
+
+            try! cacheStore.managedObjectContext.save()
+
+            let objects: [CachedGlucoseObject] = cacheStore.managedObjectContext.all()
+            XCTAssertEqual(1, objects.count)
+        }
+    }
+
+    func testSyncIdentifierUniqueConstraint() {
+        cacheStore.managedObjectContext.performAndWait {
+            let uuid = UUID()
+
+            let object1 = CachedGlucoseObject(context: cacheStore.managedObjectContext)
+            object1.setDefaultValues()
+            object1.syncIdentifier = uuid.uuidString
+
+            try! cacheStore.managedObjectContext.save()
+
+            let object2 = CachedGlucoseObject(context: cacheStore.managedObjectContext)
+            object2.setDefaultValues()
+            object2.syncIdentifier = uuid.uuidString
+
+            try! cacheStore.managedObjectContext.save()
+
+            let objects: [CachedGlucoseObject] = cacheStore.managedObjectContext.all()
+            XCTAssertEqual(1, objects.count)
+        }
+    }
+
+    func testAllUniqueConstraints() {
+        cacheStore.managedObjectContext.performAndWait {
+            let uuid = UUID()
+
+            let object1 = CachedGlucoseObject(context: cacheStore.managedObjectContext)
+            object1.setDefaultValues()
+            object1.uuid = uuid
+            object1.syncIdentifier = uuid.uuidString
+
+            try! cacheStore.managedObjectContext.save()
+
+            let object2 = CachedGlucoseObject(context: cacheStore.managedObjectContext)
+            object2.setDefaultValues()
+            object2.uuid = uuid
+            object2.syncIdentifier = uuid.uuidString
+
+            try! cacheStore.managedObjectContext.save()
+
+            let objects: [CachedGlucoseObject] = cacheStore.managedObjectContext.all()
+            XCTAssertEqual(1, objects.count)
+        }
+    }
+
+    func testSaveWithDefaultValues() {
+        cacheStore.managedObjectContext.performAndWait {
+            let object1 = CachedGlucoseObject(context: cacheStore.managedObjectContext)
+            object1.setDefaultValues()
+
+            try! cacheStore.managedObjectContext.save()
+
+            let object2 = CachedGlucoseObject(context: cacheStore.managedObjectContext)
+            object2.setDefaultValues()
+
+            try! cacheStore.managedObjectContext.save()
+
+            let objects: [CachedGlucoseObject] = cacheStore.managedObjectContext.all()
+            XCTAssertEqual(2, objects.count)
+        }
+    }
+
+}
+
+
+extension CachedGlucoseObject {
+    fileprivate func setDefaultValues() {
+        provenanceIdentifier = "CachedGlucoseObjectTests"
+        startDate = Date()
+        uuid = UUID()
+        syncIdentifier = uuid!.uuidString
+        unitString = "mg/dL"
+        value = 99
+    }
+}

--- a/LoopKitTests/Persistence/CachedInsulinDeliveryObjectTests.swift
+++ b/LoopKitTests/Persistence/CachedInsulinDeliveryObjectTests.swift
@@ -1,0 +1,107 @@
+//
+//  CachedInsulinDeliveryObjectTests.swift
+//  LoopKitTests
+//
+//  Copyright © 2018 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+@testable import LoopKit
+
+class CachedInsulinDeliveryObjectTests: PersistenceControllerTestCase {
+
+    func testUUIDUniqueConstraintPreSave() {
+        cacheStore.managedObjectContext.performAndWait {
+            let uuid = UUID()
+
+            let object1 = CachedInsulinDeliveryObject(context: cacheStore.managedObjectContext)
+            object1.setDefaultValues()
+            object1.uuid = uuid
+            object1.syncIdentifier = "object1"
+
+            let object2 = CachedInsulinDeliveryObject(context: cacheStore.managedObjectContext)
+            object2.setDefaultValues()
+            object2.uuid = uuid
+            object2.syncIdentifier = "object2"
+
+            try! cacheStore.managedObjectContext.save()
+
+            let objects: [CachedInsulinDeliveryObject] = cacheStore.managedObjectContext.all()
+            XCTAssertEqual(1, objects.count)
+        }
+    }
+
+    func testUUIDUniqueConstraintPostSave() {
+        cacheStore.managedObjectContext.performAndWait {
+            let uuid = UUID()
+
+            let object1 = CachedInsulinDeliveryObject(context: cacheStore.managedObjectContext)
+            object1.setDefaultValues()
+            object1.uuid = uuid
+
+            try! cacheStore.managedObjectContext.save()
+
+            let object2 = CachedInsulinDeliveryObject(context: cacheStore.managedObjectContext)
+            object2.setDefaultValues()
+            object2.uuid = uuid
+
+            try! cacheStore.managedObjectContext.save()
+
+            let objects: [CachedInsulinDeliveryObject] = cacheStore.managedObjectContext.all()
+            XCTAssertEqual(1, objects.count)
+        }
+    }
+
+    func testSyncIdentifierUniqueConstraint() {
+        cacheStore.managedObjectContext.performAndWait {
+            let uuid = UUID()
+
+            let object1 = CachedInsulinDeliveryObject(context: cacheStore.managedObjectContext)
+            object1.setDefaultValues()
+            object1.syncIdentifier = uuid.uuidString
+
+            try! cacheStore.managedObjectContext.save()
+
+            let object2 = CachedInsulinDeliveryObject(context: cacheStore.managedObjectContext)
+            object2.setDefaultValues()
+            object2.syncIdentifier = uuid.uuidString
+
+            try! cacheStore.managedObjectContext.save()
+
+            let objects: [CachedInsulinDeliveryObject] = cacheStore.managedObjectContext.all()
+            XCTAssertEqual(1, objects.count)
+        }
+    }
+
+    func testSaveWithDefaultValues() {
+        cacheStore.managedObjectContext.performAndWait {
+            let object1 = CachedInsulinDeliveryObject(context: cacheStore.managedObjectContext)
+            object1.setDefaultValues()
+
+            try! cacheStore.managedObjectContext.save()
+
+            let object2 = CachedInsulinDeliveryObject(context: cacheStore.managedObjectContext)
+            object2.setDefaultValues()
+
+            try! cacheStore.managedObjectContext.save()
+
+            let objects: [CachedInsulinDeliveryObject] = cacheStore.managedObjectContext.all()
+            XCTAssertEqual(2, objects.count)
+        }
+    }
+}
+
+
+extension CachedInsulinDeliveryObject {
+    fileprivate func setDefaultValues() {
+        uuid = UUID()
+        startDate = Date()
+        endDate = Date()
+        reason = .basal
+        hasLoopKitOrigin = true
+        value = 3.5
+        syncIdentifier = uuid!.uuidString
+        provenanceIdentifier = "CachedInsulinDeliveryObjectTests"
+    }
+}
+

--- a/LoopKitTests/Persistence/DeletedCarbObjectTests.swift
+++ b/LoopKitTests/Persistence/DeletedCarbObjectTests.swift
@@ -1,0 +1,59 @@
+//
+//  DeletedCarbObjectTests.swift
+//  LoopKitTests
+//
+//  Copyright © 2018 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+@testable import LoopKit
+
+class DeletedCarbObjectTests: PersistenceControllerTestCase {
+
+    func testExternalIDUniqueConstraint() {
+        cacheStore.managedObjectContext.performAndWait {
+            let uuid = UUID()
+
+            let object1 = DeletedCarbObject(context: cacheStore.managedObjectContext)
+            object1.setDefaultValues()
+            object1.externalID = uuid.uuidString
+
+            try! cacheStore.managedObjectContext.save()
+
+            let object2 = DeletedCarbObject(context: cacheStore.managedObjectContext)
+            object2.setDefaultValues()
+            object2.externalID = uuid.uuidString
+
+            try! cacheStore.managedObjectContext.save()
+
+            let objects: [DeletedCarbObject] = cacheStore.managedObjectContext.all()
+            XCTAssertEqual(1, objects.count)
+        }
+    }
+
+    func testSaveWithDefaultValues() {
+        cacheStore.managedObjectContext.performAndWait {
+            let object1 = DeletedCarbObject(context: cacheStore.managedObjectContext)
+            object1.setDefaultValues()
+
+            try! cacheStore.managedObjectContext.save()
+
+            let object2 = DeletedCarbObject(context: cacheStore.managedObjectContext)
+            object2.setDefaultValues()
+
+            try! cacheStore.managedObjectContext.save()
+
+            let objects: [DeletedCarbObject] = cacheStore.managedObjectContext.all()
+            XCTAssertEqual(2, objects.count)
+        }
+    }
+}
+
+
+extension DeletedCarbObject {
+    fileprivate func setDefaultValues() {
+        externalID = UUID().uuidString
+        uploadState = .notUploaded
+        startDate = Date()
+    }
+}

--- a/LoopKitTests/Persistence/PersistenceControllerTestCase.swift
+++ b/LoopKitTests/Persistence/PersistenceControllerTestCase.swift
@@ -1,0 +1,32 @@
+//
+//  PersistenceControllerTestCase.swift
+//  LoopKitTests
+//
+//  Copyright © 2018 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+@testable import LoopKit
+
+class PersistenceControllerTestCase: XCTestCase {
+
+    var cacheStore: PersistenceController!
+
+    override func setUp() {
+        super.setUp()
+
+        cacheStore = PersistenceController(directoryURL: URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true))
+    }
+
+    override func tearDown() {
+        cacheStore.tearDown()
+        cacheStore = nil
+
+        super.tearDown()
+    }
+
+    deinit {
+        cacheStore?.tearDown()
+    }
+    
+}

--- a/LoopKitTests/Persistence/PersistenceControllerTests.swift
+++ b/LoopKitTests/Persistence/PersistenceControllerTests.swift
@@ -1,0 +1,69 @@
+//
+//  PersistenceControllerTests.swift
+//  LoopKitTests
+//
+//  Copyright © 2018 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+import CoreData
+import HealthKit
+@testable import LoopKit
+
+class PersistenceControllerTests: PersistenceControllerTestCase {
+
+    func testPurgeObjectsBeforeSave() {
+        cacheStore.managedObjectContext.performAndWait {
+            for value in stride(from: 95, to: 105, by: 1) {
+                let glucose = CachedGlucoseObject(context: cacheStore.managedObjectContext)
+                glucose.uuid = UUID()
+                glucose.syncIdentifier = "foo\(value)"
+                glucose.syncVersion = 1
+                glucose.value = Double(value)
+                glucose.unitString = HKUnit.milligramsPerDeciliter.unitString
+                glucose.startDate = Date()
+                glucose.provenanceIdentifier = "PersistenceControllerTests"
+                glucose.isDisplayOnly = false
+            }
+
+            let predicate = NSPredicate(format: "value < %d", 100)
+            let count = try! cacheStore.managedObjectContext.purgeObjects(of: CachedGlucoseObject.self, matching: predicate)
+
+            XCTAssertEqual(0, count)
+
+            try! cacheStore.managedObjectContext.save()
+
+            let all: [CachedGlucoseObject] = cacheStore.managedObjectContext.all()
+
+            XCTAssertEqual(10, all.count)
+        }
+    }
+
+    func testPurgeObjectsAfterSave() {
+        cacheStore.managedObjectContext.performAndWait {
+            for value in stride(from: 95, to: 105, by: 1) {
+                let glucose = CachedGlucoseObject(context: cacheStore.managedObjectContext)
+                glucose.uuid = UUID()
+                glucose.syncIdentifier = "foo\(value)"
+                glucose.syncVersion = 1
+                glucose.value = Double(value)
+                glucose.unitString = HKUnit.milligramsPerDeciliter.unitString
+                glucose.startDate = Date()
+                glucose.provenanceIdentifier = "PersistenceControllerTests"
+                glucose.isDisplayOnly = false
+            }
+
+            try! cacheStore.managedObjectContext.save()
+
+            let predicate = NSPredicate(format: "value < %d", 100)
+            let count = try! cacheStore.managedObjectContext.purgeObjects(of: CachedGlucoseObject.self, matching: predicate)
+
+            XCTAssertEqual(5, count)
+
+            let all: [CachedGlucoseObject] = cacheStore.managedObjectContext.all()
+
+            XCTAssertEqual(5, all.count)
+        }
+    }
+    
+}


### PR DESCRIPTION
Reads insulin delivery data added to HealthKit, using it as truth. Pump events (and reservoir drops) are only required in the time after the latest finalized HealthKit sample.
Basal delivery not written by LoopKit is ignored, since it isn't safe to assume the absorption model follows the same insulin formulation Loop reads from a pump. Bolus delivery from Health is assumed to have the same insulin dynamics as the insulin recorded by Loop.
This solves two important cases:

1. Pump switching. When switching MM pumps, or between a MM pump and an OmniPod, or when changing OmniPods, a last-chance sync of pump events to HealthKit is done before being cleared. The next pump need only provide data as far back as the latest HealthKit sample.

2. Non-pump boluses. For those using a pen injection or inhaler to supplement  pump delivery, and those doses are stored in HealthKit, Loop will include them in its algorithm. No more disconnecting to do "Air Shots". Insulin is expensive enough.