### PR TITLE
Update LoopKit tidepool-merge with improvements from dev

### DIFF
--- a/LoopKitUI/CarbKit/CarbQuantityRow.swift
+++ b/LoopKitUI/CarbKit/CarbQuantityRow.swift
@@ -22,6 +22,7 @@ public struct CarbQuantityRow: View {
     private let formatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
+        formatter.maximumIntegerDigits = 3
         formatter.maximumFractionDigits = 1
         return formatter
     }()
@@ -76,13 +77,8 @@ public struct CarbQuantityRow: View {
     
     // Update quantity based on text field input
     private func updateQuantity(with input: String) {
-        let filtered = input.filter { "0123456789.".contains($0) }
-        if filtered != input {
-            self.carbInput = filtered
-        }
-        
-        if let doubleValue = Double(filtered) {
-            quantity = doubleValue
+        if let number = formatter.number(from: input) {
+            quantity = number.doubleValue
         } else {
             quantity = nil
         }

--- a/LoopKitUI/Views/CheckmarkListItem.swift
+++ b/LoopKitUI/Views/CheckmarkListItem.swift
@@ -74,8 +74,8 @@ public struct CheckmarkListItem: View {
                 .foregroundColor(.accentColor)
         } else {
             Circle()
-                .stroke()
-                .foregroundColor(Color(.systemGray4))
+                .stroke(lineWidth: 2)
+                .foregroundColor(Color(.systemGray))
         }
     }
     


### PR DESCRIPTION
## Purpose

Bring in improvements added to the dev branch since the tidepool-merge branch was first pushed to LoopKit

## Test

Start with a local clone using LoopWorkspace `tidepool-merge` branch:

* Perform a test merge of main into tidepool-merge for LoopKit in that local clone
* Open Xcode workspace and build with modified LoopKit

Confirm the checkmark limit is easy to see and Carb input accepts comma as a decimal separator so long as the leading zero is typed.
The issue pointed out in Loop 2307 is still present but will be corrected in a separate PR.