### PR TITLE
workaround for Loop crashing on dev (2.3.0) due to assert(!suspend.isMutable)

### DIFF
--- a/LoopKit/InsulinKit/InsulinMath.swift
+++ b/LoopKit/InsulinKit/InsulinMath.swift
@@ -373,8 +373,6 @@ extension Collection where Element == DoseEntry {
                 reconciled.append(dose)
             case .basal, .tempBasal:
                 if lastSuspend == nil, let last = lastBasal {
-                    // assert(!last.isMutable)
-
                     let endDate = Swift.min(last.endDate, dose.startDate)
 
                     // Ignore 0-duration doses
@@ -386,8 +384,6 @@ extension Collection where Element == DoseEntry {
                 lastBasal = dose
             case .resume:
                 if let suspend = lastSuspend {
-                    assert(!suspend.isMutable)
-
                     reconciled.append(DoseEntry(
                         type: suspend.type,
                         startDate: suspend.startDate,
@@ -424,8 +420,6 @@ extension Collection where Element == DoseEntry {
                 }
             case .suspend:
                 if let last = lastBasal {
-                    // assert(!last.isMutable)
-
                     reconciled.append(DoseEntry(
                         type: last.type,
                         startDate: last.startDate,

--- a/LoopKit/InsulinKit/InsulinMath.swift
+++ b/LoopKit/InsulinKit/InsulinMath.swift
@@ -373,7 +373,7 @@ extension Collection where Element == DoseEntry {
                 reconciled.append(dose)
             case .basal, .tempBasal:
                 if lastSuspend == nil, let last = lastBasal {
-                    assert(!last.isMutable)
+                    // assert(!last.isMutable)
 
                     let endDate = Swift.min(last.endDate, dose.startDate)
 
@@ -424,7 +424,7 @@ extension Collection where Element == DoseEntry {
                 }
             case .suspend:
                 if let last = lastBasal {
-                    assert(!last.isMutable)
+                    // assert(!last.isMutable)
 
                     reconciled.append(DoseEntry(
                         type: last.type,


### PR DESCRIPTION
This is a workaround for Loop crashing on dev branch. 
This has been reported by @tazitoo, @kuryk322, @elnjensen and myself.

See discussion in:
* https://github.com/LoopKit/Loop/issues/1674
* https://github.com/LoopKit/LoopKit/issues/398

Note that is one more case on line 389, which I did not fix, because it didn't crash on that line for me.

```
  case .resume:
                if let suspend = lastSuspend {
                    assert(!suspend.isMutable)
```