### PR TITLE
Store the history without the conflicting overrides

### DIFF
--- a/LoopKit/TemporaryScheduleOverrideHistory.swift
+++ b/LoopKit/TemporaryScheduleOverrideHistory.swift
@@ -271,6 +271,9 @@ public final class TemporaryScheduleOverrideHistory {
             // Wipe only conflicting overrides to retain as much history as possible.
             recentEvents.removeAll(at: invalidOverrideIndices)
 
+            // Store the history without the conflicting overrides
+            delegate?.temporaryScheduleOverrideHistoryDidUpdate(self)
+
             // Crash deliberately to notify something has gone wrong.
             preconditionFailure("No overrides should overlap.")
         }


### PR DESCRIPTION
Overlapping overrides was filtered out, but the cleaned list was never stored/persisted before exiting. 

Next time loop starts, it will crash with the same error.