### PR TITLE
Enhance Therapy Information Screens

### DIFF
--- a/LoopKit/TherapySetting.swift
+++ b/LoopKit/TherapySetting.swift
@@ -17,6 +17,8 @@ public enum TherapySetting: String {
     case insulinModel
     case carbRatio
     case insulinSensitivity
+    case addNewEntry
+    case editDeleteEntry
     case none
 }
 
@@ -43,7 +45,7 @@ public extension TherapySetting {
             return LocalizedString("Carb Ratios", comment: "Title text for carb ratios")
         case .insulinSensitivity:
             return LocalizedString("Insulin Sensitivities", comment: "Title text for insulin sensitivity")
-        case .none:
+        case .none, .addNewEntry, .editDeleteEntry :
             return ""
         }
     }
@@ -75,7 +77,11 @@ public extension TherapySetting {
             return LocalizedString("Your Carb Ratio is the number of grams of carbohydrates covered by one unit of insulin.", comment: "Descriptive text for carb ratio")
         case .insulinSensitivity:
             return LocalizedString("Your Insulin Sensitivities refer to the drop in glucose expected from one unit of insulin.", comment: "Descriptive text for insulin sensitivity")
-        case .none:
+        case .addNewEntry:
+            return LocalizedString("You can add an entry for any time slot not already filled by using the ➕ button.", comment: "Descriptive text for adding an entry")
+        case .editDeleteEntry:
+            return LocalizedString("You can edit or delete an entry using the Edit button.", comment: "Descriptive text for editing or deleting an entry")
+       case .none:
             return ""
         }
     }

--- a/LoopKitUI/Views/Information Screens/BasalRatesInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/BasalRatesInformationView.swift
@@ -35,8 +35,8 @@ public struct BasalRatesInformationView: View {
             Text(LocalizedString("Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs.", comment: "Information about basal rates"))
             Text(String(format: LocalizedString("%1$@ supports 1 to 48 rates per day.", comment: "Information about max number of basal rates"), appName))
             Text(LocalizedString("The schedule starts at midnight and cannot contain a single rate of 0 U/hr.", comment: "Information about basal rate scheduling"))
-            Text(LocalizedString("You can add an entry at half-hour intervals for any time slot not already filled by using the ➕ button.", comment: "Information about adding a basal rate entry"))
-            Text(LocalizedString("You can edit the value or delete an entry by using the Edit button.", comment: "Information about editing or deleting a basal rate entry"))
+            Text(TherapySetting.addNewEntry.descriptiveText(appName: appName))
+            Text(TherapySetting.editDeleteEntry.descriptiveText(appName: appName))
        }
         .foregroundColor(.secondary)
     }

--- a/LoopKitUI/Views/Information Screens/BasalRatesInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/BasalRatesInformationView.swift
@@ -34,8 +34,9 @@ public struct BasalRatesInformationView: View {
         VStack(alignment: .leading, spacing: 25) {
             Text(LocalizedString("Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs.", comment: "Information about basal rates"))
             Text(String(format: LocalizedString("%1$@ supports 1 to 48 rates per day.", comment: "Information about max number of basal rates"), appName))
-            Text(LocalizedString("The schedule starts at midnight and cannot contain a rate of 0 U/hr.", comment: "Information about basal rate scheduling"))
-        }
+            Text(LocalizedString("The schedule starts at midnight and cannot contain a single rate of 0 U/hr.", comment: "Information about basal rate scheduling"))
+            Text(LocalizedString("You can add (using the + symbol) new lines at any time that does not already have an entry.", comment: "Information about basal rate scheduling"))
+       }
         .foregroundColor(.secondary)
     }
 }

--- a/LoopKitUI/Views/Information Screens/BasalRatesInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/BasalRatesInformationView.swift
@@ -35,7 +35,8 @@ public struct BasalRatesInformationView: View {
             Text(LocalizedString("Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs.", comment: "Information about basal rates"))
             Text(String(format: LocalizedString("%1$@ supports 1 to 48 rates per day.", comment: "Information about max number of basal rates"), appName))
             Text(LocalizedString("The schedule starts at midnight and cannot contain a single rate of 0 U/hr.", comment: "Information about basal rate scheduling"))
-            Text(LocalizedString("You can add (using the + symbol) new lines at any time that does not already have an entry.", comment: "Information about basal rate scheduling"))
+            Text(LocalizedString("You can add an entry at half-hour intervals for any time slot not already filled by using the ➕ button.", comment: "Information about adding a basal rate entry"))
+            Text(LocalizedString("You can edit the value or delete an entry by using the Edit button.", comment: "Information about editing or deleting a basal rate entry"))
        }
         .foregroundColor(.secondary)
     }

--- a/LoopKitUI/Views/Information Screens/CarbRatioInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/CarbRatioInformationView.swift
@@ -36,7 +36,8 @@ public struct CarbRatioInformationView: View {
     private var text: some View {
         VStack(alignment: .leading, spacing: 25) {
             Text(TherapySetting.carbRatio.descriptiveText(appName: appName))
-            Text(LocalizedString("You can add different carb ratios for different times of day by using the ➕.", comment: "Description of how to add a ratio"))
+            Text(LocalizedString("You can add different carb ratios at half-hour intervals for any time slot not already filled by using the ➕ button.", comment: "Description of how to add a ratio"))
+            Text(LocalizedString("You can edit the value or delete an entry by using the Edit button.", comment: "Description of how to edit or delete an entry"))
         }
         .accentColor(.secondary)
         .foregroundColor(.accentColor)

--- a/LoopKitUI/Views/Information Screens/CarbRatioInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/CarbRatioInformationView.swift
@@ -36,8 +36,8 @@ public struct CarbRatioInformationView: View {
     private var text: some View {
         VStack(alignment: .leading, spacing: 25) {
             Text(TherapySetting.carbRatio.descriptiveText(appName: appName))
-            Text(LocalizedString("You can add different carb ratios at half-hour intervals for any time slot not already filled by using the ➕ button.", comment: "Description of how to add a ratio"))
-            Text(LocalizedString("You can edit the value or delete an entry by using the Edit button.", comment: "Description of how to edit or delete an entry"))
+            Text(TherapySetting.addNewEntry.descriptiveText(appName: appName))
+            Text(TherapySetting.editDeleteEntry.descriptiveText(appName: appName))
         }
         .accentColor(.secondary)
         .foregroundColor(.accentColor)

--- a/LoopKitUI/Views/Information Screens/CorrectionRangeInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/CorrectionRangeInformationView.swift
@@ -35,9 +35,12 @@ public struct CorrectionRangeInformationView: View {
         VStack(alignment: .leading, spacing: 25) {
             Text(LocalizedString("If you've used a CGM before, you're likely familiar with target range as a wide range of values you'd like for your glucose notification alerts, such as 70-180 mg/dL or 90-200 mg/dL.", comment: "Information about target range"))
             Text(LocalizedString("A Correction Range is different. This will be a narrower range.", comment: "Information about differences between target range and correction range"))
-            .bold()
-            Text(String(format: LocalizedString("For this range, choose the specific glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin.", comment: "Information about correction range format (1: app name)"), appName))
+                .bold()
+            Text(String(format: LocalizedString("For this range, choose the specific glucose value (or range of values) that you want %1$@ to aim for in adjusting your insulin delivery.", comment: "Information about correction range format (1: app name)"), appName))
             Text(LocalizedString("Your healthcare provider can help you choose a Correction Range that's right for you.", comment: "Disclaimer"))
+                .bold()
+            Text(TherapySetting.addNewEntry.descriptiveText(appName: appName))
+            Text(TherapySetting.editDeleteEntry.descriptiveText(appName: appName))
         }
         .foregroundColor(.secondary)
     }

--- a/LoopKitUI/Views/Information Screens/GlucoseTherapySettingInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/GlucoseTherapySettingInformationView.swift
@@ -85,7 +85,7 @@ fileprivate extension TherapySetting {
                 upperBoundString: Guardrail.unconstrainedWorkoutCorrectionRange.absoluteBounds.upperBound.bothUnitsString)
         case .suspendThreshold:
             return lowHighText(for: Guardrail.suspendThreshold)
-        case .basalRate, .deliveryLimits, .insulinModel, .carbRatio, .insulinSensitivity, .none:
+        case .basalRate, .deliveryLimits, .insulinModel, .carbRatio, .insulinSensitivity, .addNewEntry, .editDeleteEntry, .none:
             fatalError("Unexpected")
         }
     }

--- a/LoopKitUI/Views/Settings Editors/TherapySetting+Settings.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySetting+Settings.swift
@@ -39,7 +39,7 @@ extension TherapySetting {
             return AnyView(CarbRatioInformationView(onExit: nil, mode: .settings))
         case .insulinSensitivity:
             return AnyView(InsulinSensitivityInformationView(onExit: nil, mode: .settings))
-        case .none:
+        case .none, .addNewEntry, .editDeleteEntry:
             return AnyView(Text("To be implemented"))
         }
     }

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -445,7 +445,7 @@ extension TherapySettingsView {
             return { dismiss in
                 AnyView(InsulinSensitivityScheduleEditor(mode: mode, therapySettingsViewModel: viewModel, didSave: dismiss).environment(\.dismissAction, dismiss))
             }
-        case .none:
+        case .none, .addNewEntry, .editDeleteEntry:
             break
         }
         return { _ in AnyView(Text("\(setting.title)")) }


### PR DESCRIPTION
There will be a series of commits using this branch for this Pull Request.

Each commit will modify a single information screen. (Well that was the idea, but of course that got changed as I worked through them).
A graphic will be added to the conversation for each screen as updated.

* modified BasalRatesInformationView.swift

Minor wording change to 3rd phrase.  
Addition of 4th and 5th phrase.

![BasalRatesInformationView_Update](https://user-images.githubusercontent.com/19607791/165650418-bd548803-dcfb-4edb-9106-9c3d1afe1434.png)

