### PR TITLE
Unify language around fast/rapid acting insulins

### DIFF
--- a/LoopKit/InsulinKit/InsulinType.swift
+++ b/LoopKit/InsulinKit/InsulinType.swift
@@ -43,11 +43,11 @@ public enum InsulinType: Int, Codable, CaseIterable {
     public var description: String {
         switch self {
         case .novolog:
-            return LocalizedString("NovoLog (insulin aspart) is a fast-acting insulin made by Novo Nordisk", comment: "Description for novolog insulin type")
+            return LocalizedString("NovoLog (insulin aspart) is a rapid-acting insulin made by Novo Nordisk", comment: "Description for novolog insulin type")
         case .humalog:
-            return LocalizedString("Humalog (insulin lispro) is a fast-acting insulin made by Eli Lilly", comment: "Description for humalog insulin type")
+            return LocalizedString("Humalog (insulin lispro) is a rapid-acting insulin made by Eli Lilly", comment: "Description for humalog insulin type")
         case .apidra:
-            return LocalizedString("Apidra (insulin glulisine) is a fast-acting insulin made by Sanofi-aventis ", comment: "Description for apidra insulin type")
+            return LocalizedString("Apidra (insulin glulisine) is a rapid-acting insulin made by Sanofi-aventis ", comment: "Description for apidra insulin type")
         case .fiasp:
             return LocalizedString("Fiasp is a mealtime insulin aspart formulation with the addition of nicotinamide (vitamin B3) made by Novo Nordisk", comment: "Description for fiasp insulin type")
         }


### PR DESCRIPTION
Fast and rapid-acting appear to be interchangeable in diabetes literature, but the descriptions for Insulin Type and Insulin Model should be consistent when referencing them. As of now, the "Therapy Settings" screen refers to rapid-acting insulins, while the "Insulin Types" screen referee to fast-acting insulins.

Some manufacturers used rapid, while others use fast. I chose to change everything to "rapid-acting" because that is the terminology I see on the ADA website (https://www.diabetes.org/healthy-living/medication-treatments/insulin-other-injectables/insulin-basics).