### PR TITLE
Fix Temp Override missing translations issue

### DIFF
--- a/LoopKitUI/OverrideEmojiDataSource.swift
+++ b/LoopKitUI/OverrideEmojiDataSource.swift
@@ -47,17 +47,17 @@ private final class OverrideEmojiDataSource: EmojiDataSource {
     init() {
         sections = [
             EmojiSection(
-                title: NSLocalizedString("Activity", comment: "The title for the override emoji activity section"),
+                title: LocalizedString("Activity", comment: "The title for the override emoji activity section"),
                 items: type(of: self).activity,
                 indexSymbol: " 🏃‍♀️ "
             ),
             EmojiSection(
-                title: NSLocalizedString("Condition", comment: "The title for the override emoji condition section"),
+                title: LocalizedString("Condition", comment: "The title for the override emoji condition section"),
                 items: type(of: self).condition,
                 indexSymbol: "🤒"
             ),
             EmojiSection(
-                title: NSLocalizedString("Other", comment: "The title for override emoji miscellaneous section"),
+                title: LocalizedString("Other", comment: "The title for override emoji miscellaneous section"),
                 items: type(of: self).other,
                 indexSymbol: "⋯ "
             )

--- a/LoopKitUI/View Controllers/AddEditOverrideTableViewController.swift
+++ b/LoopKitUI/View Controllers/AddEditOverrideTableViewController.swift
@@ -233,7 +233,7 @@ public final class AddEditOverrideTableViewController: UITableViewController {
             switch propertyRow(for: indexPath) {
             case .symbol:
                 let cell = tableView.dequeueReusableCell(withIdentifier: LabeledTextFieldTableViewCell.className, for: indexPath) as! LabeledTextFieldTableViewCell
-                cell.titleLabel.text = NSLocalizedString("Symbol", comment: "The text for the override preset symbol setting")
+                cell.titleLabel.text = LocalizedString("Symbol", comment: "The text for the override preset symbol setting")
                 cell.textField.text = symbol
                 cell.textField.placeholder = SettingsTableViewCell.NoValueString
                 cell.maximumTextLength = 2
@@ -242,9 +242,9 @@ public final class AddEditOverrideTableViewController: UITableViewController {
                 return cell
             case .name:
                 let cell = tableView.dequeueReusableCell(withIdentifier: LabeledTextFieldTableViewCell.className, for: indexPath) as! LabeledTextFieldTableViewCell
-                cell.titleLabel.text = NSLocalizedString("Name", comment: "The text for the override preset name setting")
+                cell.titleLabel.text = LocalizedString("Name", comment: "The text for the override preset name setting")
                 cell.textField.text = name
-                cell.textField.placeholder = NSLocalizedString("Running", comment: "The text for the override preset name field placeholder")
+                cell.textField.placeholder = LocalizedString("Running", comment: "The text for the override preset name field placeholder")
                 cell.delegate = self
                 return cell
             case .insulinNeeds:
@@ -255,14 +255,14 @@ public final class AddEditOverrideTableViewController: UITableViewController {
             case .targetRange:
                 let cell = tableView.dequeueReusableCell(withIdentifier: DoubleRangeTableViewCell.className, for: indexPath) as! DoubleRangeTableViewCell
                 cell.numberFormatter = quantityFormatter.numberFormatter
-                cell.titleLabel.text = NSLocalizedString("Target Range", comment: "The text for the override target range setting")
+                cell.titleLabel.text = LocalizedString("Target Range", comment: "The text for the override target range setting")
                 cell.range = targetRange
                 cell.unitLabel.text = quantityFormatter.string(from: glucoseUnit)
                 cell.delegate = self
                 return cell
             case .startDate:
                 let cell = tableView.dequeueReusableCell(withIdentifier: DateAndDurationTableViewCell.className, for: indexPath) as! DateAndDurationTableViewCell
-                cell.titleLabel.text = NSLocalizedString("Start Time", comment: "The text for the override start time")
+                cell.titleLabel.text = LocalizedString("Start Time", comment: "The text for the override start time")
                 cell.datePicker.datePickerMode = .dateAndTime
                 cell.datePicker.minimumDate = min(startDate, Date())
                 cell.date = startDate
@@ -271,13 +271,13 @@ public final class AddEditOverrideTableViewController: UITableViewController {
             case .durationFiniteness:
                 let cell = tableView.dequeueReusableCell(withIdentifier: SwitchTableViewCell.className, for: indexPath) as! SwitchTableViewCell
                 cell.selectionStyle = .none
-                cell.textLabel?.text = NSLocalizedString("Enable Indefinitely", comment: "The text for the indefinite override duration setting")
+                cell.textLabel?.text = LocalizedString("Enable Indefinitely", comment: "The text for the indefinite override duration setting")
                 cell.switch?.isOn = !duration.isFinite
                 cell.switch?.addTarget(self, action: #selector(durationFinitenessChanged), for: .valueChanged)
                 return cell
             case .duration:
                 let cell = tableView.dequeueReusableCell(withIdentifier: DateAndDurationTableViewCell.className, for: indexPath) as! DateAndDurationTableViewCell
-                cell.titleLabel.text = NSLocalizedString("Duration", comment: "The text for the override duration setting")
+                cell.titleLabel.text = LocalizedString("Duration", comment: "The text for the override duration setting")
                 cell.datePicker.datePickerMode = .countDownTimer
                 cell.datePicker.minuteInterval = 15
                 guard case .finite(let duration) = duration else {
@@ -290,7 +290,7 @@ public final class AddEditOverrideTableViewController: UITableViewController {
             }
         case .cancel:
             let cell = tableView.dequeueReusableCell(withIdentifier: TextButtonTableViewCell.className, for: indexPath) as! TextButtonTableViewCell
-            cell.textLabel?.text = NSLocalizedString("Cancel Override", comment: "The text for the override cancellation button")
+            cell.textLabel?.text = LocalizedString("Cancel Override", comment: "The text for the override cancellation button")
             cell.textLabel?.textAlignment = .center
             cell.tintColor = .defaultButtonTextColor
             return cell
@@ -353,12 +353,12 @@ public final class AddEditOverrideTableViewController: UITableViewController {
 
         switch inputMode {
         case .customizePresetOverride(let preset):
-            return String(format: NSLocalizedString("Changes will only apply this time you enable the override. The default settings of %@ will not be affected.", comment: "Footer text for customizing an override from a preset (1: preset name)"), preset.name)
+            return String(format: LocalizedString("Changes will only apply this time you enable the override. The default settings of %@ will not be affected.", comment: "Footer text for customizing an override from a preset (1: preset name)"), preset.name)
         case .editOverride(let override):
             guard case .preset(let preset) = override.context else {
                 return nil
             }
-            return String(format: NSLocalizedString("Editing affects only the active override. The default settings of %@ will not be affected.", comment: "Footer text for editing an active override (1: preset name)"), preset.name)
+            return String(format: LocalizedString("Editing affects only the active override. The default settings of %@ will not be affected.", comment: "Footer text for editing an active override (1: preset name)"), preset.name)
         default:
             return nil
         }
@@ -411,18 +411,18 @@ public final class AddEditOverrideTableViewController: UITableViewController {
 extension AddEditOverrideTableViewController {
     private func setupTitle() {
         if let symbol = symbol, let name = name {
-            let format = NSLocalizedString("%1$@ %2$@", comment: "The format for an override symbol and name (1: symbol)(2: name)")
+            let format = LocalizedString("%1$@ %2$@", comment: "The format for an override symbol and name (1: symbol)(2: name)")
             title = String(format: format, symbol, name)
         } else {
             switch inputMode {
             case .newPreset:
-                title = NSLocalizedString("New Preset", comment: "The title for the new override preset entry screen")
+                title = LocalizedString("New Preset", comment: "The title for the new override preset entry screen")
             case .editPreset, .customizePresetOverride:
                 assertionFailure("Editing or customizing a preset means we'll have a symbol and a name")
             case .customOverride:
-                title = NSLocalizedString("Custom Override", comment: "The title for the custom override entry screen")
+                title = LocalizedString("Custom Override", comment: "The title for the custom override entry screen")
             case .editOverride:
-                title = NSLocalizedString("Edit Override", comment: "The title for the override editing screen")
+                title = LocalizedString("Edit Override", comment: "The title for the override editing screen")
             }
         }
     }
@@ -432,7 +432,7 @@ extension AddEditOverrideTableViewController {
         case .newPreset, .editPreset, .editOverride:
             navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .save, target: self, action: #selector(save))
         case .customizePresetOverride, .customOverride:
-            navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Enable", comment: "The button text for enabling a temporary override"), style: .done, target: self, action: #selector(save))
+            navigationItem.rightBarButtonItem = UIBarButtonItem(title: LocalizedString("Enable", comment: "The button text for enabling a temporary override"), style: .done, target: self, action: #selector(save))
         }
 
         updateSaveButtonEnabled()

--- a/LoopKitUI/View Controllers/OverrideSelectionViewController.swift
+++ b/LoopKitUI/View Controllers/OverrideSelectionViewController.swift
@@ -39,7 +39,7 @@ public final class OverrideSelectionViewController: UICollectionViewController, 
     public override func viewDidLoad() {
         super.viewDidLoad()
 
-        title = NSLocalizedString("Temporary Override", comment: "The title for the override selection screen")
+        title = LocalizedString("Temporary Override", comment: "The title for the override selection screen")
         collectionView?.backgroundColor = .groupTableViewBackground
         navigationItem.rightBarButtonItems = [saveButton, editButton]
         navigationItem.leftBarButtonItem = cancelButton
@@ -118,14 +118,14 @@ public final class OverrideSelectionViewController: UICollectionViewController, 
             let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: OverrideSelectionHeaderView.className, for: indexPath) as! OverrideSelectionHeaderView
             switch section(for: indexPath.section) {
             case .scheduledOverride:
-                header.titleLabel.text = NSLocalizedString("SCHEDULED OVERRIDE", comment: "The section header text for a scheduled override")
+                header.titleLabel.text = LocalizedString("SCHEDULED OVERRIDE", comment: "The section header text for a scheduled override")
             case .presets:
-                header.titleLabel.text = NSLocalizedString("PRESETS", comment: "The section header text override presets")
+                header.titleLabel.text = LocalizedString("PRESETS", comment: "The section header text override presets")
             }
             return header
         case UICollectionView.elementKindSectionFooter:
             let footer = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: OverrideSelectionFooterView.className, for: indexPath) as! OverrideSelectionFooterView
-            footer.textLabel.text = NSLocalizedString("Tap '+' to create a new override preset.", comment: "Text directing the user to configure their first override preset")
+            footer.textLabel.text = LocalizedString("Tap '+' to create a new override preset.", comment: "Text directing the user to configure their first override preset")
             return footer
         default:
             fatalError("Unexpected supplementary element kind \(kind)")
@@ -149,7 +149,7 @@ public final class OverrideSelectionViewController: UICollectionViewController, 
 
     public override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let customSymbol = "⋯"
-        let customName = NSLocalizedString("Custom", comment: "The text for a custom override")
+        let customName = LocalizedString("Custom", comment: "The text for a custom override")
 
         switch cellContent(for: indexPath) {
         case .scheduledOverride(let override):
@@ -222,7 +222,7 @@ public final class OverrideSelectionViewController: UICollectionViewController, 
             return ""
         }
 
-        return String(format: NSLocalizedString("%1$@ – %2$@ %3$@", comment: "The format for a glucose target range. (1: min target)(2: max target)(3: glucose unit)"), minTarget, maxTarget, quantityFormatter.string(from: glucoseUnit))
+        return String(format: LocalizedString("%1$@ – %2$@ %3$@", comment: "The format for a glucose target range. (1: min target)(2: max target)(3: glucose unit)"), minTarget, maxTarget, quantityFormatter.string(from: glucoseUnit))
     }
 
     public override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {

--- a/LoopKitUI/Views/InsulinSensitivityScalingTableViewCell.swift
+++ b/LoopKitUI/Views/InsulinSensitivityScalingTableViewCell.swift
@@ -108,7 +108,7 @@ final class InsulinSensitivityScalingTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
-        titleLabel.text = NSLocalizedString("Overall Insulin Needs", comment: "The title text for the insulin sensitivity scaling setting")
+        titleLabel.text = LocalizedString("Overall Insulin Needs", comment: "The title text for the insulin sensitivity scaling setting")
 
         selectedPercentage = 100
         setSelected(true, animated: false)
@@ -141,16 +141,16 @@ final class InsulinSensitivityScalingTableViewCell: UITableViewCell {
         let delta = selectedPercentage - 100
         if delta < 0 {
             footerText = String(
-                format: NSLocalizedString("Basal, bolus, and correction insulin dose amounts are decreased by %@%%.", comment: "Describes a percentage decrease in overall insulin needs"),
+                format: LocalizedString("Basal, bolus, and correction insulin dose amounts are decreased by %@%%.", comment: "Describes a percentage decrease in overall insulin needs"),
                 String(abs(delta))
             )
         } else if delta > 0 {
             footerText = String(
-                format: NSLocalizedString("Basal, bolus, and correction insulin dose amounts are increased by %@%%.", comment: "Describes a percentage increase in overall insulin needs"),
+                format: LocalizedString("Basal, bolus, and correction insulin dose amounts are increased by %@%%.", comment: "Describes a percentage increase in overall insulin needs"),
                 String(delta)
             )
         } else {
-            footerText = NSLocalizedString("Basal, bolus, and correction insulin dose amounts are unaffected.", comment: "Describes a lack of change in overall insulin needs")
+            footerText = LocalizedString("Basal, bolus, and correction insulin dose amounts are unaffected.", comment: "Describes a lack of change in overall insulin needs")
         }
 
         footerLabel.text = footerText


### PR DESCRIPTION
This PR fixes the missing translations issue by replacing the `NSLocalizedStrings` with `LocalizedStrings`.

https://github.com/LoopKit/Loop/issues/1304