### PR TITLE
Fix mmol unit conversion for missed meal detection

### DIFF
--- a/LoopKit/GlucoseSchedule.swift
+++ b/LoopKit/GlucoseSchedule.swift
@@ -33,4 +33,9 @@ public extension InsulinSensitivitySchedule {
         precondition(glucoseUnit == .millimolesPerLiter || glucoseUnit == .milligramsPerDeciliter)
         return self.convertTo(unit: glucoseUnit)
     }
+    
+    func value(for glucoseUnit: HKUnit, at time: Date) -> Double {
+        let unconvertedValue = self.value(at: time)
+        return HKQuantity(unit: self.unit, doubleValue: unconvertedValue).doubleValue(for: glucoseUnit)
+    }
 }

--- a/LoopKitTests/InsulinSensitivityScheduleTests.swift
+++ b/LoopKitTests/InsulinSensitivityScheduleTests.swift
@@ -30,6 +30,11 @@ class InsulinSensitivityScheduleTests: XCTestCase {
                 RepeatingScheduleValue(startTime: 1000,
                                        value: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: value2).doubleValue(for: .millimolesPerLiter))
             ])
+        let date = Date()
         XCTAssertEqual(insulinSensitivityScheduleMGDL!.schedule(for: .millimolesPerLiter), insulinSensitivityScheduleMMOLL!)
+        
+        
+        XCTAssertEqual(insulinSensitivityScheduleMGDL!.value(at: date), insulinSensitivityScheduleMMOLL!.value(for: .milligramsPerDeciliter, at: date))
+        XCTAssertEqual(insulinSensitivityScheduleMGDL!.value(at: date), insulinSensitivityScheduleMGDL!.value(for: .milligramsPerDeciliter, at: date))
     }
 }


### PR DESCRIPTION
This PR ensures the meal detection algorithm correctly converts mmol/L units into mg/dL when performing missed meal detection calculations.