### PR TITLE
Limit trimmed dose end date to 30 minutes

### DIFF
--- a/LoopKit/InsulinKit/InsulinMath.swift
+++ b/LoopKit/InsulinKit/InsulinMath.swift
@@ -89,7 +89,7 @@ extension DoseEntry {
         let originalDuration = endDate.timeIntervalSince(startDate)
 
         let startDate = max(start ?? .distantPast, self.startDate)
-        let endDate = max(startDate, min(end ?? .distantFuture, self.endDate))
+        let endDate = max(startDate, min(end ?? startDate.addingTimeInterval(.minutes(30)), self.endDate))
 
         var trimmedDeliveredUnits: Double? = deliveredUnits
         var trimmedValue: Double = value


### PR DESCRIPTION
On the Predicted Glucose page, glucose prediction sometimes extends 24 hours in the future, as shown in this example: 
![IMG_9831](https://user-images.githubusercontent.com/12002177/79294575-c21a0980-7e93-11ea-8217-891e7480c6f1.PNG)
In cases when Loop has not issued any temp basals for some time, it seems that a 24-hour long dose is generated based on the current standard basal rate. Here is an example of such 24-hour dose: 

`Optional(LoopKit.DoseEntry(type: LoopKit.DoseType.basal, startDate: 2020-04-06 04:26:43 +0000, endDate: 2020-04-07 04:26:43 +0000, value: 0.675, unit: LoopKit.DoseUnit.unitsPerHour, deliveredUnits: Optional(16.200000000000003), description: nil, syncIdentifier: nil, scheduledBasalRate: nil))`

When prediction is generated with `includingPendingInsulin: true`, a trimmed dose extends to its end, which is 24 hours ahead for the standard-rate dose mentioned above. This is why the predicted glucose extends 24 hours ahead, as seen on the Predicted Glucose example posted above. This display anomaly happens very often on the automatic-bolus branch, because dosing often defaults to the standard basal rate. I should also mention that I am using Medtronic pump. I am not sure if the 24-hour dose comes up on a Loop with omnipod pump. Fortunately, I do not think this bug affects dosing in any way. 

The fix in the PR ensures that a trimmed dose never extends more than 30 minutes after its start. I do not know if this is the best way to fix the bug, and I am not completely sure that the fix does not have any unintended side effects. Have not noticed anything wrong in running Loop with the fix for more than a week. Maybe the 24-hour dose should not have been generated in the first place? 