### PR TITLE
Added the basalDosingEnd argument to the insulinOnBoard() function

### DIFF
--- a/LoopKit/InsulinKit/DoseStore.swift
+++ b/LoopKit/InsulinKit/DoseStore.swift
@@ -1279,8 +1279,10 @@ extension DoseStore {
     ///   - date: The date of the value to retrieve
     ///   - completion: A closure called once the value has been retrieved
     ///   - result: The insulin on-board value
-    public func insulinOnBoard(at date: Date, completion: @escaping (_ result: DoseStoreResult<InsulinValue>) -> Void) {
-        getInsulinOnBoardValues(start: date.addingTimeInterval(.minutes(-5)), end: date.addingTimeInterval(.minutes(5))) { (result) -> Void in
+    public func insulinOnBoard(at date: Date, basalDosingEnd: Date? = nil, completion: @escaping (_ result: DoseStoreResult<InsulinValue>) -> Void) {
+        getInsulinOnBoardValues(start: date.addingTimeInterval(.minutes(-5)),
+                                end: date.addingTimeInterval(.minutes(5)),
+                                basalDosingEnd: basalDosingEnd) { (result) -> Void in
             switch result {
             case .failure(let error):
                 completion(.failure(error))


### PR DESCRIPTION
This PR just adds an optional `basalDosingEnd` argument to the `insulinOnBoard()` function, which simply forwards it to the `getInsulinOnBoardValues()` function. This is required in order to get the correct amount of insulin on board value (see https://github.com/LoopKit/Loop/issues/2319)