### PR TITLE
Reenable reading hk for data stored by current app

### DIFF
--- a/LoopKit/CarbKit/CachedCarbObject+CoreDataClass.swift
+++ b/LoopKit/CarbKit/CachedCarbObject+CoreDataClass.swift
@@ -91,8 +91,6 @@ extension CachedCarbObject {
 
     // HealthKit
     func create(from sample: HKQuantitySample, on date: Date = Date()) {
-        //precondition(!sample.createdByCurrentApp)
-
         self.absorptionTime = sample.absorptionTime
         self.createdByCurrentApp = sample.createdByCurrentApp
         self.foodType = sample.foodType

--- a/LoopKit/CarbKit/CachedCarbObject+CoreDataClass.swift
+++ b/LoopKit/CarbKit/CachedCarbObject+CoreDataClass.swift
@@ -91,7 +91,7 @@ extension CachedCarbObject {
 
     // HealthKit
     func create(from sample: HKQuantitySample, on date: Date = Date()) {
-        precondition(!sample.createdByCurrentApp)
+        //precondition(!sample.createdByCurrentApp)
 
         self.absorptionTime = sample.absorptionTime
         self.createdByCurrentApp = sample.createdByCurrentApp

--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -227,7 +227,7 @@ public final class CarbStore: HealthKitSampleStore {
 
         super.init(healthStore: healthStore,
                    observeHealthKitSamplesFromCurrentApp: true,
-                   observeHealthKitSamplesFromOtherApps: false,
+                   observeHealthKitSamplesFromOtherApps: observeHealthKitSamplesFromOtherApps,
                    type: carbType,
                    observationStart: Date(timeIntervalSinceNow: -self.observationInterval),
                    observationEnabled: observationEnabled)

--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -226,8 +226,8 @@ public final class CarbStore: HealthKitSampleStore {
         let observationEnabled = observationInterval > 0
 
         super.init(healthStore: healthStore,
-                   observeHealthKitSamplesFromCurrentApp: false,
-                   observeHealthKitSamplesFromOtherApps: observeHealthKitSamplesFromOtherApps,
+                   observeHealthKitSamplesFromCurrentApp: true,
+                   observeHealthKitSamplesFromOtherApps: false,
                    type: carbType,
                    observationStart: Date(timeIntervalSinceNow: -self.observationInterval),
                    observationEnabled: observationEnabled)

--- a/LoopKit/GlucoseKit/CachedGlucoseObject+CoreDataClass.swift
+++ b/LoopKit/GlucoseKit/CachedGlucoseObject+CoreDataClass.swift
@@ -160,7 +160,7 @@ extension CachedGlucoseObject {
 
     // HealthKit
     func create(from sample: HKQuantitySample) {
-        precondition(!sample.createdByCurrentApp)
+        //precondition(!sample.createdByCurrentApp)
 
         self.uuid = sample.uuid
         self.provenanceIdentifier = sample.provenanceIdentifier

--- a/LoopKit/GlucoseKit/CachedGlucoseObject+CoreDataClass.swift
+++ b/LoopKit/GlucoseKit/CachedGlucoseObject+CoreDataClass.swift
@@ -160,8 +160,6 @@ extension CachedGlucoseObject {
 
     // HealthKit
     func create(from sample: HKQuantitySample) {
-        //precondition(!sample.createdByCurrentApp)
-
         self.uuid = sample.uuid
         self.provenanceIdentifier = sample.provenanceIdentifier
         self.syncIdentifier = sample.syncIdentifier

--- a/LoopKit/GlucoseKit/GlucoseStore.swift
+++ b/LoopKit/GlucoseKit/GlucoseStore.swift
@@ -126,7 +126,7 @@ public final class GlucoseStore: HealthKitSampleStore {
         self.provenanceIdentifier = provenanceIdentifier
 
         super.init(healthStore: healthStore,
-                   observeHealthKitSamplesFromCurrentApp: false,
+                   observeHealthKitSamplesFromCurrentApp: true,
                    observeHealthKitSamplesFromOtherApps: observeHealthKitSamplesFromOtherApps,
                    type: glucoseType,
                    observationStart: Date(timeIntervalSinceNow: -self.observationInterval),

--- a/LoopKit/InsulinKit/InsulinDeliveryStore.swift
+++ b/LoopKit/InsulinKit/InsulinDeliveryStore.swift
@@ -66,7 +66,7 @@ public class InsulinDeliveryStore: HealthKitSampleStore {
 
         super.init(
             healthStore: healthStore,
-            observeHealthKitSamplesFromCurrentApp: false,
+            observeHealthKitSamplesFromCurrentApp: true,
             observeHealthKitSamplesFromOtherApps: observeHealthKitSamplesFromOtherApps,
             type: insulinQuantityType,
             observationStart: (test_currentDate ?? Date()).addingTimeInterval(-cacheLength),


### PR DESCRIPTION
This re-enables reading from Apple Health so that if a user deletes Loop and reinstalls, Loop will pick up any historical carbs, insulin and bg data that it had stored.