### PR TITLE
Add ability to estimate delivery duration of bolus

### DIFF
--- a/LoopKit/DeviceManager/PumpManager.swift
+++ b/LoopKit/DeviceManager/PumpManager.swift
@@ -169,7 +169,7 @@ public protocol PumpManager: DeviceManager {
     func createBolusProgressReporter(reportingOn dispatchQueue: DispatchQueue) -> DoseProgressReporter?
 
     /// Returns the estimated time for the bolus amount to be delivered
-    func estimatedDuration(toDeliver bolusUnits: Double) -> TimeInterval
+    func estimatedDuration(toBolus units: Double) -> TimeInterval
     
     /// Send a bolus command and handle the result
     ///

--- a/LoopKit/DeviceManager/PumpManager.swift
+++ b/LoopKit/DeviceManager/PumpManager.swift
@@ -168,6 +168,9 @@ public protocol PumpManager: DeviceManager {
     /// Returns a dose estimator for the current bolus, if one is in progress
     func createBolusProgressReporter(reportingOn dispatchQueue: DispatchQueue) -> DoseProgressReporter?
 
+    /// Returns the estimated time for the bolus amount to be delivered
+    func estimatedDuration(toDeliver bolusUnits: Double) -> TimeInterval
+    
     /// Send a bolus command and handle the result
     ///
     /// - Parameters:

--- a/MockKit/MockPumpManager.swift
+++ b/MockKit/MockPumpManager.swift
@@ -265,8 +265,8 @@ public final class MockPumpManager: TestingPumpManager {
         }
     }
     
-    public func estimatedDuration(toDeliver bolusUnits: Double) -> TimeInterval {
-        .minutes(bolusUnits / type(of: self).deliveryUnitsPerMinute)
+    public func estimatedDuration(toBolus units: Double) -> TimeInterval {
+        .minutes(units / type(of: self).deliveryUnitsPerMinute)
     }
 
     public var state: MockPumpManagerState {

--- a/MockKit/MockPumpManager.swift
+++ b/MockKit/MockPumpManager.swift
@@ -264,6 +264,10 @@ public final class MockPumpManager: TestingPumpManager {
             observer.pumpManager(self, didUpdate: status, oldStatus: oldStatus)
         }
     }
+    
+    public func estimatedDuration(toDeliver bolusUnits: Double) -> TimeInterval {
+        .minutes(bolusUnits / type(of: self).deliveryUnitsPerMinute)
+    }
 
     public var state: MockPumpManagerState {
         didSet {


### PR DESCRIPTION
I added a function to the `PumpManager` protocol to support estimating the duration to deliver a bolus. I chose not to add it to `DoseProgress` / `DoseProgressReporter` since I wanted to provide a lightweight function to compute the duration and `DoseProgressReporter` has a lot of other functionality (timers, observers, etc) that isn't needed for this specific usecase. We also already provide lightweight functions on `PumpManager` for computing things like the rounding to the specific bolus volume the pump supports.

See https://github.com/LoopKit/Loop/pull/1830, https://github.com/LoopKit/OmniBLE/pull/68, and https://github.com/ps2/rileylink_ios/pull/751 for other associated changes.