### PR TITLE
Increase upper range of recommendedBounds

### DIFF
--- a/Extensions/Guardrail+Settings.swift
+++ b/Extensions/Guardrail+Settings.swift
@@ -9,7 +9,11 @@
 import HealthKit
 
 public extension Guardrail where Value == HKQuantity {
-    static let suspendThreshold = Guardrail(absoluteBounds: 67...110, recommendedBounds: 74...80, unit: .milligramsPerDeciliter, startingSuggestion: 80)
+    static let suspendThreshold = Guardrail(
+        absoluteBounds: 67...110,
+        recommendedBounds: 74...100,
+        unit: .milligramsPerDeciliter,
+        startingSuggestion: 80)
 
     static func maxSuspendThresholdValue(correctionRangeSchedule: GlucoseRangeSchedule?, preMealTargetRange: ClosedRange<HKQuantity>?, workoutTargetRange: ClosedRange<HKQuantity>?) -> HKQuantity {
 
@@ -23,7 +27,11 @@ public extension Guardrail where Value == HKQuantity {
         .min()!
     }
 
-    static let correctionRange = Guardrail(absoluteBounds: 87...180, recommendedBounds: 100...115, unit: .milligramsPerDeciliter, startingSuggestion: 100)
+    static let correctionRange = Guardrail(
+        absoluteBounds: 87...180,
+        recommendedBounds: 100...150,
+        unit: .milligramsPerDeciliter,
+        startingSuggestion: 100)
 
     static func minCorrectionRangeValue(suspendThreshold: GlucoseThreshold?) -> HKQuantity {
         return [


### PR DESCRIPTION
Increase upper range of recommendedBounds for suspendThreshold and correctionRange.

This provides support to new Loopers who may wish to start at higher levels than is typical.

The overall ranges (absoluteBounds) are not modified.
