### PR TITLE
Effects of carbs after given date

### DIFF
--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -1948,7 +1948,6 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 				es,
@@ -1959,7 +1958,6 @@
 				nl,
 				nb,
 				pl,
-				ru,
 			);
 			mainGroup = 43D8FDC11C728FDF0073BE78;
 			productRefGroup = 43D8FDCC1C728FDF0073BE78 /* Products */;

--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -770,18 +770,25 @@ extension CarbStore {
     /// - Parameters:
     ///   - start: The earliest date of effects to retrieve
     ///   - end: The latest date of effects to retrieve, if provided
-    ///   - effectVelocities: A timeline of glucose effect velocities, ordered by start date
+    ///   - effectVelocities: A timeline of effect velocities of observed insulin counteraction
     ///   - completion: A closure called once the effects have been retrieved
     ///   - result: An array of effects, in chronological order
-    public func getGlucoseEffects(start: Date, end: Date? = nil, effectVelocities: [GlucoseEffectVelocity]? = nil, completion: @escaping(_ result: CarbStoreResult<[GlucoseEffect]>) -> Void) {
+    public func getGlucoseEffects(start: Date, end: Date? = nil, sampleStart: Date? = nil, effectVelocities: [GlucoseEffectVelocity]? = nil, completion: @escaping(_ result: CarbStoreResult<[GlucoseEffect]>) -> Void) {
         queue.async {
             guard let carbRatioSchedule = self.carbRatioSchedule, let insulinSensitivitySchedule = self.insulinSensitivitySchedule else {
                 completion(.failure(.notConfigured))
                 return
             }
-
-            // To know glucose effects at the requested start date, we need to fetch samples that might still be absorbing
-            let foodStart = start.addingTimeInterval(-self.maximumAbsorptionTimeInterval)
+            
+            var foodStart: Date
+            if let sampleStart = sampleStart {
+                // If requested, fetch only samples after entryStart
+                foodStart = sampleStart
+            } else {
+                // To know glucose effects at the requested start date, we need to fetch samples that might still be absorbing
+                foodStart = start.addingTimeInterval(-self.maximumAbsorptionTimeInterval)
+            }
+            
             let defaultAbsorptionTimes = self.defaultAbsorptionTimes
             let absorptionTimeOverrun = self.absorptionTimeOverrun
             let delay = self.delay
@@ -819,67 +826,6 @@ extension CarbStore {
                     )
                 }
 
-                completion(.success(effects))
-            }
-        }
-    }
-
-    /// Retrieves a timeline of effect on blood glucose from carbohydrates entered after start date
-    ///
-    /// This operation is performed asynchronously and the completion will be executed on an arbitrary background queue.
-    ///
-    /// - Parameters:
-    ///   - start: The earliest date of effects to retrieve
-    ///   - end: The latest date of effects to retrieve, if provided
-    ///   - effectVelocities: A timeline of glucose effect velocities, ordered by start date
-    ///   - completion: A closure called once the effects have been retrieved
-    ///   - result: An array of effects, in chronological order
-    public func getGlucoseEffectsFutureFood(start: Date, end: Date? = nil, effectVelocities: [GlucoseEffectVelocity]? = nil, completion: @escaping(_ result: CarbStoreResult<[GlucoseEffect]>) -> Void) {
-        queue.async {
-            guard let carbRatioSchedule = self.carbRatioSchedule, let insulinSensitivitySchedule = self.insulinSensitivitySchedule else {
-                completion(.failure(.notConfigured))
-                return
-            }
-            
-            // Fetch only food samples after start date
-            let foodStart = start
-            let defaultAbsorptionTimes = self.defaultAbsorptionTimes
-            let absorptionTimeOverrun = self.absorptionTimeOverrun
-            let delay = self.delay
-            let delta = self.delta
-            
-            self.getCachedCarbSamples(start: foodStart, end: end) { (samples) in
-                let effects: [GlucoseEffect]
-                
-                if let effectVelocities = effectVelocities {
-                    effects = samples.map(
-                        to: effectVelocities,
-                        carbRatio: carbRatioSchedule,
-                        insulinSensitivity: insulinSensitivitySchedule,
-                        absorptionTimeOverrun: absorptionTimeOverrun,
-                        defaultAbsorptionTime: defaultAbsorptionTimes.medium,
-                        delay: delay
-                        ).dynamicGlucoseEffects(
-                            from: start,
-                            to: end,
-                            carbRatios: carbRatioSchedule,
-                            insulinSensitivities: insulinSensitivitySchedule,
-                            defaultAbsorptionTime: defaultAbsorptionTimes.medium,
-                            delay: delay,
-                            delta: delta
-                    )
-                } else {
-                    effects = samples.glucoseEffects(
-                        from: start,
-                        to: end,
-                        carbRatios: carbRatioSchedule,
-                        insulinSensitivities: insulinSensitivitySchedule,
-                        defaultAbsorptionTime: defaultAbsorptionTimes.medium,
-                        delay: delay,
-                        delta: delta
-                    )
-                }
-                
                 completion(.success(effects))
             }
         }

--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -770,7 +770,8 @@ extension CarbStore {
     /// - Parameters:
     ///   - start: The earliest date of effects to retrieve
     ///   - end: The latest date of effects to retrieve, if provided
-    ///   - effectVelocities: A timeline of effect velocities of observed insulin counteraction
+    ///   - effectVelocities: A timeline of observed insulin counteraction, if provided
+    ///   - sampleStart: If provided, fetch only entries after this date
     ///   - completion: A closure called once the effects have been retrieved
     ///   - result: An array of effects, in chronological order
     public func getGlucoseEffects(start: Date, end: Date? = nil, sampleStart: Date? = nil, effectVelocities: [GlucoseEffectVelocity]? = nil, completion: @escaping(_ result: CarbStoreResult<[GlucoseEffect]>) -> Void) {
@@ -781,12 +782,17 @@ extension CarbStore {
             }
             
             var foodStart: Date
+            var observedInsulinCounteraction: [GlucoseEffectVelocity]? = nil
             if let sampleStart = sampleStart {
-                // If requested, fetch only samples after entryStart
+                // If sampleStart is provided, fetch only samples after that date
                 foodStart = sampleStart
+                // Since not all absorbing samples are necessarily fetched, glucose effects are calculated based on linear carb absorption model
+                observedInsulinCounteraction = []
             } else {
                 // To know glucose effects at the requested start date, we need to fetch samples that might still be absorbing
                 foodStart = start.addingTimeInterval(-self.maximumAbsorptionTimeInterval)
+                // All absorbing samples are fetched, glucose effects are calculated based on dynamic carb absorption model using observed insulin counteraction
+                observedInsulinCounteraction = effectVelocities
             }
             
             let defaultAbsorptionTimes = self.defaultAbsorptionTimes
@@ -797,9 +803,9 @@ extension CarbStore {
             self.getCachedCarbSamples(start: foodStart, end: end) { (samples) in
                 let effects: [GlucoseEffect]
 
-                if let effectVelocities = effectVelocities {
+                if let observedInsulinCounteraction = observedInsulinCounteraction {
                     effects = samples.map(
-                        to: effectVelocities,
+                        to: observedInsulinCounteraction,
                         carbRatio: carbRatioSchedule,
                         insulinSensitivity: insulinSensitivitySchedule,
                         absorptionTimeOverrun: absorptionTimeOverrun,


### PR DESCRIPTION
Adds getGlucoseEffectsFutureFood method to CarbStore to retrieve a timeline of effects on glucose from carbohydrates entered after start date. The method is the same as getGlucoseEffects, except only future carb entries are taken into account. Loop use case: carb correction warning when slow carb absorption is detected, such as in the following situations: (a) user enters future carbs and accepts bolus but forgets to eat, or (b) user overestimates carbs, or (c) carb absorption is delayed due to exercise or other effects. This PR complements #249. Both are needed for the Loop "carb correction notification" feature,  which is currently work in progress.   