### PR TITLE
Processing HealthKit deletions improvements.

### DIFF
--- a/Extensions/Collection.swift
+++ b/Extensions/Collection.swift
@@ -25,6 +25,18 @@ extension Collection {
     }
 }
 
+extension Collection {
+    func chunked(into size: Int) -> [SubSequence] {
+        precondition(size > 0, "Chunk size must be greater than zero")
+        var start = startIndex
+        return stride(from: 0, to: count, by: size).map {_ in
+            let end = index(start, offsetBy: size, limitedBy: endIndex) ?? endIndex
+            defer { start = end }
+            return self[start..<end]
+        }
+    }
+}
+
 extension RandomAccessCollection {
     /// Returns all unique pair combinations of elements in the collection.
     ///

--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -501,6 +501,10 @@ extension CarbStore {
 
 extension NSManagedObjectContext {
     fileprivate func cachedCarbObjectsWithUUIDs(_ uuids: [UUID], fetchLimit: Int? = nil) -> [CachedCarbObject] {
+        guard uuids.count > 0 else {
+            return []
+        }
+        
         let request: NSFetchRequest<CachedCarbObject> = CachedCarbObject.fetchRequest()
         if let limit = fetchLimit {
             request.fetchLimit = limit

--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -281,12 +281,18 @@ public final class CarbStore: HealthKitSampleStore {
             }
 
             // Remove deleted samples
+            // Deleted samples
+            self.log.debug("Starting deletion of %d samples", deleted.count)
+            //let cacheDeletedCount = self.deleteCachedObjects(forSampleUUIDs: deleted.map { $0.uuid })
+
             for sample in deleted {
                 if self.deleteCachedObject(for: sample) {
                     self.log.debug("Deleted sample %@ from cache from HKAnchoredObjectQuery", sample.uuid.uuidString)
                     notificationRequired = true
                 }
             }
+            self.log.debug("Finished deletion")
+            //self.log.debug("Finished deletion: HK delete count = %d, cache delete count = %d", deleted.count, cacheDeletedCount)
 
             // Notify listeners only if a meaningful change was made
             if notificationRequired {

--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -222,6 +222,10 @@ public final class CarbStore: HealthKitSampleStore {
 
         cacheStore.onReady { (error) in
             guard error == nil else { return }
+            
+            if !self.authorizationRequired {
+                self.createQuery()
+            }
 
             // Migrate modifiedCarbEntries and deletedCarbEntryIDs
             self.cacheStore.managedObjectContext.perform {

--- a/LoopKit/GlucoseKit/GlucoseStore.swift
+++ b/LoopKit/GlucoseKit/GlucoseStore.swift
@@ -108,9 +108,8 @@ public final class GlucoseStore: HealthKitSampleStore {
                     if !self.authorizationRequired {
                         self.createQuery()
                     }
-                    self.dataAccessQueue.async {
-                        self.updateLatestGlucose()
-                    }
+                    
+                    self.updateLatestGlucose()
                 }
             }
         }

--- a/LoopKit/GlucoseKit/GlucoseStore.swift
+++ b/LoopKit/GlucoseKit/GlucoseStore.swift
@@ -428,7 +428,7 @@ extension GlucoseStore {
 
         cacheStore.managedObjectContext.performAndWait {
             for batch in uuids.chunked(into: batchSize) {
-                for object in self.cacheStore.managedObjectContext.cachedGlucoseObjectsWithUUIDs(batch) {
+                for object in self.cacheStore.managedObjectContext.cachedGlucoseObjectsWithUUIDs(Array(batch)) {
                     self.cacheStore.managedObjectContext.delete(object)
                     deleted += 1
                 }
@@ -581,14 +581,6 @@ extension GlucoseStore {
             report.append("")
 
             completionHandler(report.joined(separator: "\n"))
-        }
-    }
-}
-
-extension Array {
-    func chunked(into size: Int) -> [[Element]] {
-        return stride(from: 0, to: count, by: size).map {
-            Array(self[$0 ..< Swift.min($0 + size, count)])
         }
     }
 }

--- a/LoopKit/GlucoseKit/GlucoseStore.swift
+++ b/LoopKit/GlucoseKit/GlucoseStore.swift
@@ -102,7 +102,7 @@ public final class GlucoseStore: HealthKitSampleStore {
             cacheStore.fetchMetadata(key: GlucoseStore.queryAnchorMetadataKey) { (value) in
                 self.dataAccessQueue.async {
                     if let encoded = value as? Data {
-                        self.queryAnchor = NSKeyedUnarchiver.unarchiveObject(with: encoded) as? HKQueryAnchor
+                        self.queryAnchor = try? NSKeyedUnarchiver.unarchivedObject(ofClass: HKQueryAnchor.self, from: encoded)
                     }
                     
                     if !self.authorizationRequired {

--- a/LoopKit/GlucoseKit/GlucoseStore.swift
+++ b/LoopKit/GlucoseKit/GlucoseStore.swift
@@ -148,6 +148,9 @@ public final class GlucoseStore: HealthKitSampleStore {
             // Deleted samples
             self.log.debug("Starting deletion of %d samples", deleted.count)
             let cacheDeletedCount = self.deleteCachedObjects(forSampleUUIDs: deleted.map { $0.uuid })
+            if cacheDeletedCount > 0 {
+                cacheChanged = true
+            }
             self.log.debug("Finished deletion: HK delete count = %d, cache delete count = %d", deleted.count, cacheDeletedCount)
 
             if let startDate = newestSampleStartDateAddedByExternalSource {

--- a/LoopKit/GlucoseKit/GlucoseStore.swift
+++ b/LoopKit/GlucoseKit/GlucoseStore.swift
@@ -100,15 +100,17 @@ public final class GlucoseStore: HealthKitSampleStore {
 
         cacheStore.onReady { (error) in
             cacheStore.fetchMetadata(key: GlucoseStore.queryAnchorMetadataKey) { (value) in
-                if let encoded = value as? Data {
-                    self.queryAnchor = NSKeyedUnarchiver.unarchiveObject(with: encoded) as? HKQueryAnchor
-                }
-                
-                if !self.authorizationRequired {
-                    self.createQuery()
-                }
                 self.dataAccessQueue.async {
-                    self.updateLatestGlucose()
+                    if let encoded = value as? Data {
+                        self.queryAnchor = NSKeyedUnarchiver.unarchiveObject(with: encoded) as? HKQueryAnchor
+                    }
+                    
+                    if !self.authorizationRequired {
+                        self.createQuery()
+                    }
+                    self.dataAccessQueue.async {
+                        self.updateLatestGlucose()
+                    }
                 }
             }
         }

--- a/LoopKit/GlucoseKit/NSManagedObjectContext+CachedGlucoseObject.swift
+++ b/LoopKit/GlucoseKit/NSManagedObjectContext+CachedGlucoseObject.swift
@@ -22,8 +22,7 @@ extension NSManagedObjectContext {
         let results: [CachedGlucoseObject]
         do {
             results = try fetch(request)
-        } catch (let error) {
-            print("Error while cachedGlucoseObjectsWithUUIDs: \(error)")
+        } catch {
             results = []
         }
         return results

--- a/LoopKit/GlucoseKit/NSManagedObjectContext+CachedGlucoseObject.swift
+++ b/LoopKit/GlucoseKit/NSManagedObjectContext+CachedGlucoseObject.swift
@@ -11,25 +11,6 @@ import CoreData
 
 extension NSManagedObjectContext {
     
-    internal func cachedGlucoseObjectsWithUUIDs(_ uuids: [UUID], fetchLimit: Int? = nil) -> [CachedGlucoseObject] {
-        guard uuids.count > 0 else {
-            return []
-        }
-
-        let request: NSFetchRequest<CachedGlucoseObject> = CachedGlucoseObject.fetchRequest()
-        if let limit = fetchLimit {
-            request.fetchLimit = limit
-        }
-        request.predicate = NSPredicate(format: "uuid IN %@", uuids.map { $0 as NSUUID })
-        
-        let results: [CachedGlucoseObject]
-        do {
-            results = try fetch(request)
-        } catch {
-            results = []
-        }
-        return results
-    }
     
     internal func cachedGlucoseObjectsWithUUID(_ uuid: UUID, fetchLimit: Int? = nil) -> [CachedGlucoseObject] {
         let request: NSFetchRequest<CachedGlucoseObject> = CachedGlucoseObject.fetchRequest()

--- a/LoopKit/GlucoseKit/NSManagedObjectContext+CachedGlucoseObject.swift
+++ b/LoopKit/GlucoseKit/NSManagedObjectContext+CachedGlucoseObject.swift
@@ -12,12 +12,15 @@ import CoreData
 extension NSManagedObjectContext {
     
     internal func cachedGlucoseObjectsWithUUIDs(_ uuids: [UUID], fetchLimit: Int? = nil) -> [CachedGlucoseObject] {
+        guard uuids.count > 0 else {
+            return []
+        }
+
         let request: NSFetchRequest<CachedGlucoseObject> = CachedGlucoseObject.fetchRequest()
         if let limit = fetchLimit {
             request.fetchLimit = limit
         }
         request.predicate = NSPredicate(format: "uuid IN %@", uuids.map { $0 as NSUUID })
-        request.sortDescriptors = [NSSortDescriptor(key: "uuid", ascending: true)]
         
         let results: [CachedGlucoseObject]
         do {

--- a/LoopKit/GlucoseKit/NSManagedObjectContext+CachedGlucoseObject.swift
+++ b/LoopKit/GlucoseKit/NSManagedObjectContext+CachedGlucoseObject.swift
@@ -10,6 +10,24 @@ import CoreData
 
 
 extension NSManagedObjectContext {
+    internal func cachedGlucoseObjectsWithUUIDs(_ uuids: [UUID], fetchLimit: Int? = nil) -> [CachedGlucoseObject] {
+        let request: NSFetchRequest<CachedGlucoseObject> = CachedGlucoseObject.fetchRequest()
+        if let limit = fetchLimit {
+            request.fetchLimit = limit
+        }
+        request.predicate = NSPredicate(format: "uuid IN %@", uuids.map { $0 as NSUUID })
+        request.sortDescriptors = [NSSortDescriptor(key: "uuid", ascending: true)]
+        
+        let results: [CachedGlucoseObject]
+        do {
+            results = try fetch(request)
+        } catch (let error) {
+            print("Error while cachedGlucoseObjectsWithUUIDs: \(error)")
+            results = []
+        }
+        return results
+    }
+    
     internal func cachedGlucoseObjectsWithUUID(_ uuid: UUID, fetchLimit: Int? = nil) -> [CachedGlucoseObject] {
         let request: NSFetchRequest<CachedGlucoseObject> = CachedGlucoseObject.fetchRequest()
         if let limit = fetchLimit {

--- a/LoopKit/GlucoseKit/NSManagedObjectContext+CachedGlucoseObject.swift
+++ b/LoopKit/GlucoseKit/NSManagedObjectContext+CachedGlucoseObject.swift
@@ -10,6 +10,7 @@ import CoreData
 
 
 extension NSManagedObjectContext {
+    
     internal func cachedGlucoseObjectsWithUUIDs(_ uuids: [UUID], fetchLimit: Int? = nil) -> [CachedGlucoseObject] {
         let request: NSFetchRequest<CachedGlucoseObject> = CachedGlucoseObject.fetchRequest()
         if let limit = fetchLimit {

--- a/LoopKit/HealthKitSampleStore.swift
+++ b/LoopKit/HealthKitSampleStore.swift
@@ -69,6 +69,7 @@ public class HealthKitSampleStore {
         self.log = OSLog(category: String(describing: Swift.type(of: self)))
 
         if !authorizationRequired {
+            log.default("Creating query on store init")
             createQuery()
         }
     }
@@ -93,6 +94,7 @@ public class HealthKitSampleStore {
     public func authorize(toShare: Bool = true, _ completion: @escaping (_ result: HealthKitSampleStoreResult<Bool>) -> Void) {
         healthStore.requestAuthorization(toShare: toShare ? [sampleType] : [], read: [sampleType]) { (completed, error) -> Void in
             if completed && !self.sharingDenied {
+                self.log.default("authorize completed: creating HK query")
                 self.createQuery()
                 completion(.success(true))
             } else {
@@ -131,6 +133,7 @@ public class HealthKitSampleStore {
         didSet {
             // If we are now looking farther back, then reset the query
             if oldValue > observationStart {
+                log.default("observationStart changed: creating HK query")
                 createQuery()
             }
         }
@@ -156,7 +159,7 @@ public class HealthKitSampleStore {
             anchor: self.queryAnchor,
             limit: HKObjectQueryNoLimit
         ) { (query, newSamples, deletedSamples, anchor, error) in
-            self.log.debug("%@: new: %d deleted: %d anchor: %@ error: %@", #function, newSamples?.count ?? 0, deletedSamples?.count ?? 0, String(describing: anchor), String(describing: error))
+            self.log.default("%{public}@: new: %{public}d deleted: %{public}d anchor: %{public}@ error: %{public}@", #function, newSamples?.count ?? 0, deletedSamples?.count ?? 0, String(describing: anchor), String(describing: error))
 
             if let error = error {
                 self.log.error("%@: error executing anchoredObjectQuery: %@", String(describing: type(of: self)), error.localizedDescription)
@@ -212,7 +215,7 @@ extension HealthKitSampleStore: HKSampleQueryTestable {
 // MARK: - Observation
 extension HealthKitSampleStore {
     private func createQuery() {
-        log.debug("%@ [observationEnabled: %d]", #function, observationEnabled)
+        log.default("%@ [observationEnabled: %{public}d]", #function, observationEnabled)
 
         guard observationEnabled else {
             return
@@ -231,7 +234,7 @@ extension HealthKitSampleStore {
             case .failure(let error):
                 self.log.error("Error enabling background delivery: %@", error.localizedDescription)
             case .success:
-                self.log.debug("Enabled background delivery for %@", self.sampleType)
+                self.log.default("Enabled background delivery for %{public}@", self.sampleType)
             }
         }
     }

--- a/LoopKit/HealthKitSampleStore.swift
+++ b/LoopKit/HealthKitSampleStore.swift
@@ -119,6 +119,7 @@ public class HealthKitSampleStore {
             }
 
             if let query = observerQuery {
+                log.debug("Executing observerQuery %@", query)
                 healthStore.execute(query)
             }
         }
@@ -155,9 +156,6 @@ public class HealthKitSampleStore {
     }
     internal let lockedQueryAnchor: Locked<HKQueryAnchor?>
 
-    // Valid to mutate only from the HealthKit query response queue
-    private var lastQueriedAnchor: HKQueryAnchor?
-
     func queryAnchorDidChange() {
         // Subclasses can override
     }
@@ -175,12 +173,6 @@ public class HealthKitSampleStore {
 
         let queryAnchor = self.queryAnchor
 
-        if let lastQueriedAnchor = lastQueriedAnchor, let queryAnchor = queryAnchor, queryAnchor == lastQueriedAnchor {
-            log.default("%@ notified with changes but we've already queried for anchor: %{public}@", query, String(describing: queryAnchor))
-            return
-        }
-
-        lastQueriedAnchor = queryAnchor
         log.default("%@ notified with changes. Fetching from: %{public}@", query, queryAnchor.map(String.init(describing:)) ?? "0")
 
         let anchoredObjectQuery = HKAnchoredObjectQuery(
@@ -199,9 +191,6 @@ public class HealthKitSampleStore {
             
             if anchor != nil {
                 self.queryAnchor = anchor
-            } else {
-                // If we received an error, reset the last queried anchor
-                self.lastQueriedAnchor = nil
             }
         }
 

--- a/LoopKit/HealthKitSampleStore.swift
+++ b/LoopKit/HealthKitSampleStore.swift
@@ -67,11 +67,6 @@ public class HealthKitSampleStore {
         self.test_currentDate = test_currentDate
 
         self.log = OSLog(category: String(describing: Swift.type(of: self)))
-
-        if !authorizationRequired {
-            log.default("Creating query on store init")
-            createQuery()
-        }
     }
 
     deinit {
@@ -140,7 +135,17 @@ public class HealthKitSampleStore {
     }
 
     /// The last-retreived anchor from an anchored object query
-    private var queryAnchor: HKQueryAnchor?
+    internal var queryAnchor: HKQueryAnchor? {
+        didSet {
+            if queryAnchor != oldValue {
+                queryAnchorDidChange()
+            }
+        }
+    }
+    
+    func queryAnchorDidChange() {
+        // Subclasses can override
+    }
 
     /// Called in response to an update by the observer query
     ///
@@ -166,7 +171,10 @@ public class HealthKitSampleStore {
             }
 
             self.processResults(from: query, added: newSamples ?? [], deleted: deletedSamples ?? [], error: error)
-            self.queryAnchor = anchor
+            
+            if anchor != nil {
+                self.queryAnchor = anchor
+            }
         }
 
         healthStore.execute(anchoredObjectQuery)
@@ -214,7 +222,7 @@ extension HealthKitSampleStore: HKSampleQueryTestable {
 
 // MARK: - Observation
 extension HealthKitSampleStore {
-    private func createQuery() {
+    internal func createQuery() {
         log.default("%@ [observationEnabled: %{public}d]", #function, observationEnabled)
 
         guard observationEnabled else {

--- a/LoopKit/HealthKitSampleStore.swift
+++ b/LoopKit/HealthKitSampleStore.swift
@@ -65,6 +65,7 @@ public class HealthKitSampleStore {
         self.observationStart = observationStart
         self.observationEnabled = observationEnabled
         self.test_currentDate = test_currentDate
+        self.lockedQueryAnchor = Locked<HKQueryAnchor?>(nil)
 
         self.log = OSLog(category: String(describing: Swift.type(of: self)))
     }
@@ -136,12 +137,23 @@ public class HealthKitSampleStore {
 
     /// The last-retreived anchor from an anchored object query
     internal var queryAnchor: HKQueryAnchor? {
-        didSet {
-            if queryAnchor != oldValue {
+        get {
+            return lockedQueryAnchor.value
+        }
+        set {
+            var changed: Bool = false
+            lockedQueryAnchor.mutate { (anchor) in
+                if anchor != newValue {
+                    anchor = newValue
+                    changed = true
+                }
+            }
+            if(changed) {
                 queryAnchorDidChange()
             }
         }
     }
+    internal let lockedQueryAnchor: Locked<HKQueryAnchor?>
     
     func queryAnchorDidChange() {
         // Subclasses can override

--- a/LoopKit/InsulinKit/InsulinDeliveryStore.swift
+++ b/LoopKit/InsulinKit/InsulinDeliveryStore.swift
@@ -84,15 +84,7 @@ public class InsulinDeliveryStore: HealthKitSampleStore {
     // MARK: - HealthKitSampleStore
 
     override func queryAnchorDidChange() {
-        let encoded = NSKeyedArchiver.archivedData(withRootObject: queryAnchor as Any)
-        cacheStore.updateMetadata(key: InsulinDeliveryStore.queryAnchorMetadataKey, value: encoded)
-        cacheStore.save { (error) in
-            if let error = error {
-                self.log.default("Failed to save queryAnchor metadata: %{public}@", String(describing: error))
-            } else {
-                self.log.default("Saved queryAnchor %{public}@", String(describing: self.queryAnchor))
-            }
-        }
+        cacheStore.storeAnchor(queryAnchor, key: InsulinDeliveryStore.queryAnchorMetadataKey)
     }
 
     public override func processResults(from query: HKAnchoredObjectQuery, added: [HKSample], deleted: [HKDeletedObject], error: Error?) {

--- a/LoopKit/InsulinKit/InsulinDeliveryStore.swift
+++ b/LoopKit/InsulinKit/InsulinDeliveryStore.swift
@@ -405,7 +405,7 @@ extension InsulinDeliveryStore {
 
         cacheStore.managedObjectContext.performAndWait {
             for batch in uuids.chunked(into: batchSize) {
-                for object in self.cacheStore.managedObjectContext.cachedInsulinDeliveryObjectsWithUUIDs(batch) {
+                for object in self.cacheStore.managedObjectContext.cachedInsulinDeliveryObjectsWithUUIDs(Array(batch)) {
 
                     self.cacheStore.managedObjectContext.delete(object)
                     self.log.default("Deleted CachedInsulinDeliveryObject with UUID %{public}@", object.uuid?.uuidString ?? "")

--- a/LoopKit/InsulinKit/InsulinDeliveryStore.swift
+++ b/LoopKit/InsulinKit/InsulinDeliveryStore.swift
@@ -69,11 +69,9 @@ public class InsulinDeliveryStore: HealthKitSampleStore {
         )
 
         cacheStore.onReady { (error) in
-            cacheStore.fetchMetadata(key: InsulinDeliveryStore.queryAnchorMetadataKey) { (value) in
+            cacheStore.fetchAnchor(key: InsulinDeliveryStore.queryAnchorMetadataKey) { (anchor) in
                 self.queue.async {
-                    if let encoded = value as? Data {
-                        self.queryAnchor = try? NSKeyedUnarchiver.unarchivedObject(ofClass: HKQueryAnchor.self, from: encoded)
-                    }
+                    self.queryAnchor = anchor
 
                     if !self.authorizationRequired {
                         self.createQuery()

--- a/LoopKit/InsulinKit/InsulinDeliveryStore.swift
+++ b/LoopKit/InsulinKit/InsulinDeliveryStore.swift
@@ -70,12 +70,14 @@ public class InsulinDeliveryStore: HealthKitSampleStore {
 
         cacheStore.onReady { (error) in
             cacheStore.fetchMetadata(key: InsulinDeliveryStore.queryAnchorMetadataKey) { (value) in
-                if let encoded = value as? Data {
-                    self.queryAnchor = NSKeyedUnarchiver.unarchiveObject(with: encoded) as? HKQueryAnchor
-                }
+                self.queue.async {
+                    if let encoded = value as? Data {
+                        self.queryAnchor = NSKeyedUnarchiver.unarchiveObject(with: encoded) as? HKQueryAnchor
+                    }
 
-                if !self.authorizationRequired {
-                    self.createQuery()
+                    if !self.authorizationRequired {
+                        self.createQuery()
+                    }
                 }
             }
         }
@@ -112,7 +114,6 @@ public class InsulinDeliveryStore: HealthKitSampleStore {
             // Deleted samples
             self.log.debug("Starting deletion of %d samples", deleted.count)
             let cacheDeletedCount = self.deleteCachedObjects(forSampleUUIDs: deleted.map { $0.uuid })
-            //self.log.debug("Finished deletion")
             self.log.debug("Finished deletion: HK delete count = %d, cache delete count = %d", deleted.count, cacheDeletedCount)
 
             let cachePredicate = NSPredicate(format: "startDate < %@", self.earliestCacheDate as NSDate)

--- a/LoopKit/InsulinKit/InsulinDeliveryStore.swift
+++ b/LoopKit/InsulinKit/InsulinDeliveryStore.swift
@@ -72,7 +72,7 @@ public class InsulinDeliveryStore: HealthKitSampleStore {
             cacheStore.fetchMetadata(key: InsulinDeliveryStore.queryAnchorMetadataKey) { (value) in
                 self.queue.async {
                     if let encoded = value as? Data {
-                        self.queryAnchor = NSKeyedUnarchiver.unarchiveObject(with: encoded) as? HKQueryAnchor
+                        self.queryAnchor = try? NSKeyedUnarchiver.unarchivedObject(ofClass: HKQueryAnchor.self, from: encoded)
                     }
 
                     if !self.authorizationRequired {

--- a/LoopKit/InsulinKit/InsulinDeliveryStore.swift
+++ b/LoopKit/InsulinKit/InsulinDeliveryStore.swift
@@ -114,6 +114,9 @@ public class InsulinDeliveryStore: HealthKitSampleStore {
             // Deleted samples
             self.log.debug("Starting deletion of %d samples", deleted.count)
             let cacheDeletedCount = self.deleteCachedObjects(forSampleUUIDs: deleted.map { $0.uuid })
+            if cacheDeletedCount > 0 {
+                cacheChanged = true
+            }
             self.log.debug("Finished deletion: HK delete count = %d, cache delete count = %d", deleted.count, cacheDeletedCount)
 
             let cachePredicate = NSPredicate(format: "startDate < %@", self.earliestCacheDate as NSDate)

--- a/LoopKit/InsulinKit/NSManagedObjectContext+CachedInsulinDeliveryObject.swift
+++ b/LoopKit/InsulinKit/NSManagedObjectContext+CachedInsulinDeliveryObject.swift
@@ -10,6 +10,17 @@ import CoreData
 
 
 extension NSManagedObjectContext {
+    internal func cachedInsulinDeliveryObjectsWithUUIDs(_ uuids: [UUID], fetchLimit: Int? = nil) -> [CachedInsulinDeliveryObject] {
+        let request: NSFetchRequest<CachedInsulinDeliveryObject> = CachedInsulinDeliveryObject.fetchRequest()
+        if let limit = fetchLimit {
+            request.fetchLimit = limit
+        }
+        request.predicate = NSPredicate(format: "uuid IN %@", uuids.map { $0 as NSUUID })
+        request.sortDescriptors = [NSSortDescriptor(key: "uuid", ascending: true)]
+
+        return (try? fetch(request)) ?? []
+    }
+
     internal func cachedInsulinDeliveryObjectsWithUUID(_ uuid: UUID, fetchLimit: Int? = nil) -> [CachedInsulinDeliveryObject] {
         let request: NSFetchRequest<CachedInsulinDeliveryObject> = CachedInsulinDeliveryObject.fetchRequest()
         if let limit = fetchLimit {

--- a/LoopKit/InsulinKit/NSManagedObjectContext+CachedInsulinDeliveryObject.swift
+++ b/LoopKit/InsulinKit/NSManagedObjectContext+CachedInsulinDeliveryObject.swift
@@ -10,19 +10,6 @@ import CoreData
 
 
 extension NSManagedObjectContext {
-    internal func cachedInsulinDeliveryObjectsWithUUIDs(_ uuids: [UUID], fetchLimit: Int? = nil) -> [CachedInsulinDeliveryObject] {
-        guard uuids.count > 0 else {
-            return []
-        }
-
-        let request: NSFetchRequest<CachedInsulinDeliveryObject> = CachedInsulinDeliveryObject.fetchRequest()
-        if let limit = fetchLimit {
-            request.fetchLimit = limit
-        }
-        request.predicate = NSPredicate(format: "uuid IN %@", uuids.map { $0 as NSUUID })
-
-        return (try? fetch(request)) ?? []
-    }
 
     internal func cachedInsulinDeliveryObjectsWithUUID(_ uuid: UUID, fetchLimit: Int? = nil) -> [CachedInsulinDeliveryObject] {
         let request: NSFetchRequest<CachedInsulinDeliveryObject> = CachedInsulinDeliveryObject.fetchRequest()

--- a/LoopKit/InsulinKit/NSManagedObjectContext+CachedInsulinDeliveryObject.swift
+++ b/LoopKit/InsulinKit/NSManagedObjectContext+CachedInsulinDeliveryObject.swift
@@ -11,12 +11,15 @@ import CoreData
 
 extension NSManagedObjectContext {
     internal func cachedInsulinDeliveryObjectsWithUUIDs(_ uuids: [UUID], fetchLimit: Int? = nil) -> [CachedInsulinDeliveryObject] {
+        guard uuids.count > 0 else {
+            return []
+        }
+
         let request: NSFetchRequest<CachedInsulinDeliveryObject> = CachedInsulinDeliveryObject.fetchRequest()
         if let limit = fetchLimit {
             request.fetchLimit = limit
         }
         request.predicate = NSPredicate(format: "uuid IN %@", uuids.map { $0 as NSUUID })
-        request.sortDescriptors = [NSSortDescriptor(key: "uuid", ascending: true)]
 
         return (try? fetch(request)) ?? []
     }
@@ -27,7 +30,6 @@ extension NSManagedObjectContext {
             request.fetchLimit = limit
         }
         request.predicate = NSPredicate(format: "uuid == %@", uuid as NSUUID)
-        request.sortDescriptors = [NSSortDescriptor(key: "uuid", ascending: true)]
 
         return (try? fetch(request)) ?? []
     }

--- a/LoopKit/Persistence/PersistenceController.swift
+++ b/LoopKit/Persistence/PersistenceController.swift
@@ -112,13 +112,18 @@ public final class PersistenceController {
 
     func save(_ completion: ((_ error: PersistenceControllerError?) -> Void)? = nil) {
         self.managedObjectContext.performAndWait {
+            guard self.managedObjectContext.hasChanges else {
+                completion?(nil)
+                return
+            }
+
             self.saveInternal(completion)
         }
     }
 
     // Should only be called from PersistenceControllerError thread
     internal func saveInternal(_ completion: ((_ error: PersistenceControllerError?) -> Void)? = nil) {
-        guard !self.isReadOnly && self.managedObjectContext.hasChanges else {
+        guard !self.isReadOnly else {
             completion?(nil)
             return
         }

--- a/LoopKit/Persistence/PersistenceController.swift
+++ b/LoopKit/Persistence/PersistenceController.swift
@@ -154,32 +154,6 @@ public final class PersistenceController {
         }
     }
     
-    func storeAnchor(_ anchor: HKQueryAnchor?, key: String) {
-        managedObjectContext.perform {
-            let encoded: Data?
-            if let anchor = anchor {
-                encoded = try? NSKeyedArchiver.archivedData(withRootObject: anchor, requiringSecureCoding: true)
-            } else {
-                encoded = nil
-            }
-            self.updateMetadata(key: key, value: encoded)
-            self.saveInternal()
-        }
-    }
-    
-    func fetchAnchor(key: String, completion: @escaping (HKQueryAnchor?) -> Void) {
-        managedObjectContext.perform {
-            self.fetchMetadata(key: key) { (value) in
-                if let encoded = value as? Data {
-                    let anchor = try? NSKeyedUnarchiver.unarchivedObject(ofClass: HKQueryAnchor.self, from: encoded)
-                    completion(anchor)
-                } else {
-                    completion(nil)
-                }
-            }
-        }
-    }
-    
     // MARK: - 
 
     private func initializeStack(inDirectory directoryURL: URL, model: NSManagedObjectModel) {
@@ -242,5 +216,36 @@ extension PersistenceController: CustomDebugStringConvertible {
             "* directoryURL: \(directoryURL)",
             "* persistenceStoreCoordinator: \(String(describing: managedObjectContext.persistentStoreCoordinator))",
         ].joined(separator: "\n")
+    }
+}
+
+
+// MARK: - Anchor store/fetch helpers
+
+extension PersistenceController {
+    func storeAnchor(_ anchor: HKQueryAnchor?, key: String) {
+        managedObjectContext.perform {
+            let encoded: Data?
+            if let anchor = anchor {
+                encoded = try? NSKeyedArchiver.archivedData(withRootObject: anchor, requiringSecureCoding: true)
+            } else {
+                encoded = nil
+            }
+            self.updateMetadata(key: key, value: encoded)
+            self.saveInternal()
+        }
+    }
+    
+    func fetchAnchor(key: String, completion: @escaping (HKQueryAnchor?) -> Void) {
+        managedObjectContext.perform {
+            self.fetchMetadata(key: key) { (value) in
+                if let encoded = value as? Data {
+                    let anchor = try? NSKeyedUnarchiver.unarchivedObject(ofClass: HKQueryAnchor.self, from: encoded)
+                    completion(anchor)
+                } else {
+                    completion(nil)
+                }
+            }
+        }
     }
 }

--- a/LoopKit/Persistence/PersistenceController.swift
+++ b/LoopKit/Persistence/PersistenceController.swift
@@ -9,6 +9,8 @@ import CoreData
 import os.log
 
 
+
+
 public protocol PersistenceControllerDelegate: class {
     /// Informs the delegate that a save operation will start, so it can start a background task on its behalf
     ///
@@ -127,7 +129,28 @@ public final class PersistenceController {
             }
         }
     }
-
+    
+    func updateMetadata(key: String, value: Any?) {
+        self.managedObjectContext.performAndWait {
+            if let coordinator = self.managedObjectContext.persistentStoreCoordinator, let store = coordinator.persistentStores.first {
+                var metadata = coordinator.metadata(for: store)
+                metadata[key] = value
+                coordinator.setMetadata(metadata, for: store)
+            }
+        }
+    }
+    
+    func fetchMetadata(key: String, completion: @escaping (Any?) -> Void) {
+        managedObjectContext.perform {
+            if let coordinator = self.managedObjectContext.persistentStoreCoordinator, let store = coordinator.persistentStores.first {
+                let metadata = coordinator.metadata(for: store)
+                completion(metadata[key])
+            } else {
+                completion(nil)
+            }
+        }
+    }
+    
     // MARK: - 
 
     private func initializeStack(inDirectory directoryURL: URL, model: NSManagedObjectModel) {


### PR DESCRIPTION
When a HealthKit anchored query is first started, HealthKit returns all the deletions since the beginning of time for that type of data. The deletions need to be processed against the cache. This PR includes performance improvements for syncing the cache with large numbers of HK deletions.

Query anchors are also persisted in PersistentStore metadata records for each cache (glucose, insulin, and carbs), so subsequent app launches should be much faster.

This fixes various issues reported with slow startup, graphs freezing, issue reports not generating, and inability to bolus.