### PR TITLE
Reorder Therapy Settings cards to match onboarding order

### DIFF
--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -93,12 +93,12 @@ public struct TherapySettingsView: View {
         if !viewModel.sensitivityOverridesEnabled {
             cards.append(workoutCorrectionRangeSection)
         }
-        cards.append(carbRatioSection)
         cards.append(basalRatesSection)
         cards.append(deliveryLimitsSection)
         if viewModel.adultChildInsulinModelSelectionEnabled {
             cards.append(insulinModelSection)
         }
+        cards.append(carbRatioSection)
         cards.append(insulinSensitivitiesSection)
 
         return CardStack(cards: cards)


### PR DESCRIPTION
I noticed that the order in which Therapy Settings are presented during Onboarding is different from the order of cards on the Therapy Settings screen after onboarding.

I moved the Carb Ratio card to be just before the Insulin Sensitivity Factor screen to match the Onboarding order, which is:
* Glucose Safety Limit
* Correction Range
* PreMeal Range
* Basal Rate
* Delivery Limits
* Carb Ratio
* Insulin Sensitivity Factor