### PR TITLE
Remove duplicate emoji (potato)

### DIFF
--- a/LoopKitUI/CarbKit/FoodEmojiDataSource.swift
+++ b/LoopKitUI/CarbKit/FoodEmojiDataSource.swift
@@ -79,7 +79,6 @@ private class FoodEmojiDataSource: EmojiDataSource {
             "🫑", // bell pepper
             "🧅", // onion
             "🧄", // garlic
-            "🥔", // potato
             "🥒", // cucumber
             "🥗", // green salad
             "🥬", // leafy green


### PR DESCRIPTION
Removed duplicate emoji „potato“ from medium food sources. 