### PR TITLE
Fix bug that was incorrectly extending end date of old override

### DIFF
--- a/LoopKit/TemporaryScheduleOverrideHistory.swift
+++ b/LoopKit/TemporaryScheduleOverrideHistory.swift
@@ -78,8 +78,10 @@ public final class TemporaryScheduleOverrideHistory {
     private func record(_ override: TemporaryScheduleOverride, at enableDate: Date) {
         recentEvents.removeAll(where: { $0.override.startDate >= override.startDate })
 
-        if recentEvents.last?.override.hasFinished(relativeTo: enableDate) == false {
-            let overrideEnd = min(override.startDate.nearestPrevious, enableDate)
+        if  let lastEvent = recentEvents.last,
+            case let overrideEnd = min(override.startDate.nearestPrevious, enableDate),
+            lastEvent.actualEndDate > overrideEnd
+        {
             recentEvents[recentEvents.endIndex - 1].end = .early(overrideEnd)
         }
 

--- a/LoopKitTests/TemporaryScheduleOverrideHistoryTests.swift
+++ b/LoopKitTests/TemporaryScheduleOverrideHistoryTests.swift
@@ -227,4 +227,21 @@ final class TemporaryScheduleOverrideHistoryTests: XCTestCase {
 
         XCTAssert(historyResolves(to: expected, referenceDateOffset: .hours(6)))
     }
+
+    func testCancelSequence() {
+        recordOverride(beginningAt: .hours(2), duration: .finite(.hours(8)), insulinNeedsScaleFactor: 1.5)
+        recordOverrideDisable(at: .hours(4))
+        recordOverride(beginningAt: .hours(7), duration: .finite(.hours(1)), insulinNeedsScaleFactor: 1.5)
+        let expected = BasalRateSchedule(dailyItems: [
+            RepeatingScheduleValue(startTime: .hours(0), value: 1.2),
+            RepeatingScheduleValue(startTime: .hours(2), value: 1.8),
+            RepeatingScheduleValue(startTime: .hours(4), value: 1.2),
+            RepeatingScheduleValue(startTime: .hours(6), value: 1.4),
+            RepeatingScheduleValue(startTime: .hours(7), value: 2.1),
+            RepeatingScheduleValue(startTime: .hours(8), value: 1.4),
+            RepeatingScheduleValue(startTime: .hours(20), value: 1.0)
+        ])!
+
+        XCTAssert(historyResolves(to: expected, referenceDateOffset: .hours(6)))
+    }
 }


### PR DESCRIPTION
The sequence of:
1. Enable an overrride
2. Cancel the override early
3. Enable another override

...was actually extending the end date of the original override to the moment before the next override was enabled. The piece of logic was supposed to truncate an enabled override if another override was enabled on top of it, but it wasn't checking the actual end date of the override to verify it needed to be adjusted.

The result is that on (3), the historical CR and ISF schedules were being changed, which meant that the effects of doses during that time became wildly different, which in turn would throw off ICE and hence carb absorption.

Fixes https://github.com/LoopKit/Loop/issues/1030, https://github.com/LoopKit/Loop/issues/1006, and https://github.com/LoopKit/Loop/issues/1043