### PR TITLE
Report Total Daily Scheduled Basal

### DIFF
--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -264,9 +264,11 @@ extension TherapySettingsView {
 
     private var basalRatesSection: Card {
         card(for: .basalRate) {
-            if let items = viewModel.therapySettings.basalRateSchedule?.items,
-               let supportedBasalRates = viewModel.pumpSupportedIncrements()?.basalRates,
-               let total = viewModel.therapySettings.basalRateSchedule?.total()  {
+            if let schedule = viewModel.therapySettings.basalRateSchedule,
+               let supportedBasalRates = viewModel.pumpSupportedIncrements()?.basalRates
+            {
+                let items = schedule.items
+                let total = schedule.total()
                 SectionDivider()
                 ForEach(items.indices, id: \.self) { index in
                     if index > 0 {

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -267,7 +267,7 @@ extension TherapySettingsView {
             if let items = viewModel.therapySettings.basalRateSchedule?.items,
                let supportedBasalRates = viewModel.pumpSupportedIncrements()?.basalRates,
                let total = viewModel.therapySettings.basalRateSchedule?.total()  {
-                Text(LocalizedString("\(round(total * 100) / 100.0) U/day", comment: "Schedule Basal Daily Total"))
+                Text(LocalizedString("\(round(total * 100) / 100.0) U/day", comment: "Scheduled Basal Daily Total"))
                 SectionDivider()
                 ForEach(items.indices, id: \.self) { index in
                     if index > 0 {

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -267,7 +267,6 @@ extension TherapySettingsView {
             if let items = viewModel.therapySettings.basalRateSchedule?.items,
                let supportedBasalRates = viewModel.pumpSupportedIncrements()?.basalRates,
                let total = viewModel.therapySettings.basalRateSchedule?.total()  {
-                Text(LocalizedString("\(round(total * 100) / 100.0) U/day", comment: "Scheduled Basal Daily Total"))
                 SectionDivider()
                 ForEach(items.indices, id: \.self) { index in
                     if index > 0 {
@@ -277,6 +276,17 @@ extension TherapySettingsView {
                                       value:  items[index].value,
                                       unit: .internationalUnitsPerHour,
                                       guardrail: .basalRate(supportedBasalRates: supportedBasalRates))
+                }
+                SectionDivider()
+                HStack {
+                    Text(NSLocalizedString("Total", comment: "The text indicating Total for Daily Schedule Basal"))
+                        .bold()
+                        .foregroundColor(.primary)
+                    Spacer()
+                    Text("\(round(total * 100) / 100.0) ")
+                        .foregroundColor(.primary) +
+                    Text(NSLocalizedString("U/day", comment: "The text indicating U/day for Daily Schedule Basal"))
+                        .foregroundColor(.secondary)
                 }
             }
         }

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -285,7 +285,7 @@ extension TherapySettingsView {
                         .bold()
                         .foregroundColor(.primary)
                     Spacer()
-                    Text("\(round(total * 100) / 100.0) ")
+                    Text(String(format: "%.2f ",total))
                         .foregroundColor(.primary) +
                     Text(NSLocalizedString("U/day", comment: "The text indicating U/day for Daily Schedule Basal"))
                         .foregroundColor(.secondary)

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -281,7 +281,6 @@ extension TherapySettingsView {
             }
         }
     }
-
     
     private var deliveryLimitsSection: Card {
         card(for: .deliveryLimits) {

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -264,7 +264,10 @@ extension TherapySettingsView {
 
     private var basalRatesSection: Card {
         card(for: .basalRate) {
-            if let items = viewModel.therapySettings.basalRateSchedule?.items, let supportedBasalRates = viewModel.pumpSupportedIncrements()?.basalRates {
+            if let items = viewModel.therapySettings.basalRateSchedule?.items,
+               let supportedBasalRates = viewModel.pumpSupportedIncrements()?.basalRates,
+               let total = viewModel.therapySettings.basalRateSchedule?.total()  {
+                Text(LocalizedString("\(round(total * 100) / 100.0) U/day", comment: "Schedule Basal Daily Total"))
                 SectionDivider()
                 ForEach(items.indices, id: \.self) { index in
                     if index > 0 {
@@ -278,6 +281,7 @@ extension TherapySettingsView {
             }
         }
     }
+
     
     private var deliveryLimitsSection: Card {
         card(for: .deliveryLimits) {


### PR DESCRIPTION
Several people have requested that the daily scheduled basal rate be reported (as it was in prior versions of Loop).
This has been discussed in zulipchat under [#development: Total daily basal](https://loop.zulipchat.com/#narrow/stream/144182-development/topic/Total.20daily.20basal/near/278302709)
There is a (very old) open issue requesting this as well [LoopKit/Loop Issue 841](https://github.com/LoopKit/Loop/issues/841)

Use Case:
1. After modifying the basal schedule, seeing the total assists user in verifying no improper entry was made
2. Many HCP ask for total daily basal rates - with closed-loop systems, they probably need the Scheduled Basal Total