### PR TITLE
Fix date picker appearance in iOS 14

### DIFF
--- a/LoopKitUI/CarbKit/CarbEntryEditViewController.swift
+++ b/LoopKitUI/CarbKit/CarbEntryEditViewController.swift
@@ -157,6 +157,11 @@ public final class CarbEntryEditViewController: UITableViewController {
             cell.titleLabel.text = LocalizedString("Date", comment: "Title of the carb entry date picker cell")
             cell.datePicker.isEnabled = isSampleEditable
             cell.datePicker.datePickerMode = .dateAndTime
+            #if swift(>=5.2)
+                if #available(iOS 14.0, *) {
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+            #endif
             cell.datePicker.maximumDate = Date(timeIntervalSinceNow: maximumDateFutureInterval)
             cell.datePicker.minuteInterval = 1
             cell.date = date

--- a/LoopKitUI/View Controllers/AddEditOverrideTableViewController.swift
+++ b/LoopKitUI/View Controllers/AddEditOverrideTableViewController.swift
@@ -264,6 +264,9 @@ public final class AddEditOverrideTableViewController: UITableViewController {
                 let cell = tableView.dequeueReusableCell(withIdentifier: DateAndDurationTableViewCell.className, for: indexPath) as! DateAndDurationTableViewCell
                 cell.titleLabel.text = LocalizedString("Start Time", comment: "The text for the override start time")
                 cell.datePicker.datePickerMode = .dateAndTime
+                if #available(iOS 14.0, *) {
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
                 cell.datePicker.minimumDate = min(startDate, Date())
                 cell.date = startDate
                 cell.delegate = self

--- a/LoopKitUI/View Controllers/AddEditOverrideTableViewController.swift
+++ b/LoopKitUI/View Controllers/AddEditOverrideTableViewController.swift
@@ -264,9 +264,11 @@ public final class AddEditOverrideTableViewController: UITableViewController {
                 let cell = tableView.dequeueReusableCell(withIdentifier: DateAndDurationTableViewCell.className, for: indexPath) as! DateAndDurationTableViewCell
                 cell.titleLabel.text = LocalizedString("Start Time", comment: "The text for the override start time")
                 cell.datePicker.datePickerMode = .dateAndTime
-                if #available(iOS 14.0, *) {
-                    cell.datePicker.preferredDatePickerStyle = .wheels
-                }
+                #if swift(>=5.2)
+                    if #available(iOS 14.0, *) {
+                        cell.datePicker.preferredDatePickerStyle = .wheels
+                    }
+                #endif
                 cell.datePicker.minimumDate = min(startDate, Date())
                 cell.date = startDate
                 cell.delegate = self


### PR DESCRIPTION
This is a small fix to address the date picker UI change that was made in iOS 14; I added a change to force the picker to show up in the `.wheels` style that it had before.

![simulator_screenshot_4EA1985C-0FDC-458E-871A-B016859222FF](https://user-images.githubusercontent.com/31571514/94377287-16791480-00d5-11eb-8493-c0e47cc4fe68.png)
