### PR TITLE
Only fetch reservoir values after reconciled events

### DIFF
--- a/LoopKit/InsulinKit/DoseStore.swift
+++ b/LoopKit/InsulinKit/DoseStore.swift
@@ -1120,7 +1120,7 @@ extension DoseStore {
     ///   - result: An array of dose entries, in chronological order by startDate
     public func getNormalizedDoseEntries(start: Date, end: Date? = nil, completion: @escaping (_ result: DoseStoreResult<[DoseEntry]>) -> Void) {
         insulinDeliveryStore.getCachedDoses(start: start, end: end, isChronological: true) { (insulinDeliveryDoses) in
-            let filteredStart = max(insulinDeliveryDoses.lastBasalEndDate ?? start, start)
+            let filteredStart = max(self.lastPumpEventsReconciliation ?? start, start)
 
             self.persistenceController.managedObjectContext.perform {
                 do {


### PR DESCRIPTION
Rather than using reservoir values after the end of the last basal, only use them after the end of the reconciled events, to avoid double-counting of boluses.

This addresses the double-counting issue for Medtronic pumps, raised in Loop as issues LoopKit/Loop#845, LoopKit/Loop#1008, LoopKit/Loop#1047, LoopKit/Loop#1373.

Some additional discussion and testing results are in [this thread](https://loop.zulipchat.com/#narrow/stream/144182-development/topic/Possible.20solution.2Fclue.20for.20double-counted.20boluses) in Zulip. 