### PR TITLE
Cleanup: Remove unused variable warning glucose per minute

### DIFF
--- a/MockKitUI/ViewModel/MockCGMManagerSettingsViewModel.swift
+++ b/MockKitUI/ViewModel/MockCGMManagerSettingsViewModel.swift
@@ -90,7 +90,6 @@ class MockCGMManagerSettingsViewModel: ObservableObject {
             lastGlucoseTrendFormatted = nil
             return
         }
-        let glucoseUnitPerMinute = displayGlucosePreference.unit.unitDivided(by: .minute())
         lastGlucoseTrendFormatted = displayGlucosePreference.formatMinuteRate(trendRate)
     }
     


### PR DESCRIPTION
- Ran script to build https://loopkit.github.io/loopdocs/build/build-app/?h=%2Fbin#build-select-script

## Before 

- Warning for unused variable
<img width="949" alt="Screenshot 2024-08-26 at 5 52 13 PM" src="https://github.com/user-attachments/assets/cb0a28c7-371b-4cf1-b18b-ff08da17c1e8">

## After 

- No warning. Removed unused variable