### PR TITLE
Store correction range units for overrides

### DIFF
--- a/LoopKit/DailyQuantitySchedule+Override.swift
+++ b/LoopKit/DailyQuantitySchedule+Override.swift
@@ -17,10 +17,11 @@ extension GlucoseRangeSchedule {
         guard let targetRange = override.settings.targetRange else {
             return self
         }
-
+        
         // Project target range changes indefinitely into the future
+        let doubleRange = targetRange.doubleRange(for: unit)
         let affectedInterval = DateInterval(start: override.startDate, end: .distantFuture)
-        let rangeSchedule = self.rangeSchedule.overridingTargetRange(with: targetRange, during: affectedInterval, relativeTo: date)
+        let rangeSchedule = self.rangeSchedule.overridingTargetRange(with: doubleRange, during: affectedInterval, relativeTo: date)
         return GlucoseRangeSchedule(rangeSchedule: rangeSchedule)
     }
 }

--- a/LoopKit/GlucoseRangeSchedule.swift
+++ b/LoopKit/GlucoseRangeSchedule.swift
@@ -125,10 +125,16 @@ public struct GlucoseRangeSchedule: DailySchedule, Equatable {
     }
 }
 
-fileprivate extension DoubleRange {
-    func quantityRange(for unit: HKUnit) -> ClosedRange<HKQuantity> {
+extension DoubleRange {
+    public func quantityRange(for unit: HKUnit) -> ClosedRange<HKQuantity> {
         let lowerBound = HKQuantity(unit: unit, doubleValue: minValue)
         let upperBound = HKQuantity(unit: unit, doubleValue: maxValue)
         return lowerBound...upperBound
+    }
+}
+
+extension ClosedRange where Bound == HKQuantity {
+    func doubleRange(for unit: HKUnit) -> DoubleRange {
+        return DoubleRange(minValue: lowerBound.doubleValue(for: unit), maxValue: upperBound.doubleValue(for: unit))
     }
 }

--- a/LoopKit/TemporaryScheduleOverrideSettings.swift
+++ b/LoopKit/TemporaryScheduleOverrideSettings.swift
@@ -6,12 +6,16 @@
 //  Copyright © 2019 LoopKit Authors. All rights reserved.
 //
 
-import Foundation
+import HealthKit
 
 
 public struct TemporaryScheduleOverrideSettings: Hashable {
-    public var targetRange: DoubleRange?
+    private var targetRangeInMgdl: DoubleRange?
     public var insulinNeedsScaleFactor: Double?
+
+    public var targetRange: ClosedRange<HKQuantity>? {
+        return targetRangeInMgdl.map { $0.quantityRange(for: .milligramsPerDeciliter) }
+    }
 
     public var basalRateMultiplier: Double? {
         return insulinNeedsScaleFactor
@@ -29,8 +33,8 @@ public struct TemporaryScheduleOverrideSettings: Hashable {
         return insulinNeedsScaleFactor ?? 1.0
     }
 
-    public init(targetRange: DoubleRange?, insulinNeedsScaleFactor: Double? = nil) {
-        self.targetRange = targetRange
+    public init(unit: HKUnit, targetRange: DoubleRange?, insulinNeedsScaleFactor: Double? = nil) {
+        self.targetRangeInMgdl = targetRange?.quantityRange(for: unit).doubleRange(for: .milligramsPerDeciliter)
         self.insulinNeedsScaleFactor = insulinNeedsScaleFactor
     }
 }
@@ -46,7 +50,7 @@ extension TemporaryScheduleOverrideSettings: RawRepresentable {
     public init?(rawValue: RawValue) {
         if let targetRangeRawValue = rawValue[Key.targetRange] as? DoubleRange.RawValue,
             let targetRange = DoubleRange(rawValue: targetRangeRawValue) {
-            self.targetRange = targetRange
+            self.targetRangeInMgdl = targetRange
         }
 
         self.insulinNeedsScaleFactor = rawValue[Key.insulinNeedsScaleFactor] as? Double
@@ -55,7 +59,7 @@ extension TemporaryScheduleOverrideSettings: RawRepresentable {
     public var rawValue: RawValue {
         var raw: RawValue = [:]
 
-        if let targetRange = targetRange {
+        if let targetRange = targetRangeInMgdl {
             raw[Key.targetRange] = targetRange.rawValue
         }
 

--- a/LoopKitTests/TemporaryScheduleOverrideHistoryTests.swift
+++ b/LoopKitTests/TemporaryScheduleOverrideHistoryTests.swift
@@ -28,7 +28,7 @@ final class TemporaryScheduleOverrideHistoryTests: XCTestCase {
         insulinNeedsScaleFactor scaleFactor: Double,
         recordedAt enableDateOffset: TimeInterval? = nil
     ) {
-        let settings = TemporaryScheduleOverrideSettings(targetRange: nil, insulinNeedsScaleFactor: scaleFactor)
+        let settings = TemporaryScheduleOverrideSettings(unit: .milligramsPerDeciliter, targetRange: nil, insulinNeedsScaleFactor: scaleFactor)
         let override = TemporaryScheduleOverride(context: .custom, settings: settings, startDate: referenceDate + offset, duration: duration)
         let enableDate: Date
         if let enableDateOffset = enableDateOffset {

--- a/LoopKitTests/TemporaryScheduleOverrideTests.swift
+++ b/LoopKitTests/TemporaryScheduleOverrideTests.swift
@@ -29,6 +29,7 @@ class TemporaryScheduleOverrideTests: XCTestCase {
         return TemporaryScheduleOverride(
             context: .custom,
             settings: TemporaryScheduleOverrideSettings(
+                unit: .milligramsPerDeciliter,
                 targetRange: nil,
                 insulinNeedsScaleFactor: 1.5
             ),

--- a/LoopKitUI/View Controllers/AddEditOverrideTableViewController.swift
+++ b/LoopKitUI/View Controllers/AddEditOverrideTableViewController.swift
@@ -112,7 +112,11 @@ public final class AddEditOverrideTableViewController: UITableViewController {
     }
 
     private func configure(with settings: TemporaryScheduleOverrideSettings) {
-        targetRange = settings.targetRange
+        if let targetRange = settings.targetRange {
+            self.targetRange = DoubleRange(minValue: targetRange.lowerBound.doubleValue(for: glucoseUnit), maxValue: targetRange.upperBound.doubleValue(for: glucoseUnit))
+        } else {
+            targetRange = nil
+        }
         insulinNeedsScaleFactor = settings.effectiveInsulinNeedsScaleFactor
     }
 
@@ -436,6 +440,7 @@ extension AddEditOverrideTableViewController {
         }
 
         return TemporaryScheduleOverrideSettings(
+            unit: glucoseUnit,
             targetRange: targetRange,
             insulinNeedsScaleFactor: insulinNeedsScaleFactor == 1.0 ? nil : insulinNeedsScaleFactor
         )

--- a/LoopKitUI/View Controllers/OverridePresetTableViewController.swift
+++ b/LoopKitUI/View Controllers/OverridePresetTableViewController.swift
@@ -114,8 +114,8 @@ public final class OverridePresetTableViewController: UITableViewController {
             let percentageString = percentageFormatter.string(from: insulinNeedsScaleFactor * 100) {
             cell.detailTextLabel?.text = String(format: NSLocalizedString("%@%% of normal insulin", comment: "The format for an insulin needs percentage."), percentageString)
         } else if let targetRange = preset.settings.targetRange,
-            let minTarget = glucoseNumberFormatter.string(from: targetRange.minValue),
-            let maxTarget = glucoseNumberFormatter.string(from: targetRange.maxValue) {
+            let minTarget = glucoseNumberFormatter.string(from: targetRange.lowerBound.doubleValue(for: glucoseUnit)),
+            let maxTarget = glucoseNumberFormatter.string(from: targetRange.upperBound.doubleValue(for: glucoseUnit)) {
             cell.detailTextLabel?.text = String(format: NSLocalizedString("%1$@ – %2$@ %3$@", comment: "The format for a glucose target range. (1: min target)(2: max target)(3: glucose unit)"), minTarget, maxTarget, quantityFormatter.string(from: glucoseUnit))
         }
 


### PR DESCRIPTION
Overrides should store the blood glucose unit in which the correction range is defined.