### PR TITLE
Remove Loop Dependencies from Charts

### DIFF
--- a/LoopKitUI/ChartColorPalette.swift
+++ b/LoopKitUI/ChartColorPalette.swift
@@ -15,12 +15,14 @@ public struct ChartColorPalette {
     public let grid: UIColor
     public let glucoseTint: UIColor
     public let insulinTint: UIColor
+    public let carbTint: UIColor
 
-    public init(axisLine: UIColor, axisLabel: UIColor, grid: UIColor, glucoseTint: UIColor, insulinTint: UIColor) {
+    public init(axisLine: UIColor, axisLabel: UIColor, grid: UIColor, glucoseTint: UIColor, insulinTint: UIColor, carbTint: UIColor) {
         self.axisLine = axisLine
         self.axisLabel = axisLabel
         self.grid = grid
         self.glucoseTint = glucoseTint
         self.insulinTint = insulinTint
+        self.carbTint = carbTint
     }
 }

--- a/LoopKitUI/Extensions/Environment+Colors.swift
+++ b/LoopKitUI/Extensions/Environment+Colors.swift
@@ -110,7 +110,8 @@ private struct ChartColorPaletteKey: EnvironmentKey {
                                                                    axisLabel: .secondaryLabel,
                                                                    grid: .systemGray3,
                                                                    glucoseTint: .systemTeal,
-                                                                   insulinTint: .orange)
+                                                                   insulinTint: .orange,
+                                                                   carbTint: .systemGreen)
 }
 
 public extension EnvironmentValues {


### PR DESCRIPTION
In order to remove Caregiver's dependency on the Loop repo, I need to move certain charts from Loop to LoopKit. This PR will not move those charts yet but instead updates some chart APIs in prep for that.

* Use `ChartColorPalette` for chart colors: Charts use UIColor extension methods, like `insulinTintColor` which are not available in LoopKit. `ChartColorPalette` is available to LoopKit so this switches to using that. Additionally, I added `carbTint` to `ChartColorPalette` which was missing.
* This needs to merge with https://github.com/LoopKit/Loop/pull/2030