### PR TITLE
Allow critical event log to be exported with mixed 3.2.x and 3.3 formats

### DIFF
--- a/LoopKit/JSONStreamEncoder.swift
+++ b/LoopKit/JSONStreamEncoder.swift
@@ -45,9 +45,19 @@ public class JSONStreamEncoder {
         }
 
         for value in values {
-            try stream.write(encoded ? ",\n" : "[\n")
-            try stream.write(try Self.encoder.encode(value))
-            encoded = true
+            do {
+                let encodedData = try Self.encoder.encode(value)
+                try stream.write(encoded ? ",\n" : "[\n")
+                try stream.write(encodedData)
+                encoded = true
+            } catch {
+                // Log the error and insert a placeholder or error message in the JSON
+                print("Failed to encode value: \(value) with error: \(error.localizedDescription)")
+                let errorInfo = "{\"error\": \"Failed to encode item due to: \(error.localizedDescription)\"}"
+                try stream.write(encoded ? ",\n" : "[\n")
+                try stream.write(errorInfo.data(using: .utf8)!)
+                encoded = true
+            }
         }
     }
 

--- a/LoopKit/JSONStreamEncoder.swift
+++ b/LoopKit/JSONStreamEncoder.swift
@@ -53,7 +53,7 @@ public class JSONStreamEncoder {
             } catch {
                 // Log the error and insert a placeholder or error message in the JSON
                 print("Failed to encode value: \(value) with error: \(error.localizedDescription)")
-                let errorInfo = "{\"error\": \"Failed to encode item due to: \(error.localizedDescription)\"}"
+                let errorInfo = "{\"error\": \"Failed to encode value: \(value) due to: \(error.localizedDescription)\"}"
                 try stream.write(encoded ? ",\n" : "[\n")
                 try stream.write(errorInfo.data(using: .utf8)!)
                 encoded = true


### PR DESCRIPTION
When switching from version 3.3 or later code to an earlier version such as 3.2.x code, the Critical Event Log can no longer be exported (from with 3.2.x or 3.3 code). See [Loop Issue 2081: Export Critical Log fails](https://github.com/LoopKit/Loop/issues/2081) 

This work-around allows the export to continue past errors.
* The user will still not be able to export the Critical Event Log while running version 3.2.3 if they switched to 3.3 and back again
* The user will be able to export the Critical Event Log while running version 3.3
   * The caveat is that the DosingDecision.json files reports "Failure to encode" for all entries that occurred while user was running 3.2.x after running 3.3.

## Test 1
* test phone has been running 3.3 (commit ed8d7a0)
   * demonstrate success with Export Critical Event Log
* install 3.2.3 onto phone
   * demonstrate failure with Export Critical Event Log
* Add 2 carbs entries while on 3.2.3 version
* Return to 3.3
   * demonstrate failure with Export Critical Event Log
* Build with new version from this PR
   * demonstrate success with Export Critical Event Log
 
Examine the Critical Event Log for the current day:
* The Carb.json file contains all the entered carbs
* The DosingDecisions.json is the only json file with the "Failure to encode" indications:

```
% find . -name "*.json" -exec grep -Hn "Failed to encode" {} \;
./dev-after-fix-Export-20240422T131220Z/20240422T131220Z/DosingDecisions.json:115:{"error": "Failed to encode item due to: The data couldn’t be read because it is missing."},
./dev-after-fix-Export-20240422T131220Z/20240422T131220Z/DosingDecisions.json:116:{"error": "Failed to encode item due to: The data couldn’t be read because it is missing."},
```

