### PR TITLE
typo in LoopPredictionOutput.swift

### DIFF
--- a/LoopKit/LoopAlgorithm/LoopPredictionOutput.swift
+++ b/LoopKit/LoopAlgorithm/LoopPredictionOutput.swift
@@ -24,7 +24,7 @@ extension LoopAlgorithmOutput: Codable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(predictedGlucose, forKey: .doseRecommendation)
+        try container.encode(predictedGlucose, forKey: .predictedGlucose)
         try container.encode(doseRecommendation, forKey: .doseRecommendation)
     }
 


### PR DESCRIPTION
I was reading the code, transcoding bits into Javascript, and I came over this. 

Is this intentional, or is it a typo ?