### PR TITLE
Return correct units per hour for netBasalUnitsPerHour for boluses

### DIFF
--- a/LoopKit/InsulinKit/DoseEntry.swift
+++ b/LoopKit/InsulinKit/DoseEntry.swift
@@ -92,6 +92,13 @@ extension DoseEntry {
 
     /// The rate of delivery, net the basal rate scheduled during that time, which can be used to compute insulin on-board and glucose effects
     public var netBasalUnitsPerHour: Double {
+        switch type {
+        case .bolus:
+            return self.unitsPerHour
+        default:
+            break;
+        }
+        
         guard let basalRate = scheduledBasalRate else {
             return 0
         }


### PR DESCRIPTION
Fixes issue in Loop with long boluses not being displayed. 

Verified no upstream effects for this besides StatusChartsManager.setDoseEntries. 