### PR TITLE
Remote PR Set #2: Introduce RemoteCommands

### DIFF
--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -519,6 +519,7 @@
 		A98ED5FC25312ED100FD8F70 /* HKAnchoredObjectQueryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E703612500390B00DAB534 /* HKAnchoredObjectQueryMock.swift */; };
 		A98ED5FE253132A400FD8F70 /* CarbStoreHKQueryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98ED5FD253132A400FD8F70 /* CarbStoreHKQueryTests.swift */; };
 		A994B884254241B10039B108 /* InsulinDeliveryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A994B883254241B10039B108 /* InsulinDeliveryStoreTests.swift */; };
+		A99A116229AA2C2B007919CE /* RemoteCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99A116129AA2C2A007919CE /* RemoteCommand.swift */; };
 		A99C7373233990D400C80963 /* TempBasalRecommendationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99C7372233990D400C80963 /* TempBasalRecommendationTests.swift */; };
 		A99C73772339A67A00C80963 /* GlucoseThresholdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99C73762339A67A00C80963 /* GlucoseThresholdTests.swift */; };
 		A99C73792339ACDC00C80963 /* ServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99C73782339ACDC00C80963 /* ServiceTests.swift */; };
@@ -1496,6 +1497,7 @@
 		A987CD4524A5893500439ADC /* JSONStreamEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONStreamEncoder.swift; sourceTree = "<group>"; };
 		A98ED5FD253132A400FD8F70 /* CarbStoreHKQueryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarbStoreHKQueryTests.swift; sourceTree = "<group>"; };
 		A994B883254241B10039B108 /* InsulinDeliveryStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsulinDeliveryStoreTests.swift; sourceTree = "<group>"; };
+		A99A116129AA2C2A007919CE /* RemoteCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteCommand.swift; sourceTree = "<group>"; };
 		A99C7372233990D400C80963 /* TempBasalRecommendationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempBasalRecommendationTests.swift; sourceTree = "<group>"; };
 		A99C73762339A67A00C80963 /* GlucoseThresholdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseThresholdTests.swift; sourceTree = "<group>"; };
 		A99C73782339ACDC00C80963 /* ServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceTests.swift; sourceTree = "<group>"; };
@@ -2871,6 +2873,7 @@
 			isa = PBXGroup;
 			children = (
 				A935793529A256F800246DED /* Actions */,
+				A99A116129AA2C2A007919CE /* RemoteCommand.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -4083,6 +4086,7 @@
 				4322B780202FA2AF0002837D /* PumpEvent+CoreDataClass.swift in Sources */,
 				89AE2227228BC54C00BDFD85 /* TemporaryScheduleOverride.swift in Sources */,
 				4322B784202FA2AF0002837D /* Reservoir+CoreDataProperties.swift in Sources */,
+				A99A116229AA2C2B007919CE /* RemoteCommand.swift in Sources */,
 				4322B778202FA2790002837D /* HKQuantitySample+CarbKit.swift in Sources */,
 				4322B771202FA26F0002837D /* HKQuantitySample+GlucoseKit.swift in Sources */,
 				433BC7AB20538D4C000B1200 /* CachedGlucoseObject+CoreDataProperties.swift in Sources */,

--- a/LoopKit/Service/Remote/RemoteCommand.swift
+++ b/LoopKit/Service/Remote/RemoteCommand.swift
@@ -1,0 +1,13 @@
+//
+//  RemoteCommand.swift
+//  LoopKit
+//
+//  Created by Bill Gestrich on 2/25/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+public protocol RemoteCommand {
+    var id: String {get}
+    var action: Action {get}
+    func validate() throws
+}

--- a/LoopKit/Service/RemoteDataService.swift
+++ b/LoopKit/Service/RemoteDataService.swift
@@ -104,11 +104,11 @@ public protocol RemoteDataService: Service {
     func uploadSettingsData(_ stored: [StoredSettings], completion: @escaping (_ result: Result<Bool, Error>) -> Void)
     
     /**
-     Validates a push notification originated from this data service.
+     Fetch a RemoteCommand from a push notification
      - Parameter notification: The push notification dictionary
-     - Returns: Success
+     - Returns: RemoteCommand
      */
-    func validatePushNotificationSource(_ notification: [String: AnyObject]) -> Result<Void, Error>
+    func commandFromPushNotification(_ notification: [String: AnyObject]) async throws -> RemoteCommand
 
 }
 
@@ -120,17 +120,4 @@ public extension RemoteDataService {
     var glucoseDataLimit: Int? { return nil }
     var pumpEventDataLimit: Int? { return nil }
     var settingsDataLimit: Int? { return nil }
-
-    func validatePushNotificationSource(_ notification: [String: AnyObject]) -> Result<Void, Error> { return .failure(PushNotificationValidationError.notificationsNotSupported) }
-}
-
-enum PushNotificationValidationError: LocalizedError {
-    case notificationsNotSupported
-    
-    var errorDescription: String? {
-        switch self {
-        case .notificationsNotSupported:
-            return "Service does not handle push notifications"
-        }
-    }
 }

--- a/MockKit/MockService.swift
+++ b/MockKit/MockService.swift
@@ -168,8 +168,12 @@ extension MockService: RemoteDataService {
         completion(.success(false))
     }
     
-    public func validatePushNotificationSource(_ notification: [String : AnyObject]) -> Result<Void, Error> {
-        return .success(Void())
+    public func commandFromPushNotification(_ notification: [String: AnyObject]) async throws -> RemoteCommand {
+        
+        enum MockServicePushNotificationError: LocalizedError {
+            case remoteCommandsNotSupported
+        }
+        
+        throw MockServicePushNotificationError.remoteCommandsNotSupported
     }
-    
 }


### PR DESCRIPTION
This PR is part of the below set that should be merged together. This one will use "RemoteCommands", a protocol for interacting with the remote services that is the source of the RemoteCommand. This will lay the groundwork for remote 2.0 commands.

* Loop: https://github.com/LoopKit/Loop/pull/1934
* LoopKit: https://github.com/LoopKit/LoopKit/pull/455
* NightscoutService: https://github.com/ps2/NightscoutService/pull/33
* TidepoolService: https://github.com/LoopKit/TidepoolService/pull/4