### PR TITLE
Fix Loop-dev crash from Correction Range accepted by Onboarding

### DIFF
--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		14B33265293ED44C009B8746 /* GlucoseRangeSchedule+SafeBounds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B33264293ED44C009B8746 /* GlucoseRangeSchedule+SafeBounds.swift */; };
 		1D096BFA24C242300078B6B5 /* CheckmarkListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D096BF924C242300078B6B5 /* CheckmarkListItem.swift */; };
 		1D096C0224C24C220078B6B5 /* InsulinModelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D096BFF24C24C220078B6B5 /* InsulinModelProvider.swift */; };
 		1D096C0324C24C220078B6B5 /* ExponentialInsulinModelPreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D096C0024C24C220078B6B5 /* ExponentialInsulinModelPreset.swift */; };
@@ -990,6 +991,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		14B33264293ED44C009B8746 /* GlucoseRangeSchedule+SafeBounds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GlucoseRangeSchedule+SafeBounds.swift"; sourceTree = "<group>"; };
 		1D096BF924C242300078B6B5 /* CheckmarkListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckmarkListItem.swift; sourceTree = "<group>"; };
 		1D096BFF24C24C220078B6B5 /* InsulinModelProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsulinModelProvider.swift; sourceTree = "<group>"; };
 		1D096C0024C24C220078B6B5 /* ExponentialInsulinModelPreset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExponentialInsulinModelPreset.swift; sourceTree = "<group>"; };
@@ -2349,6 +2351,7 @@
 				4378B64A1ED61965000AE785 /* GlucoseEffectVelocity.swift */,
 				B455F4D22600DA0B000ED456 /* GlucoseRange.swift */,
 				43D8FDEB1C7290350073BE78 /* GlucoseRangeSchedule.swift */,
+				14B33264293ED44C009B8746 /* GlucoseRangeSchedule+SafeBounds.swift */,
 				43D8FDEC1C7290350073BE78 /* GlucoseSchedule.swift */,
 				A9498D7423386C3200DAA9B9 /* GlucoseThreshold.swift */,
 				43D9888A1C87E47800DA4467 /* GlucoseValue.swift */,
@@ -3918,6 +3921,7 @@
 				B42A7472235885B600247B03 /* LoopNotificationUserInfoKey.swift in Sources */,
 				B4B85FCD24A2312000A296A3 /* GlucoseRangeCategory.swift in Sources */,
 				43C9805C212D216A003B5D17 /* GlucoseChange.swift in Sources */,
+				14B33265293ED44C009B8746 /* GlucoseRangeSchedule+SafeBounds.swift in Sources */,
 				43D8FDFB1C7290350073BE78 /* GlucoseSchedule.swift in Sources */,
 				4322B77A202FA2790002837D /* NSUserDefaults.swift in Sources */,
 				4322B776202FA2790002837D /* CarbStore.swift in Sources */,

--- a/LoopKit/GlucoseRangeSchedule+SafeBounds.swift
+++ b/LoopKit/GlucoseRangeSchedule+SafeBounds.swift
@@ -10,18 +10,14 @@ import Foundation
 import HealthKit
 
 extension GlucoseRangeSchedule {
-    public func safeSchedule(with suspendThreshold: GlucoseThreshold?) -> GlucoseRangeSchedule? {
-        var glucoseScheduleMinimunValue: Double!
-        if let threshold = suspendThreshold {
-            glucoseScheduleMinimunValue = Guardrail.minCorrectionRangeValue(suspendThreshold: threshold).doubleValue(for: threshold.unit)
-        }
-        else {
-            glucoseScheduleMinimunValue = Guardrail.correctionRange.absoluteBounds.lowerBound.doubleValue(for: .milligramsPerDeciliter)
-        }
-        return rangeScheduleWithMin(min: glucoseScheduleMinimunValue)
-    }
-
-    private func rangeScheduleWithMin(min: Double) -> GlucoseRangeSchedule? {
+    public func safeSchedule(with suspendThreshold: Double?, unit: HKUnit) -> GlucoseRangeSchedule? {
+        var min: Double!
+        min = [
+            suspendThreshold,
+            Guardrail.correctionRange.absoluteBounds.lowerBound.doubleValue(for: unit)
+        ]
+            .compactMap({ $0 })
+            .max()
         let filteredItems = rangeSchedule.valueSchedule.items.map { scheduleValue in
             let newScheduleValue = DoubleRange(minValue: max(min, scheduleValue.value.minValue), maxValue: max(min, scheduleValue.value.maxValue))
             return RepeatingScheduleValue(startTime: scheduleValue.startTime, value: newScheduleValue)

--- a/LoopKit/GlucoseRangeSchedule+SafeBounds.swift
+++ b/LoopKit/GlucoseRangeSchedule+SafeBounds.swift
@@ -10,14 +10,15 @@ import Foundation
 import HealthKit
 
 extension GlucoseRangeSchedule {
-    public func safeSchedule(with suspendThreshold: Double?, unit: HKUnit) -> GlucoseRangeSchedule? {
+    public func safeSchedule(with suspendThreshold: HKQuantity?) -> GlucoseRangeSchedule? {
         let minGlucoseValue = [
-            suspendThreshold,
-            Guardrail.correctionRange.absoluteBounds.lowerBound.doubleValue(for: unit)
+            suspendThreshold?.doubleValue(for: self.unit),
+            Guardrail.correctionRange.absoluteBounds.lowerBound.doubleValue(for: self.unit)
         ]
             .compactMap({ $0 })
             .max()!
-        let maxGlucoseValue = Guardrail.correctionRange.absoluteBounds.upperBound.doubleValue(for: unit)
+        
+        let maxGlucoseValue = Guardrail.correctionRange.absoluteBounds.upperBound.doubleValue(for: self.unit)
         
         func safeGlucoseValue(_ initialValue: Double) -> Double {
             return max(minGlucoseValue, min(maxGlucoseValue, initialValue))

--- a/LoopKit/GlucoseRangeSchedule+SafeBounds.swift
+++ b/LoopKit/GlucoseRangeSchedule+SafeBounds.swift
@@ -1,0 +1,34 @@
+//
+//  GlucoseRangeSchedule+SafeBounds.swift
+//  LoopKit
+//
+//  Created by Noah Brauner on 12/5/22.
+//  Copyright © 2022 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+import HealthKit
+
+extension GlucoseRangeSchedule {
+    public func safeSchedule(with suspendThreshold: GlucoseThreshold?) -> GlucoseRangeSchedule? {
+        var glucoseScheduleMinimunValue: Double!
+        if let threshold = suspendThreshold {
+            glucoseScheduleMinimunValue = Guardrail.minCorrectionRangeValue(suspendThreshold: threshold).doubleValue(for: threshold.unit)
+        }
+        else {
+            glucoseScheduleMinimunValue = Guardrail.correctionRange.absoluteBounds.lowerBound.doubleValue(for: .milligramsPerDeciliter)
+        }
+        return rangeScheduleWithMin(min: glucoseScheduleMinimunValue)
+    }
+
+    private func rangeScheduleWithMin(min: Double) -> GlucoseRangeSchedule? {
+        let filteredItems = rangeSchedule.valueSchedule.items.map { scheduleValue in
+            let newScheduleValue = DoubleRange(minValue: max(min, scheduleValue.value.minValue), maxValue: max(min, scheduleValue.value.maxValue))
+            return RepeatingScheduleValue(startTime: scheduleValue.startTime, value: newScheduleValue)
+        }
+        guard let filteredRangeSchedule = DailyQuantitySchedule(unit: rangeSchedule.unit, dailyItems: filteredItems) else {
+            return nil
+        }
+        return GlucoseRangeSchedule(rangeSchedule: filteredRangeSchedule, override: self.override)
+    }
+}

--- a/LoopKitUI/ViewModels/CorrectionRangeScheduleEditorViewModel.swift
+++ b/LoopKitUI/ViewModels/CorrectionRangeScheduleEditorViewModel.swift
@@ -25,8 +25,8 @@ struct CorrectionRangeScheduleEditorViewModel {
         therapySettingsViewModel: TherapySettingsViewModel,
         didSave: (() -> Void)? = nil
     ) {
-        if mode == .acceptanceFlow, let unsafeSchedule = therapySettingsViewModel.glucoseTargetRangeSchedule {
-            self.glucoseTargetRangeSchedule = unsafeSchedule.safeSchedule(with: therapySettingsViewModel.suspendThreshold?.value, unit: unsafeSchedule.unit)
+        if mode == .acceptanceFlow {
+            self.glucoseTargetRangeSchedule = therapySettingsViewModel.glucoseTargetRangeSchedule?.safeSchedule(with: therapySettingsViewModel.suspendThreshold?.quantity)
         }
         else {
             self.glucoseTargetRangeSchedule = therapySettingsViewModel.glucoseTargetRangeSchedule

--- a/LoopKitUI/ViewModels/CorrectionRangeScheduleEditorViewModel.swift
+++ b/LoopKitUI/ViewModels/CorrectionRangeScheduleEditorViewModel.swift
@@ -23,7 +23,7 @@ struct CorrectionRangeScheduleEditorViewModel {
     init(therapySettingsViewModel: TherapySettingsViewModel,
          didSave: (() -> Void)? = nil)
     {
-        self.glucoseTargetRangeSchedule = therapySettingsViewModel.glucoseTargetRangeSchedule
+        self.glucoseTargetRangeSchedule = therapySettingsViewModel.glucoseTargetRangeSchedule?.safeSchedule(with: therapySettingsViewModel.suspendThreshold)
         self.minValue = Guardrail.minCorrectionRangeValue(suspendThreshold: therapySettingsViewModel.suspendThreshold)
         self.saveGlucoseTargetRangeSchedule = { [weak therapySettingsViewModel] glucoseTargetRangeSchedule in
             guard let therapySettingsViewModel = therapySettingsViewModel else {

--- a/LoopKitUI/ViewModels/CorrectionRangeScheduleEditorViewModel.swift
+++ b/LoopKitUI/ViewModels/CorrectionRangeScheduleEditorViewModel.swift
@@ -20,10 +20,17 @@ struct CorrectionRangeScheduleEditorViewModel {
 
     var saveGlucoseTargetRangeSchedule: (_ glucoseTargetRangeSchedule: GlucoseRangeSchedule) -> Void
 
-    init(therapySettingsViewModel: TherapySettingsViewModel,
-         didSave: (() -> Void)? = nil)
-    {
-        self.glucoseTargetRangeSchedule = therapySettingsViewModel.glucoseTargetRangeSchedule?.safeSchedule(with: therapySettingsViewModel.suspendThreshold)
+    init(
+        mode: SettingsPresentationMode,
+        therapySettingsViewModel: TherapySettingsViewModel,
+        didSave: (() -> Void)? = nil
+    ) {
+        if mode == .acceptanceFlow, let unsafeSchedule = therapySettingsViewModel.glucoseTargetRangeSchedule {
+            self.glucoseTargetRangeSchedule = unsafeSchedule.safeSchedule(with: therapySettingsViewModel.suspendThreshold?.value, unit: unsafeSchedule.unit)
+        }
+        else {
+            self.glucoseTargetRangeSchedule = therapySettingsViewModel.glucoseTargetRangeSchedule
+        }
         self.minValue = Guardrail.minCorrectionRangeValue(suspendThreshold: therapySettingsViewModel.suspendThreshold)
         self.saveGlucoseTargetRangeSchedule = { [weak therapySettingsViewModel] glucoseTargetRangeSchedule in
             guard let therapySettingsViewModel = therapySettingsViewModel else {

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeScheduleEditor.swift
@@ -36,10 +36,17 @@ public struct CorrectionRangeScheduleEditor: View {
         didSave: (() -> Void)? = nil
     ) {
         self.mode = mode
-        self._scheduleItems = State(initialValue: therapySettingsViewModel.glucoseTargetRangeSchedule?.safeSchedule(with: therapySettingsViewModel.suspendThreshold)?.quantityRanges ?? [])
+        if mode == .acceptanceFlow, let unsafeSchedule = therapySettingsViewModel.glucoseTargetRangeSchedule {
+            self._scheduleItems = State(initialValue: unsafeSchedule.safeSchedule(with: therapySettingsViewModel.suspendThreshold?.value, unit: unsafeSchedule.unit)?.quantityRanges ?? [])
+        }
+        else {
+            self._scheduleItems = State(initialValue: therapySettingsViewModel.glucoseTargetRangeSchedule?.quantityRanges ?? [])
+        }
         self.viewModel = CorrectionRangeScheduleEditorViewModel(
+            mode: mode,
             therapySettingsViewModel: therapySettingsViewModel,
-            didSave: didSave)
+            didSave: didSave
+        )
     }
 
     public var body: some View {

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeScheduleEditor.swift
@@ -36,8 +36,8 @@ public struct CorrectionRangeScheduleEditor: View {
         didSave: (() -> Void)? = nil
     ) {
         self.mode = mode
-        if mode == .acceptanceFlow, let unsafeSchedule = therapySettingsViewModel.glucoseTargetRangeSchedule {
-            self._scheduleItems = State(initialValue: unsafeSchedule.safeSchedule(with: therapySettingsViewModel.suspendThreshold?.value, unit: unsafeSchedule.unit)?.quantityRanges ?? [])
+        if mode == .acceptanceFlow {
+            self._scheduleItems = State(initialValue: therapySettingsViewModel.glucoseTargetRangeSchedule?.safeSchedule(with: therapySettingsViewModel.suspendThreshold?.quantity)?.quantityRanges ?? [])
         }
         else {
             self._scheduleItems = State(initialValue: therapySettingsViewModel.glucoseTargetRangeSchedule?.quantityRanges ?? [])

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeScheduleEditor.swift
@@ -36,7 +36,7 @@ public struct CorrectionRangeScheduleEditor: View {
         didSave: (() -> Void)? = nil
     ) {
         self.mode = mode
-        self._scheduleItems = State(initialValue: therapySettingsViewModel.glucoseTargetRangeSchedule?.quantityRanges ?? [])
+        self._scheduleItems = State(initialValue: therapySettingsViewModel.glucoseTargetRangeSchedule?.safeSchedule(with: therapySettingsViewModel.suspendThreshold)?.quantityRanges ?? [])
         self.viewModel = CorrectionRangeScheduleEditorViewModel(
             therapySettingsViewModel: therapySettingsViewModel,
             didSave: didSave)


### PR DESCRIPTION
Addressing the [issue](https://github.com/LoopKit/Loop/issues/1853) posted by Marion. Created a new extension with functions to ensure that the values presented in the UI are at minimum equal to the minValue (the maximum of 87 and the suspend threshold). This will prevent the bounds crash noted in Marions issue report.