### PR TITLE
add a reset button to Pre-Meal screen

### DIFF
--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
@@ -86,6 +86,11 @@ public struct CorrectionRangeOverridesEditor: View {
         content
             .navigationBarBackButtonHidden(shouldAddCancelButton)
             .navigationBarItems(leading: leadingNavigationBarItem)
+            .navigationBarItems(leading: EmptyView(), trailing: resetButton)
+    }
+
+    private var resetButton: some View {
+        Button(action: { value.ranges = [:] } ) { Text(LocalizedString("Reset", comment: "Restore settings to nil")) }
     }
     
     private var cancelButton: some View {

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
@@ -85,15 +85,15 @@ public struct CorrectionRangeOverridesEditor: View {
     private var contentWithCancel: some View {
         content
             .navigationBarBackButtonHidden(shouldAddCancelButton)
-            .navigationBarItems(leading: leadingNavigationBarItem, trailing: unsetButton)
+            .navigationBarItems(leading: leadingNavigationBarItem, trailing: deleteButton)
     }
 
-    private var unsetButton: some View {
+    private var deleteButton: some View {
         Button( action: {
                 value.ranges = [:];
                 presetBeingEdited = nil
         } )
-        { Text(LocalizedString("Unset", comment: "Restore settings to nil")) }
+        { Text(LocalizedString("Delete", comment: "Delete values for Pre-Meal, inactivates Pre-Meal icon")) }
     }
     
     private var cancelButton: some View {

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
@@ -89,7 +89,11 @@ public struct CorrectionRangeOverridesEditor: View {
     }
 
     private var unsetButton: some View {
-        Button(action: { value.ranges = [:] } ) { Text(LocalizedString("Unset", comment: "Restore settings to nil")) }
+        Button( action: {
+                value.ranges = [:];
+                presetBeingEdited = nil
+        } )
+        { Text(LocalizedString("Unset", comment: "Restore settings to nil")) }
     }
     
     private var cancelButton: some View {

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
@@ -85,8 +85,7 @@ public struct CorrectionRangeOverridesEditor: View {
     private var contentWithCancel: some View {
         content
             .navigationBarBackButtonHidden(shouldAddCancelButton)
-            .navigationBarItems(leading: leadingNavigationBarItem)
-            .navigationBarItems(leading: EmptyView(), trailing: resetButton)
+            .navigationBarItems(leading: leadingNavigationBarItem, trailing: resetButton)
     }
 
     private var resetButton: some View {

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
@@ -85,11 +85,11 @@ public struct CorrectionRangeOverridesEditor: View {
     private var contentWithCancel: some View {
         content
             .navigationBarBackButtonHidden(shouldAddCancelButton)
-            .navigationBarItems(leading: leadingNavigationBarItem, trailing: resetButton)
+            .navigationBarItems(leading: leadingNavigationBarItem, trailing: unsetButton)
     }
 
-    private var resetButton: some View {
-        Button(action: { value.ranges = [:] } ) { Text(LocalizedString("Reset", comment: "Restore settings to nil")) }
+    private var unsetButton: some View {
+        Button(action: { value.ranges = [:] } ) { Text(LocalizedString("Unset", comment: "Restore settings to nil")) }
     }
     
     private var cancelButton: some View {


### PR DESCRIPTION
This is in response to [Issue 1654](https://github.com/LoopKit/Loop/issues/1654) (listed under LoopKit/Loop).

This code adds a Reset button to upper right of the Pre-Meal Settings screen, shown in graphic below.
Action of the button has been tested.

![PreMeal_ResetButton](https://user-images.githubusercontent.com/19607791/165095175-a0027de7-675a-4180-ae5c-455fbcabd600.png)

