### PR TITLE
Restore observer queries startup in HealthKit Stores.

### DIFF
--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -252,7 +252,11 @@ public final class CarbStore: HealthKitSampleStore {
             cacheStore.fetchAnchor(key: CarbStore.healthKitQueryAnchorMetadataKey) { (anchor) in
                 self.queue.async {
                     self.queryAnchor = anchor
-            
+
+                    if !self.authorizationRequired {
+                        self.createQuery()
+                    }
+
                     self.migrateLegacyCarbEntryKeys()
                     
                     semaphore.signal()

--- a/LoopKit/GlucoseKit/GlucoseStore.swift
+++ b/LoopKit/GlucoseKit/GlucoseStore.swift
@@ -143,6 +143,10 @@ public final class GlucoseStore: HealthKitSampleStore {
                 self.queue.async {
                     self.queryAnchor = anchor
 
+                    if !self.authorizationRequired {
+                        self.createQuery()
+                    }
+
                     self.updateLatestGlucose()
 
                     semaphore.signal()

--- a/LoopKit/HealthKitSampleStore.swift
+++ b/LoopKit/HealthKitSampleStore.swift
@@ -60,12 +60,12 @@ public class HealthKitSampleStore {
     }
     
     /// Allows unit test to inject a mock for HKObserverQuery
-    public var createObserverQuery: (HKSampleType, NSPredicate?, @escaping (HKObserverQuery, @escaping HKObserverQueryCompletionHandler, Error?) -> Void) -> HKObserverQuery = { (sampleType, predicate, updateHandler) in
+    internal var createObserverQuery: (HKSampleType, NSPredicate?, @escaping (HKObserverQuery, @escaping HKObserverQueryCompletionHandler, Error?) -> Void) -> HKObserverQuery = { (sampleType, predicate, updateHandler) in
         return HKObserverQuery(sampleType: sampleType, predicate: predicate, updateHandler: updateHandler)
     }
     
     /// Allows unit test to inject a mock for HKAnchoredObjectQuery
-    public var createAnchoredObjectQuery: (HKSampleType, NSPredicate?, HKQueryAnchor?, Int, @escaping (HKAnchoredObjectQuery, [HKSample]?, [HKDeletedObject]?, HKQueryAnchor?, Error?) -> Void) -> HKAnchoredObjectQuery = { (sampleType, predicate, anchor, limit, resultsHandler) in
+    internal var createAnchoredObjectQuery: (HKSampleType, NSPredicate?, HKQueryAnchor?, Int, @escaping (HKAnchoredObjectQuery, [HKSample]?, [HKDeletedObject]?, HKQueryAnchor?, Error?) -> Void) -> HKAnchoredObjectQuery = { (sampleType, predicate, anchor, limit, resultsHandler) in
         return HKAnchoredObjectQuery(type: sampleType, predicate: predicate, anchor: anchor, limit: limit, resultsHandler: resultsHandler)
     }
 
@@ -137,7 +137,7 @@ public class HealthKitSampleStore {
     // MARK: - Query support
 
     /// The active observer query
-    private var observerQuery: HKObserverQuery? {
+    internal var observerQuery: HKObserverQuery? {
         didSet {
             if let query = oldValue {
                 healthStore.stop(query)
@@ -317,7 +317,7 @@ extension HealthKitSampleStore {
 
 // MARK: - Observation
 extension HealthKitSampleStore {
-    private func createQuery() {
+    internal func createQuery() {
         log.debug("%@ [sampleType: %@]", #function, sampleType)
         log.debug("%@ [observationEnabled: %d]", #function, observationEnabled)
         log.debug("%@ [observeHealthKitSamplesFromCurrentApp: %d]", #function, observeHealthKitSamplesFromCurrentApp)

--- a/LoopKit/InsulinKit/InsulinDeliveryStore.swift
+++ b/LoopKit/InsulinKit/InsulinDeliveryStore.swift
@@ -85,6 +85,10 @@ public class InsulinDeliveryStore: HealthKitSampleStore {
                 self.queue.async {
                     self.queryAnchor = anchor
 
+                    if !self.authorizationRequired {
+                        self.createQuery()
+                    }
+
                     self.updateLastBasalEndDate()
 
                     semaphore.signal()


### PR DESCRIPTION
This restores calls to createQuery() lost in the 8947c0f merge.  At
present, these exist in `master` within HealthKitSampleStore's init, but
were moved into individual stores as part of 2ea6be07, and then removed
later for an unknown reason.

This adds tests for all stores that an observer query has been started
during initialization in the case that authorizationRequired returns
false; if authorization is required, queries will be created as part of
authorize().

Fixes LoopKit/Loop#1593.