### PR TITLE
Clarify that button clears credentials

### DIFF
--- a/LoopKitUI/View Controllers/AuthenticationViewController.swift
+++ b/LoopKitUI/View Controllers/AuthenticationViewController.swift
@@ -110,7 +110,7 @@ public final class AuthenticationViewController<T: ServiceAuthenticationUI>: UIT
 
             switch state {
             case .authorized:
-                cell.textLabel?.text = LocalizedString("Delete", comment: "The title of the button to remove the credentials for a service")
+                cell.textLabel?.text = LocalizedString("Clear Credentials", comment: "The title of the button to remove the credentials for a service")
                 cell.tintColor = .systemRed
             case .empty, .unauthorized, .verifying:
                 cell.textLabel?.text = LocalizedString("Add Account", comment: "The title of the button to add the credentials for a service")


### PR DESCRIPTION
A Facebook user was confused by this button name when trying to add Nightscout as a Remote CGM. 

They had an invalid URL in their Nightscout account and did not understand that they needed to hit "Delete" in order to be able to enter a new URL and API_SECRET.

I believe changing this button from "Delete" to "Clear Credentials" would work for all services. It does what I expect for Nightscout.

![clear-creditials-button-text](https://github.com/LoopKit/LoopKit/assets/19607791/0f43b2d3-5bd7-439d-a871-902389313aa2)
