### PR TITLE
Add ability to override the autocapitalizationType in TextFieldTableViewController

### DIFF
--- a/LoopKitUI/View Controllers/TextFieldTableViewController.swift
+++ b/LoopKitUI/View Controllers/TextFieldTableViewController.swift
@@ -36,6 +36,8 @@ open class TextFieldTableViewController: UITableViewController, UITextFieldDeleg
 
     public var keyboardType = UIKeyboardType.default
 
+    public var autocapitalizationType = UITextAutocapitalizationType.allCharacters
+
     open weak var delegate: TextFieldTableViewControllerDelegate?
 
     public convenience init() {
@@ -70,6 +72,7 @@ open class TextFieldTableViewController: UITableViewController, UITextFieldDeleg
         cell.textField.text = value
         cell.textField.keyboardType = keyboardType
         cell.textField.placeholder = placeholder
+        cell.textField.autocapitalizationType = autocapitalizationType
         cell.unitLabel?.text = unit
 
         return cell


### PR DESCRIPTION
This helps address https://github.com/LoopKit/Loop/issues/1136 by giving the VC that presents this VC the ability to override the autocapitalizationType when necessary. It defaults to `.allCharacters` since that seems to be what it was defaulting to, though I was only able to find that it was being set to that in TextFieldTableViewCell.xib.