### PR TITLE
Improve accessibility when using VoiceOver

### DIFF
--- a/LoopKitUI/Views/CheckmarkListItem.swift
+++ b/LoopKitUI/Views/CheckmarkListItem.swift
@@ -48,6 +48,7 @@ public struct CheckmarkListItem: View {
             Spacer(minLength: 12)
 
             selectionIndicator
+                .accessibility(label: Text(isSelected ? "Selected" : "Unselected"))
         }
         .animation(nil)
     }

--- a/LoopKitUI/Views/ExpandableSetting.swift
+++ b/LoopKitUI/Views/ExpandableSetting.swift
@@ -41,6 +41,7 @@ public struct ExpandableSetting<
                 trailingValueContent
                     .fixedSize(horizontal: true, vertical: false)
             }
+            .accessibilityElement(children: .combine)
             .contentShape(Rectangle())
             .onTapGesture {
                 withAnimation {
@@ -54,7 +55,6 @@ public struct ExpandableSetting<
                     .transition(.fadeInFromTop)
             }
         }
-
     }
 }
 

--- a/LoopKitUI/Views/GuardrailConstraintedQuantityView.swift
+++ b/LoopKitUI/Views/GuardrailConstraintedQuantityView.swift
@@ -71,6 +71,7 @@ public struct GuardrailConstrainedQuantityView: View {
                     .foregroundColor(Color(.secondaryLabel))
             }
         }
+        .accessibilityElement(children: .combine)
         .onAppear { self.hasAppeared = true }
         .animation(animation)
     }

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -244,6 +244,7 @@ extension TherapySettingsView {
                 )
             }
         }
+        .accessibilityElement(children: .combine)
     }
     
     private var maxBolusItem: some View {
@@ -261,6 +262,7 @@ extension TherapySettingsView {
                 )
             }
         }
+        .accessibilityElement(children: .combine)
     }
         
     private var insulinModelSection: some View {
@@ -276,6 +278,7 @@ extension TherapySettingsView {
                         .foregroundColor(.secondary)
                         .padding(.bottom, 8)
                 }
+                .accessibilityElement(children: .combine)
             }
         }
     }

--- a/LoopKitUI/Views/WarningView.swift
+++ b/LoopKitUI/Views/WarningView.swift
@@ -50,6 +50,7 @@ public struct WarningView: View {
                       .fixedSize(horizontal: false, vertical: true)
                       .animation(nil)
               }
+              .accessibilityElement(children: .combine)
 
               Spacer()
           }

--- a/MockKitUI/View Controllers/MockPumpManagerSettingsViewController.swift
+++ b/MockKitUI/View Controllers/MockPumpManagerSettingsViewController.swift
@@ -211,6 +211,11 @@ final class MockPumpManagerSettingsViewController: UITableViewController {
                 cell.datePicker.maximumDate = Date()
                 cell.datePicker.minimumDate = Date() - .hours(48)
                 cell.datePicker.datePickerMode = .dateAndTime
+                #if swift(>=5.2)
+                    if #available(iOS 14.0, *) {
+                        cell.datePicker.preferredDatePickerStyle = .wheels
+                    }
+                #endif
                 cell.datePicker.isEnabled = true
                 cell.delegate = self
                 return cell


### PR DESCRIPTION
There are a few groupings in Loop right now that don't get read correctly by VoiceOver, so I added the appropriate logic. I also snuck in a fix for the date picker style for the mock pump manager.