### PR TITLE
Fix locale for decimal separator in Carb Entry View

### DIFF
--- a/LoopKitUI/CarbKit/CarbQuantityRow.swift
+++ b/LoopKitUI/CarbKit/CarbQuantityRow.swift
@@ -22,7 +22,8 @@ public struct CarbQuantityRow: View {
     private let formatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.maximumFractionDigits = 1
+        formatter.maximumFractionDigits = 3
+        formatter.locale = Locale.current
         return formatter
     }()
     
@@ -39,7 +40,7 @@ public struct CarbQuantityRow: View {
                 .foregroundColor(.primary)
                 .frame(maxWidth: .infinity, alignment: .leading)
             
-            RowTextField(text: $carbInput, isFocused: $isFocused, maxLength: 5) {
+            RowTextField(text: $carbInput, isFocused: $isFocused, maxLength: 7) {
                 $0.textAlignment = .right
                 $0.keyboardType = .decimalPad
                 $0.placeholder = "0"
@@ -76,12 +77,18 @@ public struct CarbQuantityRow: View {
     
     // Update quantity based on text field input
     private func updateQuantity(with input: String) {
-        let filtered = input.filter { "0123456789.".contains($0) }
+        let decimalSeparator = formatter.decimalSeparator ?? "."
+        let allowedCharacters = "0123456789" + decimalSeparator
+        let filtered = input.filter { allowedCharacters.contains($0) }
+        if filtered != input {
+            self.carbInput = filtered
+        }
+
         if filtered != input {
             self.carbInput = filtered
         }
         
-        if let doubleValue = Double(filtered) {
+        if let doubleValue = formatter.number(from: filtered)?.doubleValue {
             quantity = doubleValue
         } else {
             quantity = nil


### PR DESCRIPTION
In the latest version of Loop there is an issue introduced where it's not possible to enter decimal separator symbol for languages with a different decimal separator than a period sybmol (`.`). For example, in Swedish a comma symbol (`,`) is used.

There is also now a limit to 1 decimal number. This causes a problem when you weight something, calculate the amount of carbons in your calculator, and then end up with three decimal numbers. You are then unable to copy it in. I've increased the allowed amount of decimal numbers to three with this PR.