### PR TITLE
Fixes for HealthKit unresponsiveness and Loop crash

### DIFF
--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -242,10 +242,8 @@ public final class CarbStore: HealthKitSampleStore {
             self.settings = CarbModelSettings(absorptionModel: PiecewiseLinearAbsorption(), initialAbsorptionTimeOverrun: 1.0, adaptiveAbsorptionRateEnabled: true, adaptiveRateStandbyIntervalFraction: 0.2)
         }
 
-        let semaphore = DispatchSemaphore(value: 0)
         cacheStore.onReady { (error) in
             guard error == nil else {
-                semaphore.signal()
                 return
             }
             
@@ -258,12 +256,9 @@ public final class CarbStore: HealthKitSampleStore {
                     }
 
                     self.migrateLegacyCarbEntryKeys()
-                    
-                    semaphore.signal()
                 }
             }
         }
-        semaphore.wait()
     }
 
     // Migrate modifiedCarbEntries and deletedCarbEntryIDs

--- a/LoopKit/GlucoseKit/GlucoseStore.swift
+++ b/LoopKit/GlucoseKit/GlucoseStore.swift
@@ -132,10 +132,8 @@ public final class GlucoseStore: HealthKitSampleStore {
                    observationStart: Date(timeIntervalSinceNow: -self.observationInterval),
                    observationEnabled: observationEnabled)
 
-        let semaphore = DispatchSemaphore(value: 0)
         cacheStore.onReady { (error) in
             guard error == nil else {
-                semaphore.signal()
                 return
             }
 
@@ -148,12 +146,9 @@ public final class GlucoseStore: HealthKitSampleStore {
                     }
 
                     self.updateLatestGlucose()
-
-                    semaphore.signal()
                 }
             }
         }
-        semaphore.wait()
     }
 
     // MARK: - HealthKitSampleStore

--- a/LoopKit/InsulinKit/DoseStore.swift
+++ b/LoopKit/InsulinKit/DoseStore.swift
@@ -182,6 +182,7 @@ public final class DoseStore {
     /// Window for retrieving historical doses that might be used to reconcile current events
     private let pumpEventReconciliationWindow = TimeInterval(hours: 24)
 
+    
     // MARK: -
 
     /// Initializes and configures a new store
@@ -201,6 +202,7 @@ public final class DoseStore {
     ///   - syncVersion: A version number for determining resolution in de-duplication
     ///   - lastPumpEventsReconciliation: The date the PumpManger last reconciled with the pump
     ///   - provenanceIdentifier: An id to store with new doses, indicating the provenance of the dose, usually the app's bundle identifier.
+    ///   - readyCallback: A closure that will be called after initialization.
     ///   - test_currentDate: Used for testing to mock current time
     public init(
         healthStore: HKHealthStore,
@@ -217,6 +219,7 @@ public final class DoseStore {
         syncVersion: Int = 1,
         lastPumpEventsReconciliation: Date? = nil,
         provenanceIdentifier: String,
+        onReady: ((DoseStoreError?) -> Void)? = nil,
         test_currentDate: Date? = nil
     ) {
         self.insulinDeliveryStore = InsulinDeliveryStore(
@@ -243,6 +246,7 @@ public final class DoseStore {
 
         persistenceController.onReady { (error) -> Void in
             guard error == nil else {
+                onReady?(.init(error: error))
                 return
             }
 
@@ -259,6 +263,8 @@ public final class DoseStore {
 
                 // Validate the state of the stored reservoir data.
                 self.validateReservoirContinuity()
+
+                onReady?(nil)
             }
         }
     }
@@ -993,6 +999,7 @@ extension DoseStore {
                 return
             }
 
+            self.log.debug("Overlaying basal schedule for %d doses starting at %@", doses.count, String(describing: startingAt))
             let reconciledDoses = doses.overlayBasalSchedule(basalSchedule, startingAt: startingAt, insertingBasalEntries: !self.pumpRecordsBasalProfileStartEvents)
             completion(.success(reconciledDoses))
         }

--- a/LoopKit/InsulinKit/InsulinDeliveryStore.swift
+++ b/LoopKit/InsulinKit/InsulinDeliveryStore.swift
@@ -102,6 +102,7 @@ public class InsulinDeliveryStore: HealthKitSampleStore {
             cacheStore.fetchAnchor(key: InsulinDeliveryStore.healthKitQueryAnchorMetadataKey) { (anchor) in
                 self.queue.async {
                     self.queryAnchor = anchor
+                    self.log.default("Fetched hk query anchor: %{public}@", String(describing: anchor))
 
                     if !self.authorizationRequired {
                         self.createQuery()

--- a/LoopKit/InsulinKit/InsulinDeliveryStore.swift
+++ b/LoopKit/InsulinKit/InsulinDeliveryStore.swift
@@ -90,11 +90,13 @@ public class InsulinDeliveryStore: HealthKitSampleStore {
             test_currentDate: test_currentDate
         )
 
-        let semaphore = DispatchSemaphore(value: 0)
         cacheStore.onReady { (error) in
             guard error == nil else {
-                semaphore.signal()
                 return
+            }
+
+            self.queue.async {
+                self.updateLastImmutableBasalEndDate()
             }
 
             cacheStore.fetchAnchor(key: InsulinDeliveryStore.healthKitQueryAnchorMetadataKey) { (anchor) in
@@ -104,14 +106,9 @@ public class InsulinDeliveryStore: HealthKitSampleStore {
                     if !self.authorizationRequired {
                         self.createQuery()
                     }
-
-                    self.updateLastImmutableBasalEndDate()
-
-                    semaphore.signal()
                 }
             }
         }
-        semaphore.wait()
     }
     
     // MARK: - HealthKitSampleStore

--- a/LoopKit/Persistence/PersistenceController.swift
+++ b/LoopKit/Persistence/PersistenceController.swift
@@ -52,14 +52,6 @@ public final class PersistenceController {
         }
     }
 
-    private enum ReadyState {
-        case waiting
-        case ready
-        case error(PersistenceControllerError)
-    }
-
-    public typealias ReadyCallback = (_ error: PersistenceControllerError?) -> Void
-
     internal let managedObjectContext: NSManagedObjectContext
 
     public let isReadOnly: Bool
@@ -69,6 +61,34 @@ public final class PersistenceController {
     public weak var delegate: PersistenceControllerDelegate?
 
     private let log = OSLog(category: "PersistenceController")
+
+    private var queue = DispatchQueue(label: "com.loopkit.PersistenceController", qos: .utility)
+
+    // MARK: - ReadyState
+    private enum ReadyState {
+        case waiting
+        case ready
+        case error(PersistenceControllerError)
+    }
+
+    public typealias ReadyCallback = (_ error: PersistenceControllerError?) -> Void
+
+    private var readyCallbacks: [ReadyCallback] = []
+
+    private var readyState: ReadyState = .waiting
+
+    func onReady(_ callback: @escaping ReadyCallback) {
+        queue.async {
+            switch self.readyState {
+            case .waiting:
+                self.readyCallbacks.append(callback)
+            case .ready:
+                callback(nil)
+            case .error(let error):
+                callback(error)
+            }
+        }
+    }
 
     /// Initializes a new persistence controller in the specified directory
     ///
@@ -99,25 +119,6 @@ public final class PersistenceController {
         self.isReadOnly = isReadOnly
         
         initializeStack(inDirectory: directoryURL, model: model)
-    }
-
-    private var readyCallbacks: [ReadyCallback] = []
-
-    private var readyState: ReadyState = .waiting
-
-    private var queue = DispatchQueue(label: "com.loopkit.PersistenceController", qos: .utility)
-
-    func onReady(_ callback: @escaping ReadyCallback) {
-        queue.async {
-            switch self.readyState {
-            case .waiting:
-                self.readyCallbacks.append(callback)
-            case .ready:
-                callback(nil)
-            case .error(let error):
-                callback(error)
-            }
-        }
     }
 
     @discardableResult

--- a/LoopKit/Persistence/PersistenceController.swift
+++ b/LoopKit/Persistence/PersistenceController.swift
@@ -264,10 +264,11 @@ extension PersistenceController {
             if let encoded = value as? Data {
                 let anchor = try? NSKeyedUnarchiver.unarchivedObject(ofClass: HKQueryAnchor.self, from: encoded)
                 if anchor == nil {
-                    self.log.error("Decoding anchor from %{public} failed.", String(describing: encoded))
+                    self.log.error("Decoding anchor from %{public}@ failed.", String(describing: encoded))
                 }
                 completion(anchor)
             } else {
+                self.log.error("Anchor metadata invalid %{public}@.", String(describing: value))
                 completion(nil)
             }
         }

--- a/LoopKitTests/DoseStoreTests.swift
+++ b/LoopKitTests/DoseStoreTests.swift
@@ -203,21 +203,29 @@ class DoseStoreTests: PersistenceControllerTestCase {
         // 1. Create a DoseStore
         let healthStore = HKHealthStoreMock()
 
+        let doseStoreInitialization = expectation(description: "Expect DoseStore to finish initialization")
+
         let doseStore = DoseStore(
             healthStore: healthStore,
             cacheStore: cacheStore,
             observationEnabled: false,
             insulinModelProvider: StaticInsulinModelProvider(WalshInsulinModel(actionDuration: .hours(4))),
             longestEffectDuration: .hours(4),
-            basalProfile: BasalRateSchedule(rawValue: ["timeZone": -28800, "items": [["value": 0.75, "startTime": 0.0], ["value": 0.8, "startTime": 10800.0], ["value": 0.85, "startTime": 32400.0], ["value": 1.0, "startTime": 68400.0]]]),
+            basalProfile: BasalRateSchedule(rawValue: ["timeZone": -28800, "items": [ // Timezone = -0800
+                ["value": 0.75, "startTime": 0.0],       // 0000 - Midnight
+                ["value": 0.8, "startTime": 10800.0],    // 0300 - 3am
+                ["value": 0.85, "startTime": 32400.0],   // 0900 - 9am
+                ["value": 1.0, "startTime": 68400.0]]]), // 1900 - 7pm
             insulinSensitivitySchedule: InsulinSensitivitySchedule(rawValue: ["unit": "mg/dL", "timeZone": -28800, "items": [["value": 40.0, "startTime": 0.0], ["value": 35.0, "startTime": 21600.0], ["value": 40.0, "startTime": 57600.0]]]),
             syncVersion: 1,
             provenanceIdentifier: Bundle.main.bundleIdentifier!,
+            onReady: { _ in doseStoreInitialization.fulfill() },
 
             // Set the current date
             test_currentDate: f("2018-12-12 18:07:14 +0000")
         )
 
+        waitForExpectations(timeout: 3)
 
         // 2. Add a temp basal which has already ended. It should be saved to Health
         let pumpEvents1 = [
@@ -314,6 +322,8 @@ class DoseStoreTests: PersistenceControllerTestCase {
         // Create a DoseStore
         let healthStore = HKHealthStoreMock()
 
+        let doseStoreInitialization = expectation(description: "Expect DoseStore to finish initialization")
+
         let doseStore = DoseStore(
             healthStore: healthStore,
             cacheStore: cacheStore,
@@ -325,9 +335,14 @@ class DoseStoreTests: PersistenceControllerTestCase {
             syncVersion: 1,
             provenanceIdentifier: Bundle.main.bundleIdentifier!,
 
+            onReady: { _ in doseStoreInitialization.fulfill() },
+
             // Set the current date (5 minutes later)
             test_currentDate: f("2018-11-29 11:04:27 +0000")
         )
+
+        waitForExpectations(timeout: 3)
+
         doseStore.pumpRecordsBasalProfileStartEvents = false
 
         doseStore.insulinDeliveryStore.test_lastImmutableBasalEndDate = f("2018-11-29 10:54:28 +0000")
@@ -481,6 +496,9 @@ class DoseStoreTests: PersistenceControllerTestCase {
             return formatter.date(from: input)!
         }
 
+        let doseStoreInitialization = expectation(description: "Expect DoseStore to finish initialization")
+
+
         // 1. Create a DoseStore
         let doseStore = DoseStore(
             healthStore: HKHealthStoreMock(),
@@ -493,9 +511,12 @@ class DoseStoreTests: PersistenceControllerTestCase {
             syncVersion: 1,
             provenanceIdentifier: Bundle.main.bundleIdentifier!,
 
+            onReady: { _ in doseStoreInitialization.fulfill() },
+
             // Set the current date
             test_currentDate: f("2018-12-12 18:07:14 +0000")
         )
+        waitForExpectations(timeout: 3)
 
 
         // 2. Add a temp basal which has already ended. It should persist in InsulinDeliveryStore.
@@ -560,6 +581,9 @@ class DoseStoreTests: PersistenceControllerTestCase {
             return formatter.date(from: input)!
         }
 
+        let doseStoreInitialization = expectation(description: "Expect DoseStore to finish initialization")
+
+
         // 1. Create a DoseStore
         let doseStore = DoseStore(
             healthStore: HKHealthStoreMock(),
@@ -572,10 +596,12 @@ class DoseStoreTests: PersistenceControllerTestCase {
             syncVersion: 1,
             provenanceIdentifier: Bundle.main.bundleIdentifier!,
 
+            onReady: { _ in doseStoreInitialization.fulfill() },
             // Set the current date
             test_currentDate: f("2018-12-12 18:07:14 +0000")
         )
 
+        waitForExpectations(timeout: 3)
 
         // 2. Add a temp basal which has already ended. It should persist in InsulinDeliveryStore.
         let pumpEvents1 = [


### PR DESCRIPTION
This includes a couple of fixes to help deal with HealthKit sluggishness
* Data store initializers do not wait for HK authorization status before returning.
* HKAnchorQueries have a limit of 500, to process in batches, and queries will continue to be issued until anchor is caught up.