### PR TITLE
Fix Decay Effect to be a continuous function

### DIFF
--- a/LoopKit/LoopMath.swift
+++ b/LoopKit/LoopMath.swift
@@ -193,20 +193,27 @@ extension GlucoseValue {
 
         let glucoseUnit = HKUnit.milligramsPerDeciliter
         let velocityUnit = GlucoseEffectVelocity.perSecondUnit
-
-        // The starting rate, which we will decay to 0 over the specified duration
-        let intercept = rate.doubleValue(for: velocityUnit) // mg/dL/s
-        let decayStartDate = startDate.addingTimeInterval(delta)
-        let slope = -intercept / (duration - delta)  // mg/dL/s/s
+        
+        let firstChange = rate.doubleValue(for: velocityUnit) * delta // mg/dl/s * time = mg/dL
+        let secondChange = firstChange * (1 - delta / (duration - delta))
+        
+        // we solve for f(t) = a*t^2 + b*t + c, where t is relative to self.startDate
+        let c = quantity.doubleValue(for: glucoseUnit) // f(0) = c
+        // f(delta) - c = firstChange = a*delta*delta + b*delta
+        // f(2*delta) -  c = firstChange + secondChange = 4*a*delta*delta + 2*b*delta
+        // --> firstChange - secondChange = 2*a*delta*delta
+        
+        let a = (secondChange - firstChange) / (2 * delta * delta) // mg/dL/s/s
+        let b = (firstChange + secondChange - 4 * a * delta * delta) / (2 * delta) // mg/dL/s
+        
 
         var values = [GlucoseEffect(startDate: startDate, quantity: quantity)]
-        var date = decayStartDate
-        var lastValue = quantity.doubleValue(for: glucoseUnit)
+        var date = startDate.addingTimeInterval(delta)
 
         repeat {
-            let value = lastValue + (intercept + slope * date.timeIntervalSince(decayStartDate)) * delta
+            let time = min(duration, date.timeIntervalSince(self.startDate))
+            let value = a * time * time + b * time + c
             values.append(GlucoseEffect(startDate: date, quantity: HKQuantity(unit: glucoseUnit, doubleValue: value)))
-            lastValue = value
             date = date.addingTimeInterval(delta)
         } while date < endDate
 

--- a/LoopKitTests/LoopMathTests.swift
+++ b/LoopKitTests/LoopMathTests.swift
@@ -185,27 +185,6 @@ class LoopMathTests: XCTestCase {
 
     func testDecayEffect() {
         let calendar = Calendar(identifier: Calendar.Identifier.gregorian)
-        let glucoseDate = calendar.date(from: DateComponents(year: 2016, month: 2, day: 1, hour: 10, minute: 13, second: 20))!
-        let type = HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bloodGlucose)!
-        let unit = HKUnit.milligramsPerDeciliter
-        let glucose = HKQuantitySample(type: type, quantity: HKQuantity(unit: unit, doubleValue: 100), start: glucoseDate, end: glucoseDate)
-
-        var startingEffect = HKQuantity(unit: unit.unitDivided(by: HKUnit.minute()), doubleValue: 2)
-
-        var effects = glucose.decayEffect(atRate: startingEffect, for: .minutes(30))
-
-        XCTAssertEqual([100, 110, 118, 124, 128, 130, 130], effects.map { $0.quantity.doubleValue(for: unit) })
-
-        let startDate = effects.first!.startDate
-        XCTAssertEqual([0, 5, 10, 15, 20, 25, 30], effects.map { $0.startDate.timeIntervalSince(startDate).minutes })
-
-        startingEffect = HKQuantity(unit: unit.unitDivided(by: HKUnit.minute()), doubleValue: -0.5)
-        effects = glucose.decayEffect(atRate: startingEffect, for: .minutes(30))
-        XCTAssertEqual([100, 97.5, 95.5, 94, 93, 92.5, 92.5], effects.map { $0.quantity.doubleValue(for: unit) })
-    }
-
-    func testDecayEffectWithEvenGlucose() {
-        let calendar = Calendar(identifier: Calendar.Identifier.gregorian)
         let glucoseDate = calendar.date(from: DateComponents(year: 2016, month: 2, day: 1, hour: 10, minute: 15, second: 0))!
         let type = HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bloodGlucose)!
         let unit = HKUnit.milligramsPerDeciliter
@@ -223,6 +202,19 @@ class LoopMathTests: XCTestCase {
         startingEffect = HKQuantity(unit: unit.unitDivided(by: HKUnit.minute()), doubleValue: -0.5)
         effects = glucose.decayEffect(atRate: startingEffect, for: .minutes(30))
         XCTAssertEqual([100, 97.5, 95.5, 94, 93, 92.5], effects.map { $0.quantity.doubleValue(for: unit) })
+        
+        let glucose2Date = glucoseDate.addingTimeInterval(TimeInterval(-1E-6))
+        let glucose2 = HKQuantitySample(type: type, quantity: HKQuantity(unit: unit, doubleValue: 100), start: glucose2Date, end: glucose2Date)
+        let effects2 = glucose2.decayEffect(atRate: startingEffect, for: .minutes(30))
+
+        XCTAssertEqual(effects.count + 1, effects2.count)
+        XCTAssertEqual(100, effects2[0].quantity.doubleValue(for: unit))
+        XCTAssertEqual(-5, effects2[0].startDate.timeIntervalSince(startDate).minutes)
+        for (index, effect) in effects.enumerated() {
+            let effect2 = effects2[index+1]
+            XCTAssertEqual(effect.startDate, effect2.startDate)
+            XCTAssertEqual(effect.quantity.doubleValue(for: unit), effect2.quantity.doubleValue(for: unit), accuracy: 1E-6)
+        }
     }
 
     func testSubtractingCarbEffectFromICEWithGaps() {


### PR DESCRIPTION
This fixes the LoopMath  implementation to ensure that the decay effect function is continuous and thus doesn't show discontinuity effects related to user sensor time (as reported in https://github.com/LoopKit/Loop/issues/2287). The test demonstrates that shifting a glucose reading by 1 microsecond earlier results in a less than 1E-6 change to glucose prediction, while the prior implementation would have resulted in a massive jump at the boundary (i.e. after 1 microsecond elapsed).

Subsequent fixes would be necessary to be done to the LoopDataManagerDosing tests which rely on fixtures which are calibrated with the old implementation which was inaccurate when sensor readings were not extremely close to the beginning of 5 minute boundaries.