### PR TITLE
Expand Information in Therapy Setting and Expand Recommended Limit Ranges

### DIFF
--- a/Extensions/Guardrail+Settings.swift
+++ b/Extensions/Guardrail+Settings.swift
@@ -9,7 +9,7 @@
 import HealthKit
 
 public extension Guardrail where Value == HKQuantity {
-    static let suspendThreshold = Guardrail(absoluteBounds: 67...110, recommendedBounds: 74...80, unit: .milligramsPerDeciliter, startingSuggestion: 80)
+    static let suspendThreshold = Guardrail(absoluteBounds: 65...120, recommendedBounds: 75...110, unit: .milligramsPerDeciliter, startingSuggestion: 90)
 
     static func maxSuspendThresholdValue(correctionRangeSchedule: GlucoseRangeSchedule?, preMealTargetRange: ClosedRange<HKQuantity>?, workoutTargetRange: ClosedRange<HKQuantity>?) -> HKQuantity {
 
@@ -23,7 +23,7 @@ public extension Guardrail where Value == HKQuantity {
         .min()!
     }
 
-    static let correctionRange = Guardrail(absoluteBounds: 87...180, recommendedBounds: 100...115, unit: .milligramsPerDeciliter, startingSuggestion: 100)
+    static let correctionRange = Guardrail(absoluteBounds: 75...180, recommendedBounds: 80...150, unit: .milligramsPerDeciliter, startingSuggestion: 110)
 
     static func minCorrectionRangeValue(suspendThreshold: GlucoseThreshold?) -> HKQuantity {
         return [

--- a/LoopKit/TherapySetting.swift
+++ b/LoopKit/TherapySetting.swift
@@ -58,13 +58,13 @@ public extension TherapySetting {
     func descriptiveText(appName: String) -> String {
         switch self {
         case .glucoseTargetRange:
-            return String(format: LocalizedString("Correction Range is the glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin and helping you calculate your boluses.", comment: "Descriptive text for glucose target range (1: app name)"), appName)
+            return String(format: LocalizedString("Correction Range is the glucose value (or range of values) that you want %1$@ to aim for in adjusting your insulin delivery and helping you calculate your boluses.\n\nThe low level offered might be limited by Glucose Safety Range  and Pre-Meal (if set) choices.", comment: "Descriptive text for glucose target range (1: app name)"), appName)
         case .preMealCorrectionRangeOverride:
-            return LocalizedString("Temporarily lower your glucose target before a meal to impact post-meal glucose spikes.", comment: "Descriptive text for pre-meal correction range override")
+            return LocalizedString("Temporarily lower your glucose target before a meal to help decrease post-meal glucose spikes.\n\nThe Pre-Meal duration is 1 hour or until user enters carbs, cancels Pre-Meal or enacts a different override.", comment: "Descriptive text for pre-meal correction range override")
         case .workoutCorrectionRangeOverride:
             return LocalizedString("Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events.", comment: "Descriptive text for workout correction range override")
         case .suspendThreshold:
-            return String(format: LocalizedString("%1$@ will deliver basal and recommend bolus insulin only if your glucose is predicted to be above this limit for the next three hours.", comment: "Descriptive format string for glucose safety limit (1: app name)"), appName)
+            return String(format: LocalizedString("%1$@ will deliver basal and recommend bolus insulin only if your glucose is predicted to be above this limit for the next three hours.\n\nIf you want to raise the limit, you may need to first adjust Pre-Meal or Correction Range settings.", comment: "Descriptive format string for glucose safety limit (1: app name)"), appName)
         case .basalRate:
             return LocalizedString("Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs.", comment: "Descriptive text for basal rate")
         case .deliveryLimits:

--- a/LoopKitUI/Views/GlucoseValuePicker.swift
+++ b/LoopKitUI/Views/GlucoseValuePicker.swift
@@ -76,7 +76,7 @@ public struct GlucoseValuePicker: View {
 private struct GlucoseValuePickerTester: View {
     @State var value = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 80)
 
-    private let guardrail = Guardrail(absoluteBounds: 54...180, recommendedBounds: 71...120, unit: .milligramsPerDeciliter, startingSuggestion: 80)
+    private let guardrail = Guardrail(absoluteBounds: 54...180, recommendedBounds: 71...150, unit: .milligramsPerDeciliter, startingSuggestion: 100)
 
     var unit: HKUnit
 

--- a/LoopKitUI/Views/Information Screens/CorrectionRangeInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/CorrectionRangeInformationView.swift
@@ -36,8 +36,10 @@ public struct CorrectionRangeInformationView: View {
             Text(LocalizedString("If you've used a CGM before, you're likely familiar with target range as a wide range of values you'd like for your glucose notification alerts, such as 70-180 mg/dL or 90-200 mg/dL.", comment: "Information about target range"))
             Text(LocalizedString("A Correction Range is different. This will be a narrower range.", comment: "Information about differences between target range and correction range"))
             .bold()
-            Text(String(format: LocalizedString("For this range, choose the specific glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin.", comment: "Information about correction range format (1: app name)"), appName))
-            Text(LocalizedString("Your healthcare provider can help you choose a Correction Range that's right for you.", comment: "Disclaimer"))
+            Text(String(format: LocalizedString("For this range, choose the specific glucose value (or range of values) that you want %1$@ to aim for in adjusting your insulin delivery.", comment: "Information about correction range format (1: app name)"), appName))
+            Text(LocalizedString("Your healthcare provider can help you choose a Correction Range that's right for you. Ask about how rapidly you should choose to lower your average blood glucose (A1C).", comment: "Disclaimer"))
+                .bold()
+            Text(LocalizedString("Note that the low-level values you can choose may be limited by Glucose Safey Limit and Pre-Meal (if set) as well as guardrails set in the code (which are noted below).", comment: "Adjustments"))
         }
         .foregroundColor(.secondary)
     }

--- a/LoopKitUI/Views/Information Screens/CorrectionRangeOverrideInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/CorrectionRangeOverrideInformationView.swift
@@ -51,7 +51,8 @@ public struct CorrectionRangeOverrideInformationView: View {
         case .preMeal:
             return VStack(alignment: .leading, spacing: 20) {
                 Text(String(format: LocalizedString("Your Pre-Meal Range should be the glucose value (or range of values) you want %1$@ to target by the time you take your first bite of your meal. This range will be in effect when you activate the Pre-Meal Preset button.", comment: "Information about pre-meal range format (1: app name)"), appName))
-                Text(LocalizedString("This will typically be", comment: "Information about pre-meal range relative to correction range")) + Text(LocalizedString(" lower ", comment: "Information about pre-meal range relative to correction range")).bold().italic() + Text(LocalizedString("than your Correction Range.", comment: "Information about pre-meal range relative to correction range"))
+                Text(LocalizedString("This will typically be", comment: "Information about pre-meal range relative to correction range")) + Text(LocalizedString(" lower ", comment: "Information about pre-meal range relative to correction range")).bold().italic() + Text(LocalizedString("than your Correction Range but cannot be lower than the Glucose Safety Limit.", comment: "Information about pre-meal range relative to correction range")) +
+                Text(LocalizedString("\n\nThe Pre-Meal duration is 1 hour or until user enters carbs, cancels Pre-Meal or enacts a different override.", comment: "Information about pre-meal duration"))
             }
             .fixedSize(horizontal: false, vertical: true) // prevent text from being cut off
         case .workout:

--- a/LoopKitUI/Views/Information Screens/GlucoseTherapySettingInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/GlucoseTherapySettingInformationView.swift
@@ -58,7 +58,7 @@ public struct GlucoseTherapySettingInformationView: View {
     private var bodyText: some View {
         VStack(alignment: .leading, spacing: 25) {
             text ?? AnyView(Text(therapySetting.descriptiveText(appName: appName)))
-            Text(therapySetting.guardrailInformationText)
+            Text(therapySetting.guardrailInformationText).bold()
         }
         .accentColor(.secondary)
         .foregroundColor(.accentColor)
@@ -96,7 +96,7 @@ fileprivate extension TherapySetting {
     }
 
     func lowHighText(lowerBoundString: String, upperBoundString: String) -> String {
-        return String(format: LocalizedString("It can be set as low as %1$@. It can be set as high as %2$@.",
+        return String(format: LocalizedString("Graphic above for illustration only; Code Limits:\n\tHigh Limit:\t%2$@\n\t Low Limit:\t%1$@",
                                               comment: "Guardrail info text format"), lowerBoundString, upperBoundString)
     }
 }

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
@@ -319,7 +319,7 @@ public extension CorrectionRangeOverrides.Preset {
     var descriptiveText: String {
         switch self {
         case .preMeal:
-            return LocalizedString("Temporarily lower your glucose target before a meal to impact post-meal glucose spikes.", comment: "Description of pre-meal mode")
+            return LocalizedString("Temporarily lower your glucose target before a meal to help decrease post-meal glucose spikes.", comment: "Description of pre-meal mode")
         case .workout:
             return LocalizedString("Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events.", comment: "Description of workout mode")
         }


### PR DESCRIPTION
This has been closed in favor of single-topic PRs.
Adding these to the list as they are opened:
* PR #403 
* PR #404 

Purpose: 
1. Based on frequently asked questions, I've expanded some of the information provided in the Therapy Settings screens, primarily for Glucose Safety Limit, Correction Range and Pre-Meal Range.
2. When people who have had higher BG values begin to get better control (via MDI, manual pump, commercial closed loop or DIY systems), they should consult their medical team for advice on how rapidly they can safely reduce average BG.  

Discussion for item 1:
* I concentrated on getting information added
* If I broke formatting "rules" I am happy to be told how best to do it and then I will update my branch

Discussion for Item 2:
* Rapid lowering of A1C can exacerbate problems with retinopathy and neuropathy. 
* To accommodate new loopers, I increased the upper level ranges over which the glucose pickers remain black.
* I suggest we get review from an endocrinologist on the best wording and levels.

