### PR TITLE
Use StateObject in Settings view to avoid parent view updates from re…

### DIFF
--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -28,7 +28,7 @@ public struct TherapySettingsView: View {
 
     private let mode: SettingsPresentationMode
 
-    @ObservedObject var viewModel: TherapySettingsViewModel
+    @StateObject var viewModel: TherapySettingsViewModel
         
     private let actionButton: ActionButton?
 
@@ -36,7 +36,7 @@ public struct TherapySettingsView: View {
                 viewModel: TherapySettingsViewModel,
                 actionButton: ActionButton? = nil) {
         self.mode = mode
-        self.viewModel = viewModel
+        self._viewModel = StateObject(wrappedValue: viewModel)
         self.actionButton = actionButton
     }
         


### PR DESCRIPTION
For https://github.com/LoopKit/Loop/issues/2267

This PR tackles the state‑loss problem that arises when TherapySettingsViewModel is instantiated inline inside SettingsView.

What’s happening

1. View‑model recreation
Because the view model is created inside the body of SettingsView, every SwiftUI refresh tears it down and builds a new one. Any changes to the View Model (e.g. basal‑rate schedule changes) disappears until the upstream data source happens to publish again. 

2. Silent nested mutations (not fixing this - but FYI)
TherapySettingsViewModel.therapySettings is a single @Published value. Mutating its nested properties doesn’t emit a change unless the containing struct itself is reassigned, so some updates never reach the UI. It's not clear if this is affecting the refreshes but this may be something to visit in the future.

Scope of this PR

This PR fixes problem 1 by converting the view model from @ObservedObject to @StateObject, anchoring its lifetime to the view hierarchy instead of the render cycle.

Trade‑offs / testing notes

* Pros: UI state survives parent refreshes.
* Cons: The view will no longer automatically pick up parent‑level updates but it's not clear we are expecting updates from the parent Settings view. Verify that changing various therapy settings still refreshes when expected. 

I believe this therapy settings view is used during app setup, so that will need tested too.