### PR TITLE
make InstructionList usable with markdown content, to display links, bo…

### DIFF
--- a/LoopKitUI/Views/InstructionList.swift
+++ b/LoopKitUI/Views/InstructionList.swift
@@ -17,18 +17,24 @@ public struct InstructionList: View {
     let startingIndex: Int
     let instructionColor: Color
     
+    // Setting this to true will also disable swiftui's localization,
+    // so the instruction should in those cases be pre-localized in those cases
+    public var markdownEnabled: Bool
+    
     @Environment(\.isEnabled) var isEnabled
     
-    public init(instructions: [String], startingIndex: Int = 1, instructionColor: Color = .primary) {
+    public init(instructions: [String], startingIndex: Int = 1, instructionColor: Color = .primary, markdownEnabled : Bool = false) {
         self.instructions = instructions.map { Instruction(text: $0, subtext: nil) }
         self.startingIndex = startingIndex
         self.instructionColor = instructionColor
+        self.markdownEnabled = markdownEnabled
     }
     
-    public init(instructions: [(String, String)], startingIndex: Int = 1, instructionColor: Color = .primary) {
+    public init(instructions: [(String, String)], startingIndex: Int = 1, instructionColor: Color = .primary, markdownEnabled : Bool = false) {
         self.instructions = instructions.map { Instruction(text: $0.0, subtext: $0.1) }
         self.startingIndex = startingIndex
         self.instructionColor = instructionColor
+        self.markdownEnabled = markdownEnabled
     }
     
     public var body: some View {
@@ -42,7 +48,7 @@ public struct InstructionList: View {
                         .foregroundColor(Color.white)
                         .font(.caption)
                         .accessibility(label: Text("\(index+1), ")) // Adds a pause after the number
-                    instructionView(instructions[index])
+                    instructionView(instructions[index], markdownEnabled: markdownEnabled)
                 }
                 .accessibilityElement(children: .combine)
             }
@@ -50,15 +56,29 @@ public struct InstructionList: View {
     }
     
     @ViewBuilder
-    private func instructionView(_ instruction: Instruction) -> some View {
+    private func instructionView(_ instruction: Instruction, markdownEnabled: Bool = false) -> some View {
         VStack(alignment: .leading, spacing: 2) {
-            Text(instruction.text)
-                .fixedSize(horizontal: false, vertical: true)
-            if let subtext = instruction.subtext {
-                Text(subtext)
+            
+            if markdownEnabled {
+                Text(LocalizedStringKey(instruction.text))
                     .fixedSize(horizontal: false, vertical: true)
-                    .foregroundColor(isEnabled ? instructionColor : Color.secondary)
-                    .font(.caption)
+            } else {
+                Text(instruction.text)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            
+            if let subtext = instruction.subtext {
+                if markdownEnabled {
+                    Text(LocalizedStringKey(subtext))
+                        .fixedSize(horizontal: false, vertical: true)
+                        .foregroundColor(isEnabled ? instructionColor : Color.secondary)
+                        .font(.caption)
+                } else {
+                    Text(subtext)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .foregroundColor(isEnabled ? instructionColor : Color.secondary)
+                        .font(.caption)
+                }
             }
         }
         .padding(2)
@@ -70,9 +90,9 @@ struct InstructionList_Previews: PreviewProvider {
     static var previews: some View {
         let instructions: [String] = [
             "This is the first step.",
-            "This second step is a bit more tricky and needs more description to support the user, albeit it could be more concise.",
+            "This second step is a bit more tricky and needs **more** description to support the user or maybe a [link](https://google.com) with more info",
             "With this final step, the task will be accomplished."
         ]
-        return InstructionList(instructions: instructions)
+        return InstructionList(instructions: instructions, markdownEnabled: true)
     }
 }


### PR DESCRIPTION
@marionbarker requested for LibreTransmitter that the GuidePage for setting up new Libre sensors contain a clickable link to the readme file. 

This implements the necessary changes to the InstructionList in LoopKit to make this possible. Note that this implementation toggles "markdown mode" for all the instructions within an InstructionList rather than individually. 

The default is off, due to a couple of reasons:
* Potentially there could be callers to InstructionList containing text that would be interpreted as markdown where it shouldn't (backward compatibility )
* According to Apple documentation, when using LocalizedStringKey any localizations done automatically by swiftui will be turned off. Therefore, when enabling markdown mode, callers need to localize the text before passing it into InstructionList. (I.e. they must use NSLocalizedString) 

![iPhone_14_Pro_Max](https://github.com/LoopKit/LoopKit/assets/442324/21b52565-ab9e-4b3b-b15a-31dfaa82db19)


If this passes, I will followup with a PR for LibreTransmitter with the following changes (this is just for reference):
```diff
index e368540..a8a8475 100644
--- a/LibreTransmitterUI/Views/Setup/ModeSelectionView.swift
+++ b/LibreTransmitterUI/Views/Setup/ModeSelectionView.swift
@@ -58,6 +58,9 @@ struct ModeSelectionView: View {
         }// .accentColor(.red)
     }

+
+
+
     var body : some View {
         GuidePage(content: {
             VStack {
@@ -67,9 +70,9 @@ struct ModeSelectionView: View {
                     InstructionList(instructions: [
                         LocalizedString("Sensor should be activated and fully warmed up", comment: "Label text for step 1 of connection setup"),
                         LocalizedString("Select the type of setup you want.", comment: "Label text for step 2 of connection setup"),
-                        LocalizedString("Not all sensor types can be supported, see readme.md", comment: "Label text for step 3 of connection setup"),
-                        LocalizedString("Fair warning: The sensor will be not be using the manufacturer's algorithm, and some safety mitigations present in the manufacturers algorithm might be missing when you use this.", comment: "Label text for step 4 of connection setup")
-                    ])
+                        LocalizedString("Not all sensor types can be supported, see [readme.md](https://github.com/LoopKit/LibreTransmitter/blob/main/readme.md)", comment: "Label text for step 3 of connection setup"),
+                        LocalizedString("Fair warning: The sensor will be not be using the manufacturer's algorithm, and some safety mitigations present in the manufacturers algorithm might be missing when you use this.", comment: "Label text for step 4 of connection setup"),
+                    ], markdownEnabled: true)
                 }

             }
```
