### PR TITLE
Swedish translations

### DIFF
--- a/LoopKit/QuantityFormatter.swift
+++ b/LoopKit/QuantityFormatter.swift
@@ -279,7 +279,7 @@ public extension HKUnit {
             if self == .hour() {
                 switch style {
                 case .short, .medium:
-                    return unitString
+                    return LocalizedString("hrs", comment: "The short unit display string for hours")
                 case .long:
                     fallthrough
                 @unknown default:

--- a/LoopKit/Resources/sv.lproj/Localizable.strings
+++ b/LoopKit/Resources/sv.lproj/Localizable.strings
@@ -13,11 +13,21 @@
 /* Descriptive text for guardrail low value warning for schedule interface */
 "A value you have entered is lower than what is typically recommended for most people." = "Det värde du har angett är lägre än vad som normalt rekommenderas för de flesta.";
 
+/* Brand name for afrezza insulin type
+   Title for Afrezza insulin type */
+"Afrezza" = "Afrezza";
+
+/* Description for afrezza insulin type */
+"Afrezza is an ultra rapid-acting mealtime insulin that is breathed in through your lungs using an oral inhaler and made by MannKind" = "Afrezza är ett ultrasnabbverkande måltidsinsulin som inhaleras genom lungorna med hjälp av en oral inhalator och tillverkas av MannKind";
+
 /* Brand name for apidra insulin type */
 "Apidra" = "Apidra";
 
 /* Title for Apidra insulin type */
 "Apidra (insulin glulisine)" = "Apidra (insulinglulisin)";
+
+/* Description for apidra insulin type */
+"Apidra (insulin glulisine) is a rapid-acting insulin made by Sanofi-aventis " = "Apidra (insulin glulisine) är ett snabbverkande insulin tillverkat av Sanofi-aventis ";
 
 /* Title for basal dose type */
 "Basal" = "Basal";
@@ -52,11 +62,23 @@
 /* Descriptive text for glucose target range (1: app name) */
 "Correction Range is the glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin and helping you calculate your boluses." = "Målvärde är det ideala blodsockerintervall som du vill att %1$@ ska hålla dig inom.";
 
+/* Description of critical software update needed */
+"Critical Update" = "Kritisk uppdatering";
+
 /* Title text for delivery limits */
 "Delivery Limits" = "Maxdoser";
 
 /* Generic pump error description */
 "Device Refused" = "Enhet vägrade";
+
+/* Accessibility label for device status critical state */
+"Device Status Critical" = "Enhetens status: kritisk";
+
+/* Accessibility label for device status normal state */
+"Device Status Normal" = "Enhetens status: normal";
+
+/* Accessibility label for device status warning state */
+"Device Status Warning" = "Enhetens status: varning";
 
 /* Recovery suggestion for a no data error */
 "Ensure carb data exists for the specified date" = "Kontrollera att kolhydratvärde finns";
@@ -87,13 +109,25 @@
 "g/U" = "g/E";
 
 /* Title text for glucose safety limit */
-"Glucose Safety Limit" = "Tröskelvärde för blodsocker";
+"Glucose Safety Limit" = "Tröskelvärde\nför blodsocker";
+
+/* The long unit display string for a singular hour */
+"Hour" = "timme";
+
+/* The long unit display string for hours */
+"Hours" = "timmar";
+
+/* The short unit display string for hours */
+"hrs" = "tim";
 
 /* Brand name for humalog insulin type */
 "Humalog" = "Humalog";
 
 /* Title for Humalog insulin type */
 "Humalog (insulin lispro)" = "Humalog (insulin lispro)";
+
+/* Description for humalog insulin type */
+"Humalog (insulin lispro) is a rapid-acting insulin made by Eli Lilly" = "Humalog (insulin lispro) är ett snabbverkande insulin tillverkat av Eli Lilly";
 
 /* Title text for fast acting insulin model */
 "Insulin Model" = "Insulinmodell";
@@ -104,11 +138,21 @@
 /* Generic pump error description */
 "Invalid Configuration" = "Ogiltig konfiguration";
 
+/* Brand name for lyumjev insulin type
+   Title for Lyumjev insulin type */
+"Lyumjev" = "Lyumjev";
+
+/* Description for lyumjev insulin type */
+"Lyumjev is a mealtime insulin lispro formulation with the addition of citrate and treprostinil made by Eli Lilly" = "Lyumjev är en måltidsinsulin av insulin lispro med tillsats av citrat och treprostinil, tillverkat av Eli Lilly";
+
 /* Recovery suggestion for uncertain delivery */
 "Make sure your pump is within communication range of your phone." = "Säkerställ att din pump är inom räckvidd för kommunikation med telefon.";
 
 /* Title text for maximum basal rate configuration */
 "Maximum Basal Rate" = "Maximal basaldos";
+
+/* Descriptive text for maximum basal rate (1: app name) */
+"Maximum Basal Rate is the highest temporary basal rate %1$@ is allowed to set." = "Maximal basaldos är den högsta temporära basalen %1$@ har lov att genomföra.";
 
 /* Title text for maximum bolus configuration */
 "Maximum Bolus" = "Maximal bolus";
@@ -116,17 +160,26 @@
 /* Descriptive text for maximum bolus */
 "Maximum Bolus is the highest bolus amount you can deliver at one time to cover carbs or bring down high glucose." = "Maximal bolus är den högsta bolusmängd som kan ges vid ett tillfälle för att täcka kolhydrater eller ett högt blodsocker.";
 
+/* The short unit display string for milligrams per liter per minute */
+"mg/dL/min" = "mg/dL/min";
+
 /* The short unit display string for milligrams per deciliter per U */
 "mg/dL/U" = "mg/dl/E";
 
 /* The short unit display string for millimoles per liter */
 "mmol/L" = "mmol/L";
 
+/* The short unit display string for millimoles per liter per minute */
+"mmol/L/min" = "mmol/L/min";
+
 /* The short unit display string for millimoles per liter per U */
 "mmol/L/U" = "mmol/L/E";
 
 /* Sensor state description for the non-valid state */
 "Needs Attention" = "Kräver uppmärksamhet";
+
+/* Description of no software update needed */
+"No Update" = "Ingen uppdatering";
 
 /* Describes an error for no data found in a CarbStore request */
 "No values found" = "Inga värden funna";
@@ -137,6 +190,9 @@
 /* Title for Novolog insulin type */
 "Novolog (insulin aspart)" = "Novolog (insulin aspart)";
 
+/* Description for novolog insulin type */
+"NovoLog (insulin aspart) is a rapid-acting insulin made by Novo Nordisk" = "NovoLog (insulin aspart) är ett snabbverkande insulin tillverkat av Novo Nordisk";
+
 /* Sensor state description for the valid state */
 "OK" = "OK";
 
@@ -145,6 +201,9 @@
 
 /* Title for pre-meal mode */
 "Pre-Meal" = "Före måltid";
+
+/* Description of supported software update needed */
+"Recommended Update" = "Rekommenderad uppdatering";
 
 /* Title for resume dose type */
 "Resumed" = "Återupptagen";
@@ -203,6 +262,9 @@
 /* The long unit display string for international units of insulin per hour */
 "Units/hour" = "Enhet/timme";
 
+/* Description of informational software update needed */
+"Update Available" = "Uppdatering tillgänglig";
+
 /* Title for workout mode */
 "Workout" = "Träning";
 
@@ -214,4 +276,3 @@
 
 /* Descriptive text for insulin sensitivity */
 "Your Insulin Sensitivities refer to the drop in glucose expected from one unit of insulin." = "Insulinkänslighet är ett mått på hur mycket ditt blodsocker sänks av en enhet insulin.";
-

--- a/LoopKitUI/CarbKit/AbsorptionTimePickerRow.swift
+++ b/LoopKitUI/CarbKit/AbsorptionTimePickerRow.swift
@@ -12,6 +12,7 @@ public struct AbsorptionTimePickerRow: View {
     @Binding private var absorptionTime: TimeInterval
     @Binding private var isFocused: Bool
     
+    private let title: String
     private let validDurationRange: ClosedRange<TimeInterval>
     private let minuteStride: Int
     
@@ -24,9 +25,10 @@ public struct AbsorptionTimePickerRow: View {
         return formatter
     }()
     
-    public init(absorptionTime: Binding<TimeInterval>, isFocused: Binding<Bool>, validDurationRange: ClosedRange<TimeInterval>, minuteStride: Int = 30, showHowAbsorptionTimeWorks: Binding<Bool>? = nil) {
+    public init(absorptionTime: Binding<TimeInterval>, isFocused: Binding<Bool>, title: String, validDurationRange: ClosedRange<TimeInterval>, minuteStride: Int = 30, showHowAbsorptionTimeWorks: Binding<Bool>? = nil) {
         self._absorptionTime = absorptionTime
         self._isFocused = isFocused
+        self.title = title
         self.validDurationRange = validDurationRange
         self.minuteStride = minuteStride
         self.showHowAbsorptionTimeWorks = showHowAbsorptionTimeWorks
@@ -35,7 +37,7 @@ public struct AbsorptionTimePickerRow: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
-                Text("Absorption Time")
+                Text(title)
                     .foregroundColor(.primary)
                 
                 if showHowAbsorptionTimeWorks != nil {

--- a/LoopKitUI/CarbKit/DatePickerRow.swift
+++ b/LoopKitUI/CarbKit/DatePickerRow.swift
@@ -19,6 +19,7 @@ public struct DatePickerRow: View {
     
     @Binding var isFocused: Bool
     
+    private let title: String
     private let maximumDate: Date
     private let minimumDate: Date
     
@@ -42,9 +43,10 @@ public struct DatePickerRow: View {
     
     private let timeStepSize: TimeInterval = .minutes(15)
     
-    public init(date: Binding<Date>, isFocused: Binding<Bool>, minimumDate: Date, maximumDate: Date) {
+    public init(date: Binding<Date>, isFocused: Binding<Bool>, title: String, minimumDate: Date, maximumDate: Date) {
         self._date = date
         self._isFocused = isFocused
+        self.title = title
         self.minimumDate = minimumDate
         self.maximumDate = maximumDate
     }
@@ -52,7 +54,7 @@ public struct DatePickerRow: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
-                Text("Time")
+                Text(title)
                     .foregroundColor(.primary)
                 
                 Spacer()

--- a/LoopKitUI/CarbKit/FoodTypeRow.swift
+++ b/LoopKitUI/CarbKit/FoodTypeRow.swift
@@ -17,6 +17,7 @@ public struct FoodTypeRow: View {
     @Binding private var absorptionTimeWasEdited: Bool
     @Binding private var isFocused: Bool
     
+    private var title: String
     private var defaultAbsorptionTimes: CarbStore.DefaultAbsorptionTimes
     private var orderedAbsorptionTimes: [TimeInterval] {
         [defaultAbsorptionTimes.fast, defaultAbsorptionTimes.medium, defaultAbsorptionTimes.slow]
@@ -27,7 +28,7 @@ public struct FoodTypeRow: View {
     @State private var selectedEmojiIndex = 1
     
     /// Contains emoji shortcuts, an emoji keyboard, and modifies absorption time to match emoji
-    public init(foodType: Binding<String>, absorptionTime: Binding<TimeInterval>, selectedDefaultAbsorptionTimeEmoji: Binding<String>, usesCustomFoodType: Binding<Bool>, absorptionTimeWasEdited: Binding<Bool>, isFocused: Binding<Bool>, defaultAbsorptionTimes: CarbStore.DefaultAbsorptionTimes) {
+    public init(foodType: Binding<String>, absorptionTime: Binding<TimeInterval>, selectedDefaultAbsorptionTimeEmoji: Binding<String>, usesCustomFoodType: Binding<Bool>, absorptionTimeWasEdited: Binding<Bool>, isFocused: Binding<Bool>, title: String, defaultAbsorptionTimes: CarbStore.DefaultAbsorptionTimes) {
         self._foodType = foodType
         self._absorptionTime = absorptionTime
         self._selectedDefaultAbsorptionTimeEmoji = selectedDefaultAbsorptionTimeEmoji
@@ -35,12 +36,13 @@ public struct FoodTypeRow: View {
         self._absorptionTimeWasEdited = absorptionTimeWasEdited
         self._isFocused = isFocused
         
+        self.title = title
         self.defaultAbsorptionTimes = defaultAbsorptionTimes
     }
     
     public var body: some View {
         HStack {
-            Text("Food Type")
+            Text(title)
                 .foregroundColor(.primary)
             
             Spacer()

--- a/LoopKitUI/Resources/sv.lproj/InsulinKit.strings
+++ b/LoopKitUI/Resources/sv.lproj/InsulinKit.strings
@@ -1,20 +1,20 @@
 /* Class = "UILabel"; text = "Title"; ObjectID = "7Fi-wD-gf2"; */
-"7Fi-wD-gf2.text" = "Title";
+"7Fi-wD-gf2.text" = "Titel";
 
 /* Class = "UILabel"; text = "..."; ObjectID = "7Fy-gG-Zof"; */
 "7Fy-gG-Zof.text" = "...";
 
 /* Class = "UILabel"; text = "Detail"; ObjectID = "9jm-X6-3QA"; */
-"9jm-X6-3QA.text" = "Detail";
+"9jm-X6-3QA.text" = "Detalj";
 
 /* Class = "UILabel"; text = "U IOB"; ObjectID = "dZi-Ta-IHm"; */
-"dZi-Ta-IHm.text" = "U IOB";
+"dZi-Ta-IHm.text" = "E aktivt";
 
 /* Class = "UILabel"; text = "No pump configured"; ObjectID = "jSc-64-2tZ"; */
-"jSc-64-2tZ.text" = "No pump configured";
+"jSc-64-2tZ.text" = "Ingen pump konfigurerad";
 
 /* Class = "UILabel"; text = "U Total"; ObjectID = "kys-by-14s"; */
-"kys-by-14s.text" = "U Total";
+"kys-by-14s.text" = "E totalt";
 
 /* Class = "UILabel"; text = "..."; ObjectID = "PZQ-gO-084"; */
 "PZQ-gO-084.text" = "...";
@@ -26,8 +26,7 @@
 "TyZ-xm-mVN.segmentTitles[1]" = "Händelsehistorik";
 
 /* Class = "UISegmentedControl"; TyZ-xm-mVN.segmentTitles[2] = "Non-Pump Insulin"; ObjectID = "TyZ-xm-mVN"; */
-"TyZ-xm-mVN.segmentTitles[2]" = "Non-Pump Insulin";
+"TyZ-xm-mVN.segmentTitles[2]" = "Icke-pumpinsulin";
 
 /* Class = "UINavigationItem"; title = "Insulin Delivery"; ObjectID = "vls-EW-uwI"; */
-"vls-EW-uwI.title" = "Insulin Delivery";
-
+"vls-EW-uwI.title" = "Insulin doserat";

--- a/LoopKitUI/Resources/sv.lproj/Localizable.strings
+++ b/LoopKitUI/Resources/sv.lproj/Localizable.strings
@@ -1,3 +1,21 @@
+/* No comment provided by engineer. */
+"" = "";
+
+/* No comment provided by engineer. */
+"\(dayAtTime, formatter: Self.dateFormatter)" = "\(dayAtTime, formatter: Self.dateFormatter)";
+
+/* No comment provided by engineer. */
+"\(food.carbsString(formatter: carbFormatter)) carbs, \(food.absorptionTimeString(formatter: absorptionTimeFormatter)) absorption" = "\(food.carbsString(formatter: carbFormatter)) carbs, \(food.absorptionTimeString(formatter: absorptionTimeFormatter)) absorption";
+
+/* No comment provided by engineer. */
+"\(index+1), " = "\(index+1), ";
+
+/* No comment provided by engineer. */
+"\(index+startingIndex)" = "\(index+startingIndex)";
+
+/* No comment provided by engineer. */
+"\(value)" = "\(value)";
+
 /* Information about workout range relative to correction range */
 " higher " = " högre ";
 
@@ -16,14 +34,8 @@
 /* No comment provided by engineer. */
 "···" = "···";
 
-/* No comment provided by engineer. */
-"%@" = "%@";
-
 /* Appends a full-stop to a statement */
 "%@." = "%@.";
-
-/* The format for an insulin needs percentage. */
-"%@%% of normal insulin" = "%@%% of normal insulin";
 
 /* Format string for reservoir volume. (1: The localized volume) */
 "%@U" = "%@E";
@@ -31,12 +43,18 @@
 /* The format for a glucose target range. (1: min target)(2: max target)(3: glucose unit) */
 "%1$@ – %2$@ %3$@" = "%1$@ – %2$@ %3$@";
 
-/* The format for an override preset cell. (1: symbol)(2: name)
+/* The format for a preset symbol and name (1: symbol)(2: name)
    The format for an override symbol and name (1: symbol)(2: name) */
 "%1$@ %2$@" = "%1$@ %2$@";
 
+/* Information about insulin action duration (1: app name) */
+"%1$@ assumes that the insulin it has delivered is actively working to lower your glucose for 6 hours. This setting cannot be changed." = "%1$@ förutsätter att insulinet som har doserats, aktivt arbetar för att sänka ditt blodsocker i 6 timmar. Denna inställning kan inte ändras.";
+
 /* Lower bound workout information text format (1: app name) */
 "%1$@ or your Glucose Safety Limit, whichever is higher" = "%1$@ eller ditt Tröskelvärde, beroende på vilket som är högst";
+
+/* Information about max number of basal rates (1: app name) (2: maximum schedule entry count) */
+"%1$@ supports 1 to %2$@ rates per day." = "%1$@ stöder 1 till %2$@ basaler per dygn.";
 
 /* Reservoir entry (1: volume value) */
 "%1$@ U" = "%1$@ E";
@@ -44,12 +62,18 @@
 /* Accessibility format string for (1: localized volume)(2: time) */
 "%1$@ units remaining at %2$@" = "%1$@ enheter återstår kl. %2$@";
 
+/* Format string describing glucose units per minute (1: glucose unit string) */
+"%1$@/min" = "%1$@/min";
+
+/* String format for value with units (1: value, 2: separator, 3: units) */
+"%1$@%2$@%3$@" = "%1$@%2$@%3$@";
+
 /* Description of a basal temp basal dose entry (1: title for dose type, 2: value (? if no value) in bold, 3: unit)
    Description of a bolus dose entry (1: title for dose type, 2: value (? if no value) in bold, 3: unit) */
 "%1$@: <b>%2$@</b> %3$@" = "%1$@: <b>%2$@</b> %3$@";
 
-/* String format for value with units (1: value, 2: separator, 3: units) */
-"%1$@%2$@%3$@" = "%1$@%2$@%3$@";
+/* Format string for progress accessibility label (1: duration in seconds) */
+"%1$d percent complete." = "%1$d procent slutfört.";
 
 /* No comment provided by engineer. */
 "🍽" = "🍽";
@@ -76,10 +100,10 @@
 "A value of 0 U/hr means you will be scheduled to receive no basal insulin." = "Ett värde på 0 / h innebär att du inte kommer få någon basal insulintillförsel.";
 
 /* No comment provided by engineer. */
-"Above the save button" = "Ovanför spara-knappen";
+"Above dynamic data" = "Ovanför dynamiskt data";
 
-/* Title of the carb entry absorption time cell */
-"Absorption Time" = "Absorptionstid";
+/* No comment provided by engineer. */
+"Above the save button" = "Ovanför spara-knappen";
 
 /* No comment provided by engineer. */
 "Action Button" = "Åtgärdsknapp";
@@ -87,7 +111,7 @@
 /* The text for the override history duration */
 "Active Duration" = "Aktiv varaktighet";
 
-/* The title for the override emoji activity section */
+/* The title for the custom preset emoji activity section */
 "Activity" = "Aktivitet";
 
 /* Button text to confirm adding a new schedule item */
@@ -96,8 +120,8 @@
 /* The title of the button to add the credentials for a service */
 "Add Account" = "Lägg till konto";
 
-/* The title of the view controller to create a new carb entry */
-"Add Carb Entry" = "Lägg till kolhydrater";
+/* Title of insulin model preset - afrezza */
+"Afrezza" = "Afrezza";
 
 /* Action sheet confirmation message for pump history deletion */
 "Are you sure you want to delete all history entries?" = "Säkert att du vill radera all händelsehistorik?";
@@ -124,13 +148,19 @@
 "Basal, bolus, and correction insulin dose amounts are unaffected." = "Basal, bolus, och korrigeringsdoser är oförändrade.";
 
 /* No comment provided by engineer. */
+"Below dynamic data" = "Nedanför dynamiskt data";
+
+/* No comment provided by engineer. */
+"Bottom" = "Nedre";
+
+/* No comment provided by engineer. */
 "Bottom component" = "Nedre komponent";
 
-/* The title of the cancel action in an action sheet */
+/* Button text to cancel adding a new schedule item
+   Cancel editing settings button title
+   The text for the scheduled custom preset cancel button
+   The title of the cancel action in an action sheet */
 "Cancel" = "Avbryt";
-
-/* The text for the override cancellation button */
-"Cancel Override" = "Avbryt Override";
 
 /* Title text for suspend resume button when temp basal canceling */
 "Canceling Temp Basal" = "Avbryt temporär basal";
@@ -138,24 +168,12 @@
 /* Title text for multi-value carb ratio warning */
 "Carb Ratios" = "Insulinkvoter";
 
-/* Footer text for customizing an override from a preset (1: preset name) */
-"Changes will only apply this time you enable the override. The default settings of %@ will not be affected." = "Ändringarna kommer endast att utföras denna gång du använder override. De ordinarie inställingarna på %@ kommer inte att påverkas. ";
-
 /* Footer text for customizing from a preset (1: preset name) */
 "Changes will only apply this time you enable the preset. The default settings of %@ will not be affected." = "Ändringarna kommer endast att gälla denna gång du använder undantag. De ordinarie inställningarna på %@ kommer inte att påverkas.";
-
-/* Carb entry section footer text explaining absorption time */
-"Choose a longer absorption time for larger meals, or those containing fats and proteins. This is only guidance to the algorithm and need not be exact." = "Välj en längre absorptionstid för måltid med mycket fett eller protein. Ofta är det bäst att dela upp måltiden i snabba och långsamma kolhydrater och mata in dessa var för sig.";
 
 /* Button text to close a modal
    Text to close informational page */
 "Close" = "Stäng";
-
-/* The format string describing the date of a COB value. The first format argument is the localized date. */
-"com.loudnate.CarbKit.COBDateLabel" = "kl %1$@";
-
-/* The format string describing the starting date of a total value. The first format argument is the localized date. */
-"com.loudnate.CarbKit.totalDateLabel" = "sedan %1$@";
 
 /* The format string describing the date of an IOB value. The first format argument is the localized date. */
 "com.loudnate.InsulinKit.IOBDateLabel" = "kl %1$@";
@@ -169,7 +187,7 @@
 /* Accessibility label for ProgressIndicatorView when showIndeterminantProgress */
 "Completed." = "Klart.";
 
-/* The title for the override emoji condition section */
+/* The title for the custom preset emoji condition section */
 "Condition" = "Tillstånd";
 
 /* The button text for confirming the setting */
@@ -178,8 +196,14 @@
 /* No comment provided by engineer. */
 "content" = "innehåll";
 
-/* Title of the setup button to continue */
+/* Button text to confirm saving from alert popup when some schedule values are outside the recommended range
+   Button to advance to setting editor
+   Text for continue action on confirmation alert
+   Title of the setup button to continue */
 "Continue" = "Fortsätt";
+
+/* Instruction to correct unsupported value */
+"Correct the highlighted unsupported value(s)." = "Korrigera de markerade ogiltiga värdena.";
 
 /* The section footer of correction range schedule */
 "Correction range is the blood glucose range that you would like Loop to correct to." = "Målvärden är det blodglukosintervall du vill att Loop ska korrigera blodsockret till.";
@@ -187,26 +211,21 @@
 /* Title text for multi-value correction value warning */
 "Correction Values" = "Målvärden";
 
-/* The text for a custom override */
+/* The text for a custom preset
+   Title for custom override history cell */
 "Custom" = "Anpassad";
 
-/* The title for the custom override entry screen */
+/* Custom override preset title */
 "Custom Override" = "Anpassad Override";
 
 /* The title for the custom preset entry screen
    The title for the custom preset selection screen */
 "Custom Preset" = "Anpassad förinställning";
 
-/* Title of the carb entry date picker cell */
-"Date" = "Tid";
-
 /* Delete values for Pre-Meal, inactivates Pre-Meal icon
    Test for table cell delete button
    The title of the button to remove the credentials for a service */
 "Delete" = "Ta bort";
-
-/* The title of the button to remove the credentials for a service */
-"Delete Account" = "Radera konto";
 
 /* Button title to delete all objects */
 "Delete All" = "Radera allt";
@@ -223,23 +242,21 @@
 /* Text for dismiss button
    Text for done button
    Video player done button label */
-"Done" = "Färdig";
+"Done" = "Klar";
 
-/* The text for the override duration setting */
-"Duration" = "Duration";
+/* The text for the custom preset duration setting
+   The text for the override duration setting */
+"Duration" = "Varaktighet";
+
+/* No comment provided by engineer. */
+"Dynamic component #\(value)" = "Dynamisk komponent #\(value)";
+
+/* No comment provided by engineer. */
+"Dynamic data \(value)" = "Dynamiskt data \(value)";
 
 /* Text for edit button
    The title for the enabled custom preset editing screen */
 "Edit" = "Ändra";
-
-/* The title of the view controller to edit an existing carb entry */
-"Edit Carb Entry" = "Ändra kolhydrater";
-
-/* The title for the override editing screen */
-"Edit Override" = "Ändra Override";
-
-/* Footer text for editing an active override (1: preset name) */
-"Editing affects only the active override. The default settings of %@ will not be affected." = "Ändringar ändrar endast aktiv Override. De ordinarie inställningarna på %@ kommer inte att påverkas";
 
 /* Footer text for editing an enabled custom preset (1: preset name) */
 "Edits persist only until the preset is disabled. The default settings of %@ will not be affected." = "Ändringar gäller endast tills förinställningen är inaktiverad. Standardinställningarna för %@ påverkas inte.";
@@ -247,7 +264,7 @@
 /* The button text for enabling a temporary override */
 "Enable" = "Aktivera";
 
-/* The text for the indefinite override duration setting */
+/* The text for the indefinite custom preset duration setting */
 "Enable Indefinitely" = "Sätt på oändligt";
 
 /* The detail text describing an enabled setting */
@@ -258,12 +275,6 @@
 
 /* Format string for accessibility label for value entry. (1: value label) */
 "Enter %1$@ value" = "Ange %1$@värde";
-
-/* The placeholder text instructing users how to enter a maximum bolus */
-"Enter a number of units" = "Ange antal eheter";
-
-/* The placeholder text instructing users how to enter a maximum basal rate */
-"Enter a rate in units per hour" = "Ange värde i enheter per timme";
 
 /* Segmented button title for insulin delivery log event history */
 "Event History" = "Händelsehistorik";
@@ -368,19 +379,27 @@
 /* Title text for the low workout value warning */
 "Low Workout Value" = "Lågt träningsvärde";
 
-/* Placeholder for maximum value in glucose range */
+/* Title of insulin model preset - lyumjev */
+"Lyumjev" = "Lyumjev";
+
+/* Placeholder for maximum value in glucose range
+   Placeholder for quantity range upper bound */
 "max" = "max";
 
-/* The title text for the maximum basal rate value */
-"Maximum Basal Rate" = "Maximal basaldos";
+/* Information about maximum basal rate (1: app name) */
+"Maximum Basal Rate is the maximum automatically adjusted basal rate that %1$@ is allowed to enact to help reach your correction range." = "Maximal basaldos är den högsta automatiskt justerade basal som %1$@ har lov att genomföra för att hjälpa till att nå ditt målvärde.";
 
-/* The title text for the maximum bolus value */
-"Maximum Bolus" = "Maximal bolus";
+/* Information about maximum bolus (1: app name) */
+"Maximum Bolus is the highest bolus amount that you will allow %1$@ to recommend at one time to cover carbs or bring down high glucose." = "Maximal bolus är den högsta bolusmängd som du tillåter %1$@ att rekommendera vid ett tillfälle för att täcka kolhydrater eller sänka högt glukosvärde.";
 
 /* Section title for medium absorbing food */
 "Medium" = "Medium";
 
-/* Placeholder for minimum value in glucose range */
+/* No comment provided by engineer. */
+"Middle" = "Mitten";
+
+/* Placeholder for minimum value in glucose range
+   Placeholder for quantity range lower bound */
 "min" = "min";
 
 /* No comment provided by engineer. */
@@ -389,20 +408,23 @@
 /* Alert action title to open error help */
 "More Info" = "Mer info";
 
-/* The text for the override preset name setting */
+/* The text for the custom preset name setting */
 "Name" = "Namn";
 
 /* Title for mini-modal to add a new schedule entry */
 "New Entry" = "Ny post";
 
-/* The title for the new override preset entry screen */
+/* The title for the new custom preset entry screen */
 "New Preset" = "Ny förinställning";
 
 /* Title text for the zero basal rate warning */
 "No Basal Insulin" = "Inget basalinsulin";
 
+/* No comment provided by engineer. */
+"Nothing to See Here!" = "Inget att se här!";
+
 /* Section title for no-carb food
-   The title for override emoji miscellaneous section */
+   The title for custom preset emoji miscellaneous section */
 "Other" = "Annan";
 
 /* The title text for the insulin sensitivity scaling setting */
@@ -411,16 +433,11 @@
 /* Title for override history view */
 "Override History" = "Historik av Undantag";
 
-/* The title text for the override presets screen */
-"Override Presets" = "Override förinställningar";
-
-/* Text directing the user to configure override presets */
-"Override presets can be set up under the 'Configuration' section of the settings screen." = "Override förinställningar kan ställas in under ‘Konfiguration’ i menyn inställningar.";
-
 /* The section title of glucose overrides */
 "Overrides" = "Overrides";
 
-/* Title for the pre-meal override range */
+/* Title for pre-meal override history cell
+   Title for the pre-meal override range */
 "Pre-Meal" = "Före måltid";
 
 /* Title text for multi-value pre-meal value warning */
@@ -429,7 +446,7 @@
 /* title for prescription section */
 "Prescription" = "Recept";
 
-/* The section header text override presets */
+/* The section header text for custom presets */
 "PRESETS" = "FÖRINSTÄLLNINGAR";
 
 /* Accessibility label for ProgressIndicatorView when showIndeterminantProgress */
@@ -465,11 +482,12 @@
 /* Description of how to interact with summary screen */
 "Review your therapy settings below. If you’d like to edit any of these settings, tap Back to go back to that screen." = "Granska dina behandlingsinställningar nedan. Om du behöver ändra någon av dessa, tryck Tillbaka för att gå tillbaka till det fönstret.";
 
-/* The text for the override preset name field placeholder */
+/* The text for the custom preset name field placeholder */
 "Running" = "Löpning";
 
 /* Button text for saving glucose correction range schedule
-   Button text for saving insulin sensitivity schedule */
+   Button text for saving insulin sensitivity schedule
+   The button text for saving on a configuration page */
 "Save" = "Spara";
 
 /* Alert title for confirming basal rates outside the recommended range */
@@ -496,8 +514,8 @@
 /* Alert title for confirming workout range overrides outside the recommended range */
 "Save Workout Range?" = "Spara målvärde för träning?";
 
-/* The section header text for a scheduled override */
-"SCHEDULED OVERRIDE" = "SCHEMALAGD OVERRIDE";
+/* The button text during saving on a configuration page */
+"Saving..." = "Sparar...";
 
 /* The section header text for a scheduled custom preset */
 "SCHEDULED PRESET" = "SCHEMALAGD FÖRINSTÄLLNING";
@@ -508,7 +526,7 @@
 /* Information about typical maximum basal rates */
 "Some users choose a value 2, 3, or 4 times their highest scheduled basal rate." = "Vissa användare väljer ett värde 2, 3 eller 4 gånger sin högsta schemalagda basaldos.";
 
-/* The text for the override start time */
+/* The text for the custom preset start time */
 "Start Time" = "Starttid";
 
 /* Title text for suspend resume button when temp basal starting */
@@ -529,16 +547,19 @@
 /* No comment provided by engineer. */
 "Switch Preview State" = "Byt förhandsvisningsläge";
 
-/* The text for the override preset symbol setting */
+/* The text for the custom preset symbol setting */
 "Symbol" = "Symbol";
 
 /* Text directing the user to configure their first custom preset */
 "Tap '+' to create a new custom preset." = "Tryck på '+' för att skapa en ny anpassad förinställning.";
 
+/* No comment provided by engineer. */
+"Tap back to continue exploring the rest of the \(appName) interface." = "Tryck tillbaka för att fortsätta utforska resten av \(appName)-gränssnittet.";
+
 /* The empty-state text for a configuration value */
 "Tap to set" = "Klicka för att ange";
 
-/* The text for the override target range setting */
+/* The text for the custom preset target range setting */
 "Target Range" = "Målvärden";
 
 /* Description of pre-meal mode */
@@ -547,21 +568,15 @@
 /* Description of workout mode */
 "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events." = "Höj tillfälligt ditt målvärde före, under eller efter fysisk aktivitet för att minska risken för låga blodsockervärden.";
 
-/* The title for the override selection screen */
-"Temporary Override" = "Temporär Override";
-
 /* Information about pre-meal range relative to correction range
    Information about workout range relative to correction range */
 "than your Correction Range." = "än ditt målvärde.";
 
+/* Description for selection when no insulin type is selected. */
+"The currently selected fast acting insulin model will be used as a default." = "Den för närvarande valda snabbverkande insulinmodellen kommer att användas som standard.";
+
 /* Subtitle description of Walsh insulin model setting */
 "The legacy model used by Loop, allowing customization of action duration." = "Äldre modell använd av Loop, vilken tillåter anpassning av insulinets verkningstid.";
-
-/* Alert body displayed absorption time greater than max (1: maximum absorption time) */
-"The maximum absorption time is %@" = "Maximala absorptionstiden är %@";
-
-/* Alert body displayed for quantity greater than max (1: maximum quantity in grams) */
-"The maximum allowed amount is %@ grams" = "Maximala mängd är %@ gram";
 
 /* Information about adult insulin model */
 "The rapid-acting adult model assumes peak activity at 75 minutes." = "Den snabbverkande vuxenmodellen antar en maximal aktivitet vid 75 minuter.";
@@ -575,6 +590,9 @@
 /* Therapy Settings screen title */
 "Therapy Settings" = "Behandlingsinställningar";
 
+/* Subtitle of afrezza preset */
+"This model assumes peak insulin activity at 19 minutes." = "Denna modell antar en maximal aktivitet vid 19 minuter.";
+
 /* Subtitle of Fiasp preset
    Subtitle of Lyumjev preset */
 "This model assumes peak insulin activity at 55 minutes." = "Denna modell antar en maximal aktivitet vid 55 minuter.";
@@ -584,6 +602,12 @@
 
 /* Subtitle of Rapid-Acting – Adult preset */
 "This model assumes peak insulin activity at 75 minutes." = "Denna modell antar en maximal aktivitet vid 75 minuter.";
+
+/* No comment provided by engineer. */
+"This section of the \(appName) app is unavailable in this simulator." = "Denna del av \(appName)-appen är inte tillgänglig i denna simulator.";
+
+/* Information about maximum automated insulin on board (1: app name) */
+"This setting will also determine a safety limit for automatic dosing. %1$@ will limit automatic delivery to keep the amount of active insulin below twice your maximum bolus." = "Denna inställning kommer också att bestämma en säkerhetsgräns för automatisk dosering. %1$@ kommer att begränsa automatisk insulintillförsel för att hålla mängden aktivt insulin under dubbla din maximala bolus.";
 
 /* Information about pre-meal range relative to correction range
    Information about workout range relative to correction range */
@@ -599,20 +623,28 @@
 "To be implemented" = "Att bli implementerat";
 
 /* No comment provided by engineer. */
+"Top" = "Övre";
+
+/* No comment provided by engineer. */
 "Top component" = "Översta komponenten";
 
-/* The unit string for units per hour */
-"U/hour" = "E/timme";
+/* The text indicating Total for Daily Schedule Basal */
+"Total" = "Totalt";
+
+/* The text indicating U/day for Daily Schedule Basal */
+"U/day" = "E/dygn";
 
 /* Alert title when error occurs while saving a schedule */
 "Unable to Save" = "Kunde inte spara";
 
-/* The unit string for units */
-"Units" = "Eheter";
-
-/* Accessibility value for an unknown value
-   The default title to use when an entry has none */
+/* Accessibility value for an unknown value */
 "Unknown" = "Okänd";
+
+/* Title for selection when no insulin type is selected. */
+"Unset" = "Ej vald";
+
+/* No comment provided by engineer. */
+"Unsupported \(title)" = "Ogiltig \(title)";
 
 /* Placeholder text until value is entered */
 "Value" = "Värde";
@@ -626,13 +658,11 @@
 /* Title of insulin model setting */
 "Walsh" = "Walsh";
 
-/* Title of an alert containing a validation warning */
-"Warning" = "Varning";
-
 /* Disclaimer */
 "Work with your healthcare provider to choose a value that is higher than your highest scheduled basal rate, but as conservative or aggressive as you feel comfortable." = "Rådgör med din vårdgivare för att bestämma ett värde som är högre än din högsta schemalagda basaldos, men så konservativ eller aggressiv som du känner dig bekväm med.";
 
-/* Title for the workout override range */
+/* Title for the workout override range
+   Title for workout override history cell */
 "Workout" = "Träning";
 
 /* Information about workout range format (1: app name) */
@@ -652,6 +682,9 @@
 
 /* Description of how to add a range */
 "You can add entries for different times of day by using the ➕." = "Du kan lägga till inmatningar för olika tider på dagen med hjälp av ➕.";
+
+/* Information about insulin model (1: app name) */
+"You can choose how %1$@ measures rapid acting insulin's peak activity according to one of these two insulin models." = "Du kan välja hur %1$@ mäter snabbverkande insulins maximala aktivitet enligt en av dessa två insulinmodeller.";
 
 /* Description of how to edit setting */
 "You can edit a setting by tapping into any line item." = "Du kan ändra en inställning genom att trycka på ett objekt på en av raderna.";
@@ -673,4 +706,3 @@
 
 /* Information about pre-meal range format (1: app name) */
 "Your Pre-Meal Range should be the glucose value (or range of values) you want %1$@ to target by the time you take your first bite of your meal. This range will be in effect when you activate the Pre-Meal Preset button." = "Ditt målvärde för 'Före måltid' ska vara det blodsockervärde (eller målvärdesintervall) som du vill att %1$@ ska sikta på när du tar din första tugga av din måltid. Detta målvärde kommer börja gälla när du aktiverar knappen 'Före måltid'.";
-

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -285,13 +285,13 @@ extension TherapySettingsView {
                 }
                 SectionDivider()
                 HStack {
-                    Text(NSLocalizedString("Total", comment: "The text indicating Total for Daily Schedule Basal"))
+                    Text(LocalizedString("Total", comment: "The text indicating Total for Daily Schedule Basal"))
                         .bold()
                         .foregroundColor(.primary)
                     Spacer()
                     Text(String(format: "%.2f ",total))
                         .foregroundColor(.primary) +
-                    Text(NSLocalizedString("U/day", comment: "The text indicating U/day for Daily Schedule Basal"))
+                    Text(LocalizedString("U/day", comment: "The text indicating U/day for Daily Schedule Basal"))
                         .foregroundColor(.secondary)
                 }
             }
@@ -411,7 +411,7 @@ extension TherapySettingsView {
         Section {
             NavigationLink(destination: DemoPlaceHolderView(appName: appName)) {
                 HStack {
-                    Text("Get help with Therapy Settings", comment: "Support button for Therapy Settings")
+                    Text(LocalizedString("Get help with Therapy Settings", comment: "Support button for Therapy Settings"))
                         .foregroundColor(.primary)
                     Spacer()
                     Disclosure()


### PR DESCRIPTION
I noticed that there were a lot of missing Swedish translations in general for the Loop app. This PR addresses this in the LoopKit repository.

- Added missing Swedish translations in the respective `Localizable.strings` files.
- Added/Changed to `LocalizedString` calls where needed, which will help with other translations as well.
- Removed outdated translations that are no longer needed.