### PR TITLE
Upload mutable pump events

### DIFF
--- a/LoopKit/InsulinKit/DoseStore.swift
+++ b/LoopKit/InsulinKit/DoseStore.swift
@@ -934,7 +934,7 @@ extension DoseStore {
             return
         }
 
-        guard let objects = try? getPumpEventObjects(matching: NSPredicate(format: "uploaded = false && mutable = false"), chronological: true, limit: 5000), objects.count > 0 else {
+        guard let objects = try? getPumpEventObjects(matching: NSPredicate(format: "uploaded = false"), chronological: true, limit: 5000), objects.count > 0 else {
             return
         }
 


### PR DESCRIPTION
This may cause some amount of repeat uploads, but it gives users a more realtime view in nightscout. LoopKit will need to be updated later to better support updating mutable events, keeping track of upload status.