### PR TITLE
Fix for issue 328

### DIFF
--- a/LoopKit/GlucoseKit/GlucoseMath.swift
+++ b/LoopKit/GlucoseKit/GlucoseMath.swift
@@ -143,6 +143,19 @@ extension Collection where Element: GlucoseSampleValue, Index == Int {
 
         return true
     }
+    
+    // interpolate the two values; note if they have the same date the value returned will be the first
+    private func interpolateMgdL(_ first: GlucoseEffect, _ second: GlucoseEffect, _ date: Date) -> Double {
+        let mgdL = HKUnit.milligramsPerDeciliter
+        let firstValue = first.quantity.doubleValue(for: mgdL)
+        let secondValue = second.quantity.doubleValue(for: mgdL)
+        
+        guard firstValue != secondValue, first.startDate != second.startDate, date != first.startDate else {
+            return firstValue
+        }
+        
+        return firstValue + ((secondValue - firstValue) * (date.timeIntervalSince(first.startDate) / second.startDate.timeIntervalSince(first.startDate)))
+    }
 
     /// Calculates a timeline of effect velocity (glucose/time) observed in glucose readings that counteract the specified effects.
     ///
@@ -164,7 +177,7 @@ extension Collection where Element: GlucoseSampleValue, Index == Int {
         guard var startGlucoseIdx else {
             return []
         }
-
+        
         var endGlucoseIdx = startGlucoseIdx + 1
 
         while endGlucoseIdx != self.endIndex {
@@ -196,10 +209,19 @@ extension Collection where Element: GlucoseSampleValue, Index == Int {
                 break
             }
 
+            var precedingStartEffect: GlucoseEffect = effects[Swift.max(effectIndex - 1, 0)]
+            var precedingEndEffect: GlucoseEffect = precedingStartEffect
             var startEffect: GlucoseEffect?
             var endEffect: GlucoseEffect?
 
             for effect in effects[effectIndex..<effects.count] {
+                if effect.startDate < startGlucose.startDate {
+                    precedingStartEffect = effect
+                }
+                if effect.startDate < endGlucose.startDate {
+                    precedingEndEffect = effect
+                }
+                
                 if startEffect == nil && effect.startDate >= startGlucose.startDate {
                     startEffect = effect
                 } else if endEffect == nil && effect.startDate >= endGlucose.startDate {
@@ -209,12 +231,14 @@ extension Collection where Element: GlucoseSampleValue, Index == Int {
 
                 effectIndex += 1
             }
+                        
 
-            guard let startEffectValue = startEffect?.quantity.doubleValue(for: mgdL),
-                let endEffectValue = endEffect?.quantity.doubleValue(for: mgdL)
-            else {
+            guard let startEffect = startEffect, let endEffect = endEffect else {
                 break
             }
+            
+            let startEffectValue = interpolateMgdL(startEffect, precedingStartEffect, startGlucose.startDate)
+            let endEffectValue = interpolateMgdL(endEffect, precedingEndEffect, endGlucose.startDate)
 
             let effectChange = endEffectValue - startEffectValue
             let discrepancy = glucoseChange - effectChange

--- a/LoopKitTests/GlucoseMathTests.swift
+++ b/LoopKitTests/GlucoseMathTests.swift
@@ -239,6 +239,32 @@ class GlucoseMathTests: XCTestCase {
 
         XCTAssertEqual(0, effects.count)
     }
+    
+    func testCounteractionEffectsForUnalignedSamples() {
+        let mgdL = HKUnit.milligramsPerDeciliter
+        let input = loadInputFixture("counteraction_effect_falling_glucose_input")
+        let insulinEffect = loadOutputFixture("counteraction_effect_falling_glucose_insulin")
+        
+        let shiftedInput = input.map{ GlucoseFixtureValue(startDate: $0.startDate.addingTimeInterval(TimeInterval(1E-6)), quantity: $0.quantity, isDisplayOnly: $0.isDisplayOnly, wasUserEntered: $0.wasUserEntered, provenanceIdentifier: $0.provenanceIdentifier, condition: $0.condition, trendRate: $0.trendRate) }
+        var adjustedInsulinEffect = [insulinEffect[0]]
+        let firstValue = insulinEffect[0].quantity.doubleValue(for: mgdL)
+        for i in 1..<insulinEffect.count {
+            adjustedInsulinEffect.append(GlucoseEffect(startDate: insulinEffect[i].startDate, quantity: HKQuantity(unit: mgdL, doubleValue: firstValue - Double(i * i))))
+        }
+        let effects = input.counteractionEffects(to: adjustedInsulinEffect)
+
+        adjustedInsulinEffect.append(GlucoseEffect(startDate: insulinEffect.last!.startDate.addingTimeInterval(.minutes(5)), quantity: HKQuantity(unit: mgdL, doubleValue: firstValue - Double(insulinEffect.count * insulinEffect.count))))
+        
+        let shiftedEffects = shiftedInput.counteractionEffects(to: adjustedInsulinEffect)
+        let unit = HKUnit.milligramsPerDeciliter.unitDivided(by: .minute())
+
+        XCTAssertEqual(effects.count, shiftedEffects.count)
+
+        for (effect, shifted) in zip(effects, shiftedEffects) {
+            XCTAssertEqual(shifted.startDate.timeIntervalSince(effect.startDate), 1E-6, accuracy: 1E-7)
+            XCTAssertEqual(effect.quantity.doubleValue(for: unit), shifted.quantity.doubleValue(for: unit), accuracy: Double(1E-6))
+        }
+    }
 
     func testCounteractionEffectsForFallingGlucose() {
         let input = loadInputFixture("counteraction_effect_falling_glucose_input")


### PR DESCRIPTION
Uses piecewise linear interpolation on the received effects to align with the glucose values.

All LoopKit tests pass, including a newly added test that failed under the previous behavior.

Note that the Loop tests using LiveCapture will fail after applying this fix as is expected when correcting Loop algorithm bugs.

fix for [Issue 328](https://github.com/LoopKit/LoopKit/issues/328)