### PR TITLE
fix: Prevent app crash while moving presets

### DIFF
--- a/LoopKitUI/View Controllers/OverrideSelectionViewController.swift
+++ b/LoopKitUI/View Controllers/OverrideSelectionViewController.swift
@@ -388,7 +388,8 @@ public final class OverrideSelectionViewController: UICollectionViewController, 
             return originalIndexPath
         }
 
-        return proposedIndexPath == indexPathOfCustomOverride()
+        let customPresetRow = self.collectionView(collectionView, numberOfItemsInSection: proposedIndexPath.section) - 2
+        return proposedIndexPath.row >= customPresetRow
             ? originalIndexPath
             : proposedIndexPath
 


### PR DESCRIPTION
## Screen recording of crash:

https://github.com/user-attachments/assets/500ebf9a-6bbc-4884-9a47-c9faf9b66a4b
![Screenshot 2024-08-18 at 20 24 10](https://github.com/user-attachments/assets/2d16a59f-ae58-4f80-996b-219f9a5fe36a)

Reported by @bedtime4bonzos (https://github.com/LoopKit/Loop/issues/2210)

## Proposed fix
It feels like this wasn't an issue until the override history was added. But the fix is to check what the greater allowed index is, and everything above it to cap at the original index