### PR TITLE
Partial fix scroll issue glucose range and fractional quantity pickers

### DIFF
--- a/LoopKitUI/Views/FractionalQuantityPicker.swift
+++ b/LoopKitUI/Views/FractionalQuantityPicker.swift
@@ -123,7 +123,7 @@ public struct FractionalQuantityPicker: View {
                 colorForValue: colorForWhole
             )
             // Ensure whole picker color updates when fraction updates
-            .id(whole + fraction)
+            //.id(whole + fraction)
             .frame(width: availableWidth / 3.5)
             .overlay(
                 Text(separator)
@@ -143,7 +143,7 @@ public struct FractionalQuantityPicker: View {
                 colorForValue: colorForFraction
             )
             // Ensure fractional picker values update when whole value updates
-            .id(whole + fraction)
+            //.id(whole + fraction)
             .frame(width: availableWidth / 3.5)
             .padding(.trailing, spacing + unitLabelWidth)
             .clipped()

--- a/LoopKitUI/Views/GlucoseRangePicker.swift
+++ b/LoopKitUI/Views/GlucoseRangePicker.swift
@@ -100,7 +100,7 @@ public struct GlucoseRangePicker: View {
                 isUnitLabelVisible: false
             )
             // Ensure the selectable picker values update when either bound changes
-            .id(lowerBound...upperBound)
+            //.id(lowerBound...upperBound)
             .frame(width: availableWidth / 3.5)
             .overlay(
                 Text(separator)
@@ -120,7 +120,7 @@ public struct GlucoseRangePicker: View {
                 bounds: upperBoundRange
             )
             // Ensure the selectable picker values update when either bound changes
-            .id(lowerBound...upperBound)
+            //.id(lowerBound...upperBound)
             .frame(width: availableWidth / 3.5)
             .padding(.trailing, unitLabelWidth)
             .clipped()


### PR DESCRIPTION
A first attempt to fix the [scroll animation issue when 2 pickers are used](https://github.com/LoopKit/Loop/issues/1479).

It seems some race condition is happening, causing the scroll animation to run on the other picker after changing the value.

It might be caused by the forced update to  ensure the selectable picker values update when either bound changes.
Creating the same indexes on both pickers within the function.

As a test I disabled them. It seems to solve the issue at least on the FractionalQuantityPicker.swift file, but on the GlucoseRangePicker.swift the upperrange still gets an unintended animation, while the lower range does seem to work properly.

It might be needed to create unique variables for the id's or create a state function outside of the Picker to ensure the updates happen in the right sequential order, but I don't know how to set that up in a correct way. I have only done it for a website once in Vue.js.