### PR TITLE
Do not embed SwiftCharts in LoopKitUI

### DIFF
--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -772,7 +772,6 @@
 		C1CB895925C8E7D900782BAC /* Modelv1v4.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = C1E84B8425C62FB100623C08 /* Modelv1v4.xcmappingmodel */; };
 		C1CCF1062858F07A0035389C /* SwiftCharts in Frameworks */ = {isa = PBXBuildFile; productRef = C1CCF1052858F07A0035389C /* SwiftCharts */; };
 		C1CCF1082858F1E10035389C /* SwiftCharts in Frameworks */ = {isa = PBXBuildFile; productRef = C1CCF1072858F1E10035389C /* SwiftCharts */; };
-		C1CCF1092858F1E10035389C /* SwiftCharts in Embed Frameworks */ = {isa = PBXBuildFile; productRef = C1CCF1072858F1E10035389C /* SwiftCharts */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		C1DD512B259FD8A600DE27AE /* InsulinTypeChooser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1742345259CD3ED00399C9D /* InsulinTypeChooser.swift */; };
 		C1DD517825A016E700DE27AE /* InsulinTypeSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1DD515A259FE3AB00DE27AE /* InsulinTypeSetting.swift */; };
 		C1DE4C2125A253BD007065F8 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1DE4C2025A253BD007065F8 /* Color.swift */; };
@@ -978,7 +977,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				C1CCF1092858F1E10035389C /* SwiftCharts in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
This fixes an issue causing uploads to TestFlight to fail with the following error:

```
2022-06-24 16:56:57.326 *** Error: CFBundleIdentifier Collision. There is more than one bundle with the CFBundleIdentifier value 'SwiftCharts' under the iOS application 'Loop.app'. With error code STATE_ERROR.VALIDATION_ERROR.90685 for id 442acbb2-8016-452d-af3c-f861ab65be36 Asset validation failed (-19208)
 {
    NSLocalizedDescription = "CFBundleIdentifier Collision. There is more than one bundle with the CFBundleIdentifier value 'SwiftCharts' under the iOS application 'Loop.app'. With error code STATE_ERROR.VALIDATION_ERROR.90685 for id 442acbb2-8016-452d-af3c-f861ab65be36";
    NSLocalizedFailureReason = "Asset validation failed";
}
```

https://tidepool.atlassian.net/browse/LOOP-4116