### PR TITLE
Fix carb entry bug, Issue 2307

### DIFF
--- a/LoopKitUI/CarbKit/CarbQuantityRow.swift
+++ b/LoopKitUI/CarbKit/CarbQuantityRow.swift
@@ -76,7 +76,9 @@ public struct CarbQuantityRow: View {
     
     // Update quantity based on text field input
     private func updateQuantity(with input: String) {
-        let filtered = input.filter { "0123456789.".contains($0) }
+        let decimalSeparator = formatter.decimalSeparator ?? "."
+        let allowedCharacters = "0123456789" + decimalSeparator
+        let filtered = input.filter { allowedCharacters.contains($0) }
         if filtered != input {
             self.carbInput = filtered
         }

--- a/LoopKitUI/CarbKit/CarbQuantityRow.swift
+++ b/LoopKitUI/CarbKit/CarbQuantityRow.swift
@@ -22,7 +22,6 @@ public struct CarbQuantityRow: View {
     private let formatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.maximumIntegerDigits = 3
         formatter.maximumFractionDigits = 1
         return formatter
     }()
@@ -77,8 +76,14 @@ public struct CarbQuantityRow: View {
     
     // Update quantity based on text field input
     private func updateQuantity(with input: String) {
-        if let number = formatter.number(from: input) {
-            quantity = number.doubleValue
+        let filtered = input.filter { "0123456789.".contains($0) }
+        if filtered != input {
+            self.carbInput = filtered
+        }
+
+        let minAllowedCarbEntry = 1.0
+        if let doubleValue = Double(filtered), doubleValue >= minAllowedCarbEntry {
+            quantity = doubleValue
         } else {
             quantity = nil
         }
@@ -86,10 +91,9 @@ public struct CarbQuantityRow: View {
     
     // Update text field input based on quantity
     private func updateCarbInput(with newQuantity: Double?) {
+        // Do not enable Continue button if newQuantity is invalid (< minAllowedCarbEntry)
         if let value = newQuantity {
             carbInput = formatter.string(from: NSNumber(value: value)) ?? ""
-        } else {
-            carbInput = ""
         }
     }
     


### PR DESCRIPTION
## Purpose

Fix for [Loop Issue 2307](https://github.com/LoopKit/Loop/issues/2307).

## Method

I asked for help on solving this and got a suggestion from @bjorkert (thanks).

Once the file that needed to be modified was identified, I checked the status of that file in the `tidepool-merge` branch, `LoopKit/LoopKitUI/CarbKit/CarbQuantityRow.swift`
* The file has been updated, so I started with the `tidepool-merge` version
   * The bug still happens with that version of the file
* I modified the suggestion from @bjorkert to work with the `tidepool-merge` version
* I configured a `minAllowedCarbEntry` of 1.0 (instead of using hard-coded 1.0) and required the entry be >= `minAllowedCarbEntry` before the continue button is enabled

I'm happy to modify this as desired.

## Test

This fixes the reported bug:
* A user can no longer type  ".", "0", "5" and wind up with 5 g of carbs
* The entered value must be >= 1 before the user can continue
* If a value < 1 is entered, the continue button is inactive