### PR TITLE
Improve Afrezza Insulin Model

### DIFF
--- a/LoopKit/Insulin/ExponentialInsulinModelPreset.swift
+++ b/LoopKit/Insulin/ExponentialInsulinModelPreset.swift
@@ -27,7 +27,7 @@ extension ExponentialInsulinModelPreset {
         case .lyumjev:
             return .minutes(360)
         case .afrezza:
-            return .minutes(360)
+            return .minutes(300)
         }
     }
 
@@ -42,7 +42,7 @@ extension ExponentialInsulinModelPreset {
         case .lyumjev:
             return .minutes(55)
         case.afrezza:
-            return .minutes(30)
+            return .minutes(29)
         }
     }
 

--- a/LoopKit/Insulin/ExponentialInsulinModelPreset.swift
+++ b/LoopKit/Insulin/ExponentialInsulinModelPreset.swift
@@ -42,7 +42,7 @@ extension ExponentialInsulinModelPreset {
         case .lyumjev:
             return .minutes(55)
         case.afrezza:
-            return .minutes(19)
+            return .minutes(30)
         }
     }
 
@@ -57,7 +57,7 @@ extension ExponentialInsulinModelPreset {
         case .lyumjev:
             return .minutes(10)
         case.afrezza:
-            return .minutes(5)
+            return .minutes(10)
         }
     }
     


### PR DESCRIPTION
Changing some parameters of the model fit, per [this discussion on Zulip](https://loop.zulipchat.com/#narrow/stream/144182-development/topic/Afrezza.20insulin.20type).

My previous implementation was (incorrectly) fit to an insulin absorption curve, not a glucose infusion rate curve.

The parameters were estimated to match the purple curve in this plot, which is taken from the [Afrezza website](https://afrezzahcp.com/about-afrezza/).

![time_action_profiles](https://user-images.githubusercontent.com/8095080/173468087-a0d2b310-8380-4f16-9108-bbbd404773ea.png)

# Curve Fitting Methodology

1. Digitize the published plot with [WebPlotDigitizer](https://github.com/ankitrohatgi/WebPlotDigitizer).
2. Normalize digitized curve to have a maximum GIR of 1.
3. Optimize the Insulin Activity Curve using different loss functions with [L-BFGS-B](https://doi.org/10.1137/0916069).
4. Visually inspect the results and choose parameters that seem sensible.

# Choosing Afrezza Parameters

After fitting with several loss functions, I obtained these parameter values:

|loss_type | peakActivityTime| actionDuration|     delay|
|:---------|----------------:|--------------:|---------:|
|rmse      |         25.35840|       360.0000| 14.567972|
|msd       |         60.00000|       360.0000|  0.000000|
|mae       |         26.93182|       239.9962| 14.301885|
|mape      |         30.11783|       360.0000| 12.792466|
|smape     |         32.57058|       360.0000|  9.075338|
|mase      |         26.93486|       240.0239| 14.300999|

Graphically, they look like this:

![image](https://user-images.githubusercontent.com/8095080/173470734-a3acd00a-f66e-425b-9ebb-935547ae1ed4.png)

From here, I concluded that something between the `mape` and `mase` curves would be desirable.
All of the other insulin models currently use a `delay` parameter of 10 minutes.
I see no reason why we should have a _longer_ delay for Afrezza, so I set the delay to 10 minutes. actionDuration to 300 minutes, and peakActivityTime to 29 minutes.

That curve looks like this:
![image](https://user-images.githubusercontent.com/8095080/173471099-9e5c2314-6c83-4bfe-b06f-1be6e645b555.png)


Relevant code is documented [here](https://gist.github.com/damonbayer/cf65fafc26291dfd5c99fcc8437be985).