### PR TITLE
Translations, localizable.xcstrings (Multilingual)

### DIFF
--- a/LoopKit/Resources/Localizable.xcstrings
+++ b/LoopKit/Resources/Localizable.xcstrings
@@ -4,6 +4,12 @@
     "%@ Range" : {
       "comment" : "Format for correction range override therapy setting card",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ Range"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -34,13 +40,25 @@
             "value" : "%@ Plage"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ Range"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ Range"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Intervallo %@"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ Målområde"
@@ -58,16 +76,28 @@
             "value" : "%@ Zakres"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ Interval"
+            "state" : "new",
+            "value" : "%@ Range"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ Range"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ Диапазон"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ Range"
           }
         },
         "sv" : {
@@ -81,6 +111,30 @@
             "state" : "translated",
             "value" : "%@ Aralık"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ Range"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ Phạm vi"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ Range"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ Range"
+          }
         }
       }
     },
@@ -88,16 +142,136 @@
       "comment" : "Describes a certain bolus failure (1: size of the bolus in units)",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus failed"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus failed"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus failed"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus failed"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus failed"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus failed"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus failed"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus failed"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bolo %1$@ U fallito"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ E bolus feilet"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus failed"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus failed"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus failed"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus failed"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus failed"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus failed"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ IE bolus misslyckades"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus failed"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus failed"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ U liều bolus bị lỗi"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus failed"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus failed"
           }
         }
       }
@@ -106,16 +280,136 @@
       "comment" : "Describes an uncertain bolus failure (1: size of the bolus in units)",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus may not have succeeded"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus may not have succeeded"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus may not have succeeded"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus may not have succeeded"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus may not have succeeded"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus may not have succeeded"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus may not have succeeded"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus may not have succeeded"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il bolo %1$@ U potrebbe non essere riuscito"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ E bolus kan ha feilet"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus may not have succeeded"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus may not have succeeded"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus may not have succeeded"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus may not have succeeded"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus may not have succeeded"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus may not have succeeded"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ IE bolus kan ha misslyckats"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus may not have succeeded"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus may not have succeeded"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bolus %1$@ U có thể chưa thành công"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus may not have succeeded"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U bolus may not have succeeded"
           }
         }
       }
@@ -123,6 +417,12 @@
     "%1$@ will deliver basal and recommend bolus insulin only if your glucose is predicted to be above this limit for the next three hours." : {
       "comment" : "Descriptive format string for glucose safety limit (1: app name)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ will deliver basal and recommend bolus insulin only if your glucose is predicted to be above this limit for the next three hours."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -153,13 +453,25 @@
             "value" : "%1$@ ne délivrera de l'insuline basale et ne recommandera un bolus que si la projection de glycémie est supérieure à cette limite au cours des trois prochaines heures."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ will deliver basal and recommend bolus insulin only if your glucose is predicted to be above this limit for the next three hours."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ will deliver basal and recommend bolus insulin only if your glucose is predicted to be above this limit for the next three hours."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ erogherà l'insulina basale e consiglierà il bolo solo se si prevede che la tua glicemia sarà superiore a questo limite per le prossime tre ore."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ vil levere basal og anbefale bolusinsulin bare hvis blodsukkeret ditt forventes å være over denne grensen de neste tre timene."
@@ -177,16 +489,28 @@
             "value" : "%1$@ będzie dostarczać insulinę podstawową i zalecaną w bolusie tylko wtedy, gdy przewiduje się, że poziom glukozy przekroczy ten limit przez następne trzy godziny."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ va livra bazala şi bolusul recomandat numai dacă glucoza este estimată a fi peste această limită pentru următoarele trei ore."
+            "state" : "new",
+            "value" : "%1$@ will deliver basal and recommend bolus insulin only if your glucose is predicted to be above this limit for the next three hours."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ will deliver basal and recommend bolus insulin only if your glucose is predicted to be above this limit for the next three hours."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ будет вводить базу и рекомендовать болюсы, только если прогнозируется, что уровень глюкозы будет выше этого предела в течение следующих трех часов."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ will deliver basal and recommend bolus insulin only if your glucose is predicted to be above this limit for the next three hours."
           }
         },
         "sv" : {
@@ -201,6 +525,24 @@
             "value" : "%1$@ bazal insülin verecek ve yalnızca KŞ'nizin önümüzdeki üç saat boyunca bu sınırın üzerinde olacağı tahmin ediliyorsa bolus insülin önerecektir."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ will deliver basal and recommend bolus insulin only if your glucose is predicted to be above this limit for the next three hours."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ sẽ bơm insulin nền và đề xuất insulin bolus chỉ khi đường huyết của bạn được dự đoán sẽ cao hơn giới hạn này trong ba giờ tới."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ will deliver basal and recommend bolus insulin only if your glucose is predicted to be above this limit for the next three hours."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -212,55 +554,61 @@
     "%1$@%2$@%3$@" : {
       "comment" : "String format for value with units (1: value, 2: separator, 3: units)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@%3$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@%2$@%3$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@%2$@%3$@"
+            "value" : "%1$@ %2$@ %3$@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@%2$@%3$@"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ %2$@ %3$@"
@@ -268,31 +616,31 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@%2$@%3$@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@%2$@%3$@"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
@@ -304,25 +652,37 @@
         },
         "sv" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@%2$@%3$@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@%2$@%3$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         }
@@ -331,6 +691,12 @@
     "A value you have entered is higher than what is typically recommended for most people." : {
       "comment" : "Descriptive text for guardrail high value warning for schedule interface",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value you have entered is higher than what is typically recommended for most people."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -361,13 +727,25 @@
             "value" : "Une valeur a été entrée qui est supérieure ce qui est typiquement recommandé pour la majorité des personnes."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value you have entered is higher than what is typically recommended for most people."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value you have entered is higher than what is typically recommended for most people."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il valore inserito è superiore a quello tipicamente consigliato per la maggior parte delle persone."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "En verdi du har lagt inn er høyere enn det som vanligvis anbefales for de fleste."
@@ -385,16 +763,28 @@
             "value" : "Wprowadzona wartość jest wyższa niż zwykle zalecana dla większości osób."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valoarea pe care ați introdus-o este mai mare decât cea recomandată de obicei pentru majoritatea oamenilor."
+            "state" : "new",
+            "value" : "A value you have entered is higher than what is typically recommended for most people."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value you have entered is higher than what is typically recommended for most people."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Введенное вами значение выше, чем обычно рекомендуется для большинства людей."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value you have entered is higher than what is typically recommended for most people."
           }
         },
         "sv" : {
@@ -408,12 +798,42 @@
             "state" : "translated",
             "value" : "Girdiğiniz bir değer, çoğu insan için tipik olarak önerilenden daha yüksektir."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value you have entered is higher than what is typically recommended for most people."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giá trị bạn vừa nhập cao hơn mức thường được khuyến nghị cho hầu hết mọi người."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value you have entered is higher than what is typically recommended for most people."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value you have entered is higher than what is typically recommended for most people."
+          }
         }
       }
     },
     "A value you have entered is lower than what is typically recommended for most people." : {
       "comment" : "Descriptive text for guardrail low value warning for schedule interface",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value you have entered is lower than what is typically recommended for most people."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -444,13 +864,25 @@
             "value" : "Une valeur a été entrée qui est inférieure à ce qui est typiquement recommandé pour la majorité des personnes."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value you have entered is lower than what is typically recommended for most people."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value you have entered is lower than what is typically recommended for most people."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il valore inserito è inferiore a quello tipicamente consigliato per la maggior parte delle persone."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "En verdi du har lagt inn er lavere enn det som vanligvis anbefales for de fleste."
@@ -468,16 +900,28 @@
             "value" : "Wprowadzona wartość jest niższa niż zwykle zalecana dla większości osób."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valoarea pe care ați introdus-o este mai mica decât cea recomandată de obicei pentru majoritatea oamenilor."
+            "state" : "new",
+            "value" : "A value you have entered is lower than what is typically recommended for most people."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value you have entered is lower than what is typically recommended for most people."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Введенное вами значение ниже того, которое обычно рекомендуется для большинства людей."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value you have entered is lower than what is typically recommended for most people."
           }
         },
         "sv" : {
@@ -491,67 +935,133 @@
             "state" : "translated",
             "value" : "Girdiğiniz bir değer, çoğu insan için tipik olarak önerilenden daha düşüktür."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value you have entered is lower than what is typically recommended for most people."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giá trị bạn vừa nhập thấp hơn mức thường được khuyến nghị cho hầu hết mọi người."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value you have entered is lower than what is typically recommended for most people."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value you have entered is lower than what is typically recommended for most people."
+          }
         }
       }
     },
     "Afrezza" : {
       "comment" : "Brand name for afrezza insulin type\nTitle for Afrezza insulin type",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Afrezza"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Afrezza"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Afrezza"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Afrezza"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Afrezza"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Afrezza"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Afrezza"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Afrezza"
           }
         },
-        "ro" : {
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
+        "sk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afrezza"
           }
         },
-        "ru" : {
+        "sv" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afrezza"
@@ -559,7 +1069,31 @@
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
             "state" : "translated",
+            "value" : "Afrezza"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Afrezza"
           }
         }
@@ -568,6 +1102,12 @@
     "Afrezza is an ultra rapid-acting mealtime insulin that is breathed in through your lungs using an oral inhaler and made by MannKind" : {
       "comment" : "Description for afrezza insulin type",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afrezza هو أنسولين فائق السرعة يُستخدم في أوقات الوجبات، ويُستَنشَق عن طريق الرئتين باستخدام جهاز استنشاق فموي، من إنتاج شركة MannKind"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -577,7 +1117,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Afrezza ist ein ultraschnell wirkendes Mahlzeiteninsulin, das mit einem oralen Inhalator durch Deine Lungen eingeatmet wird und von MannKind hergestellt wird."
+            "value" : "Afrezza ist ein ultraschnell wirkendes Mahlzeiteninsulin, das mit einem oralen Inhalator durch Ihre Lungen eingeatmet wird und von MannKind hergestellt wird."
           }
         },
         "es" : {
@@ -586,19 +1126,37 @@
             "value" : "Afrezza es una insulina de acción ultrarrápida que se inhala a través de los pulmones mediante un inhalador oral, fabricado por MannKind."
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza is an ultra rapid-acting mealtime insulin that is breathed in through your lungs using an oral inhaler and made by MannKind"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afrezza est une insuline prandiale à action ultra rapide qui est inhalée par vos poumons à l'aide d'un inhalateur oral et fabriquée par MannKind."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza is an ultra rapid-acting mealtime insulin that is breathed in through your lungs using an oral inhaler and made by MannKind"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza is an ultra rapid-acting mealtime insulin that is breathed in through your lungs using an oral inhaler and made by MannKind"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Afrezza è un'insulina ad azione ultra rapida somministrata durante i pasti, che viene inalata attraverso i polmoni tramite un inalatore orale ed è prodotta da MannKind"
+            "value" : "Afrezza è un'insulina prandiale ad azione ultra rapida che viene inalata attraverso i polmoni utilizzando un inalatore orale e prodotta da MannKind"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afrezza er et ultrahurtigvirkende måltidsinsulin som pustes inn gjennom lungene ved hjelp av en oral inhalator og laget av MannKind"
@@ -616,10 +1174,16 @@
             "value" : "Afrezza to ultraszybko działająca doposiłkowa insulina wziewna, którą wdycha się przy użyciu doustnego inhalatora, wytwarzana przez firmę MannKind."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afrezza este o insulină cu acțiune ultra rapidă în timpul mesei, care este inspirată prin plămâni folosind un inhalator oral și produsă de MannKind."
+            "state" : "new",
+            "value" : "Afrezza is an ultra rapid-acting mealtime insulin that is breathed in through your lungs using an oral inhaler and made by MannKind"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza is an ultra rapid-acting mealtime insulin that is breathed in through your lungs using an oral inhaler and made by MannKind"
           }
         },
         "ru" : {
@@ -628,10 +1192,46 @@
             "value" : "Afrezza - это инсулин сверхбыстрого действия во время еды, который вдыхается через легкие с помощью перорального ингалятора и производится MannKind"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afrezza je ultrarýchlo pôsobiaci bolusový inzulín, ktorý sa vdychuje cez pľúca pomocou perorálneho inhalátora vyrábaný spoločnosťou MannKind"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afrezza är ett ultrasnabbverkande insulin som andas in genom lungorna med hjälp av en oral inhalator och tillverkas av MannKind"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afrezza, oral bir inhaler kullanılarak akciğerlerinizden solunan ve MannKind tarafından üretilen ultra hızlı etkili bir öğün insülinidir."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afrezza - це інсулін надшвидкої дії під час їжі, який вдихається через легені за допомогою перорального інгалятора та виробляється MannKind"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afrezza là loại insulin tác dụng cực nhanh dùng vào bữa ăn, được hít vào phổi bằng ống hít và được sản xuất bởi MannKind"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza is an ultra rapid-acting mealtime insulin that is breathed in through your lungs using an oral inhaler and made by MannKind"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza is an ultra rapid-acting mealtime insulin that is breathed in through your lungs using an oral inhaler and made by MannKind"
           }
         }
       }
@@ -639,63 +1239,87 @@
     "Apidra" : {
       "comment" : "Brand name for apidra insulin type",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Apidra"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Apidra"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Apidra"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Apidra"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Apidra"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Apidra"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Apidra"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Apidra"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Apidra"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Apidra"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Apidra"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Apidra"
           }
         },
@@ -703,6 +1327,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Апидра"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apidra"
           }
         },
         "sv" : {
@@ -713,7 +1343,31 @@
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
             "state" : "translated",
+            "value" : "Apidra"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Apidra"
           }
         }
@@ -722,6 +1376,12 @@
     "Apidra (insulin glulisine)" : {
       "comment" : "Title for Apidra insulin type",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra (insulin glulisine)"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -752,13 +1412,25 @@
             "value" : "Apidra (insuline glulisine)"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra (insulin glulisine)"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra (insulin glulisine)"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Apidra (insulina glulisina)"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Apidra (insulin glulisin)"
@@ -776,16 +1448,28 @@
             "value" : "Apidra (insulina glulizynowa)"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apidra (insulină glulisine)"
+            "state" : "new",
+            "value" : "Apidra (insulin glulisine)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra (insulin glulisine)"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Апидра (инсулин глюлизин)"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apidra (inzulín glulizín)"
           }
         },
         "sv" : {
@@ -799,12 +1483,42 @@
             "state" : "translated",
             "value" : "Apidra (insülin glulisin)"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra (insulin glulisine)"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apidra (insulin glulisine)"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra (insulin glulisine)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra (insulin glulisine)"
+          }
         }
       }
     },
     "Apidra (insulin glulisine) is a rapid-acting insulin made by Sanofi-aventis " : {
       "comment" : "Description for apidra insulin type",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra (insulin glulisine) is a rapid-acting insulin made by Sanofi-aventis "
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -823,10 +1537,28 @@
             "value" : "Apidra (insulina glulisina) es una insulina de acción rápida fabricada por Sanofi-aventis"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra (insulin glulisine) is a rapid-acting insulin made by Sanofi-aventis "
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Apidra (insuline glulisine) est une insuline à action rapide fabriquée par Sanofi-Aventis "
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra (insulin glulisine) is a rapid-acting insulin made by Sanofi-aventis "
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra (insulin glulisine) is a rapid-acting insulin made by Sanofi-aventis "
           }
         },
         "it" : {
@@ -835,7 +1567,7 @@
             "value" : "Apidra (insulina glulisina) è un'insulina ad azione rapida prodotta da Sanofi-aventis"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Apidra (insulin glulisin) er et hurtigvirkende insulin laget av Sanofi-aventis"
@@ -853,10 +1585,16 @@
             "value" : "Apidra (insulina glulizynowa) to szybko działająca insulina firmy Sanofi-Aventis."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apidra (insulina glulizină) este o insulină cu acțiune rapidă produsă de Sanofi-aventis"
+            "state" : "new",
+            "value" : "Apidra (insulin glulisine) is a rapid-acting insulin made by Sanofi-aventis "
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra (insulin glulisine) is a rapid-acting insulin made by Sanofi-aventis "
           }
         },
         "ru" : {
@@ -865,10 +1603,46 @@
             "value" : "Апидра (инсулин глюлизин) - это инсулин быстрого действия, производимый Sanofi-aventis "
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apidra (inzulín glulizín) je rýchlo pôsobiaci inzulín glulizín vyrábaný spoločnosťou Sanofi "
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apidra (insulin glulisine) är ett snabbverkande insulin från Sanofi-aventis "
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Apidra (insülin glulisine) Sanofi-aventis tarafından üretilen hızlı etkili bir insülindir"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra (insulin glulisine) is a rapid-acting insulin made by Sanofi-aventis "
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apidra (insulin glulisine) là loại insulin tác dụng nhanh do Sanofi-Aventis sản xuất "
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra (insulin glulisine) is a rapid-acting insulin made by Sanofi-aventis "
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apidra (insulin glulisine) is a rapid-acting insulin made by Sanofi-aventis "
           }
         }
       }
@@ -877,16 +1651,136 @@
       "comment" : "The error description describing when Health sharing was denied",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Autorizzazione negata"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Autorisasjon avslått"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auktorisation nekad"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cấp quyền bị từ chối"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
           }
         }
       }
@@ -894,6 +1788,12 @@
     "Basal" : {
       "comment" : "Title for basal dose type",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "القاعدية"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -908,19 +1808,31 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Basal"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Basaali"
+            "value" : "Basaalinen"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Basal"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Basal"
           }
         },
@@ -930,9 +1842,9 @@
             "value" : "Basale"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Basal"
           }
         },
@@ -945,19 +1857,31 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dawka podstawowa"
+            "value" : "Podstawowy"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bazală"
+            "state" : "new",
+            "value" : "Basal"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Базал"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bazálna"
           }
         },
         "sv" : {
@@ -971,6 +1895,30 @@
             "state" : "translated",
             "value" : "Bazal"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Базал"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Basal"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "基础"
+          }
         }
       }
     },
@@ -981,12 +1929,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "الضخ المستمر"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Úrovně bazálu"
           }
         },
         "da" : {
@@ -1021,7 +1963,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Basal Rates"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Basal Rates"
           }
         },
@@ -1031,13 +1979,7 @@
             "value" : "Velocità basali"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "基礎レート"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Basal-satser"
@@ -1055,16 +1997,16 @@
             "value" : "Dawka Podstawowa (Baza)"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal Rates"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Taxas Basais"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rate bazale"
           }
         },
         "ru" : {
@@ -1091,10 +2033,22 @@
             "value" : "Bazal Oranlar"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Швидкості Базалу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lịch biểu tiêm liều nền"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal Rates"
           }
         },
         "zh-Hans" : {
@@ -1111,7 +2065,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bolus"
+            "value" : "الجرعة"
           }
         },
         "da" : {
@@ -1135,7 +2089,7 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bolus"
+            "value" : "Lisäannos"
           }
         },
         "fr" : {
@@ -1146,8 +2100,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Bolus"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bólus"
           }
         },
         "it" : {
@@ -1156,13 +2116,7 @@
             "value" : "Bolo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ボーラス"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bolus"
@@ -1176,19 +2130,19 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Bolus"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Bolus"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bolus"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Bolus"
           }
         },
@@ -1212,14 +2166,32 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Bolus"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Болюс"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bolus"
+            "value" : "Liều bolus"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bolus Value"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大剂量"
           }
         }
       }
@@ -1236,91 +2208,91 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kulhydratforhold"
+            "value" : "Kolhydratsratio"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "KH-Verhältnis"
+            "value" : "Kohlenhydratfaktoren"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ratios de carbohidratos"
+            "value" : "Ratio de carbohidratos"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hiilihydraattisuhteet"
+            "value" : "Hiilihydraattisuhde"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ratios Insuline-Glucides"
+            "value" : "Ratios de glucides"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Carb Ratios"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Szénhidrát arány"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Rapporti carboidrati"
+            "value" : "Rapporto carboidrati"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Carb Ratios"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Karb forhold"
+            "value" : "Karbohydratforhold"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Koolhydraatratio's"
+            "value" : "Koolhydraten ratio's"
           }
         },
         "pl" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Carb Ratios"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "Współczynniki węglowodanowe"
+            "value" : "Taxas de carbo"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Taxas de Carbs"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Raport carbohidrați/insulină"
+            "value" : "Taxas de carbo"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Соотношения углеводов"
+            "value" : "Углеводные коэффициенты"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Inzulínovo sacharidový pomer"
+            "value" : "Sacharidový pomer"
           }
         },
         "sv" : {
@@ -1335,16 +2307,28 @@
             "value" : "Karbonhidrat Oranları"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вуглеводні Коефіцієнти"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Tỷ lệ Carb"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Carb Ratios"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "碳水化合物吸收率"
+            "value" : "碳水化合物系数"
           }
         }
       }
@@ -1353,16 +2337,136 @@
       "comment" : "Recovery instruction for an uncertain bolus failure",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check your pump before retrying"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check your pump before retrying"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check your pump before retrying"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check your pump before retrying"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check your pump before retrying"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check your pump before retrying"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check your pump before retrying"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check your pump before retrying"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Controlla la pompa prima di riprovare"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sjekk pumpen din før du prøver på nytt"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check your pump before retrying"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check your pump before retrying"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check your pump before retrying"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check your pump before retrying"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check your pump before retrying"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check your pump before retrying"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kontrollera din pump innan du försöker igen"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check your pump before retrying"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check your pump before retrying"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kiểm tra lại bơm trước khi thử lại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check your pump before retrying"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check your pump before retrying"
           }
         }
       }
@@ -1371,16 +2475,22 @@
       "comment" : "The description of an error returned when attempting to delete a sample not shared by the current app",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilladelse nægtet"
+            "state" : "new",
+            "value" : "Authorization Denied"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autorisierung verweigert"
+            "state" : "new",
+            "value" : "Authorization Denied"
           }
         },
         "en" : {
@@ -1391,26 +2501,32 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autorización Denegada"
+            "state" : "new",
+            "value" : "Authorization Denied"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valtuutus hylättiin"
+            "state" : "new",
+            "value" : "Authorization Denied"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autorisation refusée"
+            "state" : "new",
+            "value" : "Authorization Denied"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "הרשאה נדחתה"
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
           }
         },
         "it" : {
@@ -1419,13 +2535,7 @@
             "value" : "Autorizzazione negata"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "認証が拒否されました"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Autorisasjon avslått"
@@ -1433,32 +2543,38 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autorisatie Geweigerd"
+            "state" : "new",
+            "value" : "Authorization Denied"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odmowa autoryzacji"
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autorização negada"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autorizare refuzată"
+            "state" : "new",
+            "value" : "Authorization Denied"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Авторизация не состоялась"
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
           }
         },
         "sv" : {
@@ -1469,8 +2585,14 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yetkilendirme Reddedildi"
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
           }
         },
         "vi" : {
@@ -1479,10 +2601,16 @@
             "value" : "Cấp quyền bị từ chối"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authorization Denied"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "没有权限"
+            "state" : "new",
+            "value" : "Authorization Denied"
           }
         }
       }
@@ -1491,6 +2619,12 @@
       "comment" : "The error recovery suggestion when attempting to delete a sample not shared by the current app",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This sample can be deleted from the Health app"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1533,19 +2667,19 @@
             "value" : "ניתן למחוק דגימה זו מאפליקציית Health"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This sample can be deleted from the Health app"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Questo campione può essere eliminato dall'app Salute"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This sample can be deleted from the Health app"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Denne testen kan slettes fra Helse-appen"
@@ -1563,22 +2697,28 @@
             "value" : "Ten wynik może być usunięty z aplikacji Zdrowie"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This sample can be deleted from the Health app"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Este exemplo pode ser excluído do app Saúde"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acest exemplu poate fi șters din aplicația Sănătate"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Этот экземпляр может быть удален из приложения Здоровье"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This sample can be deleted from the Health app"
           }
         },
         "sv" : {
@@ -1593,10 +2733,22 @@
             "value" : "Bu örnek Health uygulamasından silinebilir"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This sample can be deleted from the Health app"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mẫu này có thể bị xóa khỏi ứng dụng Health"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This sample can be deleted from the Health app"
           }
         },
         "zh-Hans" : {
@@ -1610,6 +2762,12 @@
     "Communication Failure" : {
       "comment" : "Generic pump error description",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Communication Failure"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1642,7 +2800,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Communication Failure"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Communication Failure"
           }
         },
@@ -1652,13 +2816,7 @@
             "value" : "Errore di comunicazione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通信エラー"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kommunikasjonsfeil"
@@ -1676,22 +2834,28 @@
             "value" : "Błąd komunikacji"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Communication Failure"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Falha de Comunicação"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eroare de comunicare"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ошибка связи"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Communication Failure"
           }
         },
         "sv" : {
@@ -1706,10 +2870,22 @@
             "value" : "İletişim Hatası"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Communication Failure"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Liên lạc thất bại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Communication Failure"
           }
         },
         "zh-Hans" : {
@@ -1723,6 +2899,12 @@
     "Communications interrupted during insulin delivery command." : {
       "comment" : "Failure reason for uncertain delivery",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Communications interrupted during insulin delivery command."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1753,13 +2935,25 @@
             "value" : "Communications interrompues pendant la commande d’administration d’insuline."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Communications interrupted during insulin delivery command."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Communications interrupted during insulin delivery command."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Comunicazioni interrotte durante il comando di erogazione dell'insulina."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kommunikasjonen ble avbrutt ved administrasjon av insulin."
@@ -1777,16 +2971,28 @@
             "value" : "Komunikacja przerwana podczas polecenia podania insuliny."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comunicații întrerupte în timpul comenzii de livrare a insulinei."
+            "state" : "new",
+            "value" : "Communications interrupted during insulin delivery command."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Communications interrupted during insulin delivery command."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Связь прервана во время подачи команды на введение инсулина."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Communications interrupted during insulin delivery command."
           }
         },
         "sv" : {
@@ -1800,12 +3006,42 @@
             "state" : "translated",
             "value" : "İnsülin iletim komutu sırasında iletişim kesildi."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Communications interrupted during insulin delivery command."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kết nối bị gián đoạn trong khi gửi lệnh bơm insulin."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Communications interrupted during insulin delivery command."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Communications interrupted during insulin delivery command."
+          }
         }
       }
     },
     "Connection Failure" : {
       "comment" : "Generic pump error description",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connection Failure"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1838,7 +3074,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Connection Failure"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Connection Failure"
           }
         },
@@ -1848,13 +3090,7 @@
             "value" : "Errore di connessione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "接続エラー"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tilkoblingsfeil"
@@ -1872,22 +3108,28 @@
             "value" : "Błąd połączenia"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connection Failure"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Falha na Conexão"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eroare de conectare"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ошибка соединения"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connection Failure"
           }
         },
         "sv" : {
@@ -1902,10 +3144,22 @@
             "value" : "Bağlantı hatası"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connection Failure"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kết nối thất bại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connection Failure"
           }
         },
         "zh-Hans" : {
@@ -1957,7 +3211,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Correction Range"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Correction Range"
           }
         },
@@ -1967,13 +3227,7 @@
             "value" : "Intervallo di correzione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ターゲット範囲"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Korreksjonsområde"
@@ -1991,22 +3245,28 @@
             "value" : "Zakres docelowy"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Range"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Faixa de Correção"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Interval țintă pentru corecție"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Диапазон коррекции"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Range"
           }
         },
         "sv" : {
@@ -2021,10 +3281,22 @@
             "value" : "Düzeltme Aralığı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Range"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Phạm vi liều Bổ sung"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Range"
           }
         },
         "zh-Hans" : {
@@ -2038,6 +3310,12 @@
     "Correction Range is the glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin and helping you calculate your boluses." : {
       "comment" : "Descriptive text for glucose target range (1: app name)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Range is the glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin and helping you calculate your boluses."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2068,13 +3346,25 @@
             "value" : "La plage de correction est la valeur de glucose (ou la plage de valeurs) que vous voulez que %1$@ vise en ajustant votre insuline basale et en vous aidant à calculer vos bolus."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Range is the glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin and helping you calculate your boluses."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Range is the glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin and helping you calculate your boluses."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "L'intervallo di correzione è il valore di glicemia (o intervallo di valori) che %1$@ deve raggiungere per regolare l'insulina basale e aiutarti a calcolare i boli."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Korreksjonsområde er blodsukkerverdien (eller verdiområdet) som du vil at %1$@ skal sikte på for å justere basalinsulinet og hjelpe deg med å beregne bolusene dine."
@@ -2092,16 +3382,28 @@
             "value" : "Zakres docelowy (zakres korekty) to wartość glukozy (lub zakres wartości), do której chcesz dążyć %1$@ podczas dostosowywania insuliny bazowej i pomagania w obliczaniu bolusów."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intervalul de corecție este valoarea glicemiei (sau intervalul de valori) spre care doriți ca %1$@ să țintească în ajustarea insulinei bazale și în calculul bolusurilor."
+            "state" : "new",
+            "value" : "Correction Range is the glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin and helping you calculate your boluses."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Range is the glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin and helping you calculate your boluses."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Диапазон коррекции - это значение глюкозы (или диапазон значений), к которому вы хотите, чтобы %1$@ стремился при корректировке ВБС и расчете болюсов."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Range is the glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin and helping you calculate your boluses."
           }
         },
         "sv" : {
@@ -2116,6 +3418,24 @@
             "value" : "Düzeltme Aralığı, bazal insülininizi ayarlamak ve boluslarınızı hesaplamanıza yardımcı olmak için %1$@ 'ın hedeflemesini istediğiniz KŞ değeridir (veya değer aralığıdır)."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Range is the glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin and helping you calculate your boluses."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khoảng hiệu chỉnh là giá trị đường huyết (hoặc khoảng giá trị) mà bạn muốn %1$@ nhắm tới để điều chỉnh insulin nền và hỗ trợ bạn tính toán liều bolus."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Range is the glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin and helping you calculate your boluses."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2127,6 +3447,12 @@
     "Critical Update" : {
       "comment" : "Description of critical software update needed",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Critical Update"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2145,10 +3471,28 @@
             "value" : "Actualización crítica"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Critical Update"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mise à jour critique"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Critical Update"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Critical Update"
           }
         },
         "it" : {
@@ -2157,7 +3501,7 @@
             "value" : "Aggiornamento critico"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kritisk oppdatering"
@@ -2175,10 +3519,16 @@
             "value" : "Krytyczna aktualizacja"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizare critică"
+            "state" : "new",
+            "value" : "Critical Update"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Critical Update"
           }
         },
         "ru" : {
@@ -2187,10 +3537,46 @@
             "value" : "Критическое обновление"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Critical Update"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kritisk uppdatering"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kritik Güncelleme"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Critical Update"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bản cập nhật quan trọng"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Critical Update"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Critical Update"
           }
         }
       }
@@ -2202,12 +3588,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "حدود الضخ"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limity podávání"
           }
         },
         "da" : {
@@ -2242,23 +3622,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Delivery Limits"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Delivery Limits"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Limiti di erogazione"
+            "value" : "Limiti Erogazione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "注入限度"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Leveringsgrenser"
@@ -2276,16 +3656,16 @@
             "value" : "Limity podawania"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delivery Limits"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Limites de Entrega"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limite de livrare"
           }
         },
         "ru" : {
@@ -2312,10 +3692,22 @@
             "value" : "İletim Limitleri"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ліміти подачі"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Giới hạn liều tiêm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delivery Limits"
           }
         },
         "zh-Hans" : {
@@ -2329,6 +3721,12 @@
     "Device Refused" : {
       "comment" : "Generic pump error description",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Refused"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2361,7 +3759,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Device Refused"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Device Refused"
           }
         },
@@ -2371,13 +3775,7 @@
             "value" : "Dispositivo rifiutato"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "機器拒否"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enheten nektet"
@@ -2395,22 +3793,28 @@
             "value" : "Urządzenie odmówiło"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Refused"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dispositivo Recusado"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dispozitiv refuzat"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Устройство отклонено"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Refused"
           }
         },
         "sv" : {
@@ -2425,10 +3829,22 @@
             "value" : "Cihaz Reddedildi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Refused"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thiết bị bị từ chối"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Refused"
           }
         },
         "zh-Hans" : {
@@ -2442,10 +3858,52 @@
     "Device Status Critical" : {
       "comment" : "Accessibility label for device status critical state",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Critical"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Critical"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gerätestatus Kritisch"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Critical"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Critical"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Critical"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Critical"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Critical"
           }
         },
         "it" : {
@@ -2454,10 +3912,16 @@
             "value" : "Stato del dispositivo critico"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enhetens status er kritisk"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Critical"
           }
         },
         "pl" : {
@@ -2466,10 +3930,64 @@
             "value" : "Krytyczny stan urządzenia"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Critical"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Critical"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Критическое состояние устройства"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Critical"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enhetsstatus kritisk"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Critical"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Critical"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thiết bị ở trạng thái nguy cấp"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Critical"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Critical"
           }
         }
       }
@@ -2477,10 +3995,52 @@
     "Device Status Normal" : {
       "comment" : "Accessibility label for device status normal state",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Normal"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Normal"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gerätestatus Normal"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Normal"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Normal"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Normal"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Normal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Normal"
           }
         },
         "it" : {
@@ -2489,10 +4049,16 @@
             "value" : "Stato del dispositivo normale"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enhetens status er Normal"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Normal"
           }
         },
         "pl" : {
@@ -2501,10 +4067,64 @@
             "value" : "Stan urządzenia Normalny"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Normal"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Normal"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Нормальное состояние устройства"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Normal"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normal enhetsstatus"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Normal"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Normal"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trạng thái thiết bị Bình thường"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Normal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Normal"
           }
         }
       }
@@ -2512,10 +4132,52 @@
     "Device Status Warning" : {
       "comment" : "Accessibility label for device status warning state",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Warning"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Warning"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gerätestatus Warnung"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Warning"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Warning"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Warning"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Warning"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Warning"
           }
         },
         "it" : {
@@ -2524,10 +4186,16 @@
             "value" : "Avviso sullo stato del dispositivo"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Advarsel om enhetsstatus"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Warning"
           }
         },
         "pl" : {
@@ -2536,10 +4204,64 @@
             "value" : "Ostrzeżenie o stanie urządzenia"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Warning"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Warning"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Предупреждение о состоянии устройства"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Warning"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enhetsstatusvarning"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Warning"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Warning"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cảnh báo trạng thái thiết bị"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Warning"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Status Warning"
           }
         }
       }
@@ -2547,6 +4269,12 @@
     "Ensure carb data exists for the specified date" : {
       "comment" : "Recovery suggestion for a no data error",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Ensure carb data exists for the specified date"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2579,7 +4307,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Ensure carb data exists for the specified date"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Ensure carb data exists for the specified date"
           }
         },
@@ -2589,13 +4323,7 @@
             "value" : "Assicurati che i dati sui carboidrati esistano per la data specificata"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "指定した日に糖質のデータがあるか確認してください"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verifiser at karbohydratoppføring eksisterer for den valgte datoen"
@@ -2613,22 +4341,28 @@
             "value" : "Upewnij się, że wartość istnieje w tej dacie"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Ensure carb data exists for the specified date"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verifique se os dados de carboidratos existem na data especificada"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asigurați-vă că există date despre carbohidrați pentru data specificată"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Убедитесь, что данные об углеводах имеются на указанную дату"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Ensure carb data exists for the specified date"
           }
         },
         "sv" : {
@@ -2643,10 +4377,22 @@
             "value" : "Belirtilen tarih için karbonhidrat verilerinin var olduğundan emin olun"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Ensure carb data exists for the specified date"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đảm bảo dữ liệu carb tồn tại cho ngày cụ thể"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Ensure carb data exists for the specified date"
           }
         },
         "zh-Hans" : {
@@ -2660,6 +4406,12 @@
     "Falling" : {
       "comment" : "Glucose trend down",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Falling"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2692,7 +4444,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Falling"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Falling"
           }
         },
@@ -2702,13 +4460,7 @@
             "value" : "Abbassamento"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "降下"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Synker"
@@ -2726,22 +4478,28 @@
             "value" : "Spadek"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Falling"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Caindo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "În scădere"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Падение"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Falling"
           }
         },
         "sv" : {
@@ -2756,10 +4514,22 @@
             "value" : "Düşüyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Falling"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang hạ"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Falling"
           }
         },
         "zh-Hans" : {
@@ -2773,6 +4543,12 @@
     "Falling fast" : {
       "comment" : "Glucose trend down-down",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Falling fast"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2805,7 +4581,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Falling fast"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Falling fast"
           }
         },
@@ -2815,13 +4597,7 @@
             "value" : "Abbassamento veloce"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "急降下"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Synker raskt"
@@ -2839,22 +4615,28 @@
             "value" : "Szybki spadek"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Falling fast"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Caindo rápido"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "În scădere rapidă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Быстрое падение"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Falling fast"
           }
         },
         "sv" : {
@@ -2869,10 +4651,22 @@
             "value" : "Hızlı Düşüyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Falling fast"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang hạ nhanh"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Falling fast"
           }
         },
         "zh-Hans" : {
@@ -2886,6 +4680,12 @@
     "Falling very fast" : {
       "comment" : "Glucose trend down-down-down",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Falling very fast"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2918,7 +4718,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Falling very fast"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Falling very fast"
           }
         },
@@ -2928,13 +4734,7 @@
             "value" : "Abbassamento molto veloce"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "超急降下"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Synker veldig raskt"
@@ -2952,22 +4752,28 @@
             "value" : "Bardzo szybki spadek"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Falling very fast"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Caindo muito rápido"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "În scădere foarte rapidă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Очень быстрое падение"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Falling very fast"
           }
         },
         "sv" : {
@@ -2982,10 +4788,22 @@
             "value" : "Çok Hızlı Düşüyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Falling very fast"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang hạ rất nhanh"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Falling very fast"
           }
         },
         "zh-Hans" : {
@@ -3001,89 +4819,95 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Fiasp"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fiasp"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Fiasp"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fiasp"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fiasp"
+          }
+        },
+        "sk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fiasp"
@@ -3097,7 +4921,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Fiasp"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
@@ -3107,9 +4937,15 @@
             "value" : "Fiasp"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fiasp"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         }
@@ -3118,6 +4954,12 @@
     "Fiasp is a mealtime insulin aspart formulation with the addition of nicotinamide (vitamin B3) made by Novo Nordisk" : {
       "comment" : "Description for fiasp insulin type",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fiasp هو تركيبة من أنسولين أسبارت مخصصة لوقت الوجبات، مع إضافة النيكوتيناميد (فيتامين B3)، من إنتاج شركة Novo Nordisk"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3148,13 +4990,25 @@
             "value" : "Fiasp est une formulation d'insuline asparte prandiale avec ajout de nicotinamide (vitamine B3) qui est produite par Novo Nordisk"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fiasp is a mealtime insulin aspart formulation with the addition of nicotinamide (vitamin B3) made by Novo Nordisk"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fiasp is a mealtime insulin aspart formulation with the addition of nicotinamide (vitamin B3) made by Novo Nordisk"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fiasp è una formulazione d'insulina ad azione rapida con un l'aggiunta di Nicotinamide (vitamina B3) prodotta da Novo Nordisk."
+            "value" : "Fiasp è una formulazione di insulina ad azione rapida con un l'aggiunta di Nicotinamide (vitamina B3) prodotta da Novo Nordisk. "
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fiasp er en måltidsformulering av insulin aspart i tillegg til nikotinamid (vitamin B3) laget av Novo Nordisk"
@@ -3172,16 +5026,28 @@
             "value" : "Fiasp to insulina aspart do posiłków z dodatkiem nikotynamidu (witaminy B3) firmy Novo Nordisk."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fiasp este o formă de insulină aspart administrată în timpul mesei, cu adaos de nicotinamidă (vitamina B3) produsă de Novo Nordisk"
+            "state" : "new",
+            "value" : "Fiasp is a mealtime insulin aspart formulation with the addition of nicotinamide (vitamin B3) made by Novo Nordisk"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fiasp is a mealtime insulin aspart formulation with the addition of nicotinamide (vitamin B3) made by Novo Nordisk"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fiasp - это препарат инсулин аспарт с добавлением никотинамида (витамина B3) производства Novo Nordisk"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fiasp je bolusový inzulín aspartát s prídavkom nikotínamidu (vitamín B3) vyrábaný spoločnosťou Novo Nordisk"
           }
         },
         "sv" : {
@@ -3195,12 +5061,42 @@
             "state" : "translated",
             "value" : "Fiasp, Novo Nordisk tarafından üretilen nikotinamid (B3 vitamini) ilaveli bir öğün insülin aspart formülasyonudur"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fiasp — це препарат інсуліну аспарт під час прийому їжі з додаванням нікотинаміду (вітамін B3), виготовлений компанією Novo Nordisk."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fiasp là một công thức insulin aspart dùng trong bữa ăn có bổ sung nicotinamide (vitamin B3) do Novo Nordisk sản xuất"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fiasp is a mealtime insulin aspart formulation with the addition of nicotinamide (vitamin B3) made by Novo Nordisk"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fiasp is a mealtime insulin aspart formulation with the addition of nicotinamide (vitamin B3) made by Novo Nordisk"
+          }
         }
       }
     },
     "Flat" : {
       "comment" : "Glucose trend flat",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Flat"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3233,7 +5129,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Flat"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Flat"
           }
         },
@@ -3243,13 +5145,7 @@
             "value" : "Piatto"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "平坦"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Flatt"
@@ -3267,22 +5163,28 @@
             "value" : "Powolna zmiana"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Flat"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Estável"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Constantă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Стабильно"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Flat"
           }
         },
         "sv" : {
@@ -3297,9 +5199,21 @@
             "value" : "Sabit"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Flat"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Ổn định"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Flat"
           }
         },
@@ -3314,6 +5228,12 @@
     "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from different models for the peak activity." : {
       "comment" : "Descriptive text for fast acting insulin model (1: app name)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from different models for the peak activity."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3344,13 +5264,25 @@
             "value" : "Pour l'insuline à action rapide, %1$@ suppose qu'elle agit activement pendant 6 heures. Vous pouvez choisir parmi différents modèles pour le pic d'activité."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from different models for the peak activity."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from different models for the peak activity."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Per l'insulina ad azione rapida, %1$@ presuppone che agisca attivamente per 6 ore. È possibile scegliere tra diversi modelli per l'attività massima."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "For hurtigvirkende insulin antar %1$@ at det virker aktivt i 6 timer. Du kan velge mellom ulike modeller for toppaktiviteten."
@@ -3368,16 +5300,28 @@
             "value" : "W przypadku szybko działającej insuliny %1$@ zakłada jej działanie przez 6 godzin. Możesz wybrać spośród różnych modeli szczytowej aktywności."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pentru insulina cu acțiune rapida, %1$@ presupune ca funcționează activ timp de 6 ore. Poți alege dintre modele diferite pentru vârful acțiunii."
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from different models for the peak activity."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from different models for the peak activity."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Для быстродействующего инсулина %1$@ предполагается, что он активно работает в течение 6 часов. Вы можете выбрать различные модели для пика активности."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from different models for the peak activity."
           }
         },
         "sv" : {
@@ -3391,12 +5335,42 @@
             "state" : "translated",
             "value" : "Hızlı etkili insülin için, %1$@ 6 saat boyunca aktif olarak çalıştığını varsayar. En yüksek etki için farklı modeller arasından seçim yapabilirsiniz."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from different models for the peak activity."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đối với insulin tác dụng nhanh, %1$@ giả định rằng nó có hiệu lực trong 6 giờ. Bạn có thể chọn các mô hình khác nhau cho thời điểm hoạt động đỉnh."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from different models for the peak activity."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from different models for the peak activity."
+          }
         }
       }
     },
     "g/U" : {
       "comment" : "The short unit display string for grams per U",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "غرام لكل وحدة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3417,7 +5391,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "g/U"
           }
         },
@@ -3429,6 +5403,12 @@
         },
         "he" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "g/U"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
             "state" : "translated",
             "value" : "g/U"
           }
@@ -3439,13 +5419,7 @@
             "value" : "g/U"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "g/U"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "g/E"
@@ -3459,26 +5433,32 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "g/J"
+            "state" : "new",
+            "value" : "g/U"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "g/U"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "g/U"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "g/U"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "g/U"
+            "value" : "г/Eд"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "g/J"
           }
         },
         "sv" : {
@@ -3490,12 +5470,24 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "gr/Ü"
+            "value" : "g/Ü"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "гр/U"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "g/U"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "g/U"
           }
         },
@@ -3510,6 +5502,12 @@
     "Glucose Safety Limit" : {
       "comment" : "Title text for glucose safety limit",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose Safety Limit"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3540,13 +5538,25 @@
             "value" : "Limite de sécurité pour la glycémie"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose Safety Limit"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose Safety Limit"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Limite glicemico di sicurezza"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sikkerhetsgrense for blodsukker"
@@ -3564,16 +5574,28 @@
             "value" : "Granica bezpiecznego poziomu glukozy"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limita de siguranță a glicemiei"
+            "state" : "new",
+            "value" : "Glucose Safety Limit"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose Safety Limit"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Безопасный предел глюкозы"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bezpečnostný limit glykémie"
           }
         },
         "sv" : {
@@ -3588,6 +5610,24 @@
             "value" : "KŞ Güvenlik Limiti"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose Safety Limit"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giới hạn an toàn đường huyết"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose Safety Limit"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3599,6 +5639,12 @@
     "Hour" : {
       "comment" : "The long unit display string for a singular hour",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hour"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3617,10 +5663,28 @@
             "value" : "Hora"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hour"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Heure"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hour"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hour"
           }
         },
         "it" : {
@@ -3629,7 +5693,7 @@
             "value" : "Ora"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Time"
@@ -3647,10 +5711,16 @@
             "value" : "Godzina"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oră"
+            "state" : "new",
+            "value" : "Hour"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hour"
           }
         },
         "ru" : {
@@ -3659,10 +5729,46 @@
             "value" : "Час"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hodina"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timme"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Saat"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hour"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giờ"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hour"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hour"
           }
         }
       }
@@ -3670,6 +5776,12 @@
     "Hours" : {
       "comment" : "The long unit display string for hours",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hours"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3688,10 +5800,28 @@
             "value" : "Horas"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hours"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Heures"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hours"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hours"
           }
         },
         "it" : {
@@ -3700,7 +5830,7 @@
             "value" : "Ore"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Timer"
@@ -3718,10 +5848,16 @@
             "value" : "Godziny"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ore"
+            "state" : "new",
+            "value" : "Hours"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hours"
           }
         },
         "ru" : {
@@ -3730,10 +5866,46 @@
             "value" : "Часы"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hours"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timmar"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Saat"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hours"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giờ"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hours"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hours"
           }
         }
       }
@@ -3741,63 +5913,87 @@
     "Humalog" : {
       "comment" : "Brand name for humalog insulin type",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Humalog"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Humalog"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Humalog"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Humalog"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Humalog"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Humalog"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Humalog"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Humalog"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Humalog"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Humalog"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Humalog"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Humalog"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Humalog"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Humalog"
           }
         },
@@ -3805,6 +6001,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Хумалог"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Humalog"
           }
         },
         "sv" : {
@@ -3815,7 +6017,31 @@
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Humalog"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Humalog"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
             "state" : "translated",
+            "value" : "Humalog"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Humalog"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Humalog"
           }
         }
@@ -3824,9 +6050,15 @@
     "Humalog (insulin lispro)" : {
       "comment" : "Title for Humalog insulin type",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Humalog (insulin lispro)"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Humalog (insulin lispro)"
           }
         },
@@ -3850,7 +6082,19 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Humalog (insulin lispro)"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Humalog (insulin lispro)"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Humalog (insulin lispro)"
           }
         },
@@ -3860,15 +6104,15 @@
             "value" : "Humalog (insulina lispro)"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Humalog (insulin lispro)"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Humalog (insulin lispro)"
           }
         },
@@ -3878,16 +6122,28 @@
             "value" : "Humalog (insulina lispro)"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Humalog (insulină lispro)"
+            "state" : "new",
+            "value" : "Humalog (insulin lispro)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Humalog (insulin lispro)"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Хумалог (инсулин лизпро)"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Humalog (inzulín lispro)"
           }
         },
         "sv" : {
@@ -3901,12 +6157,42 @@
             "state" : "translated",
             "value" : "Hümalog (insülin lispro)"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Humalog (insulin lispro)"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Humalog (insulin lispro)"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Humalog (insulin lispro)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Humalog (insulin lispro)"
+          }
         }
       }
     },
     "Humalog (insulin lispro) is a rapid-acting insulin made by Eli Lilly" : {
       "comment" : "Description for humalog insulin type",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Humalog (الأنسولين ليزبرو) هو أنسولين سريع المفعول من إنتاج شركة Eli Lilly"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3925,10 +6211,28 @@
             "value" : "Humalog (insulina lispro) es una insulina de acción rápida fabricada por Eli Lilly"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Humalog (insulin lispro) is a rapid-acting insulin made by Eli Lilly"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Humalog (insuline lispro) est une insuline à action rapide fabriquée par Eli Lilly"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Humalog (insulin lispro) is a rapid-acting insulin made by Eli Lilly"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Humalog (insulin lispro) is a rapid-acting insulin made by Eli Lilly"
           }
         },
         "it" : {
@@ -3937,7 +6241,7 @@
             "value" : "Humalog (insulin Lispro) è una insulina ad azione rapida prodotta dalla Ely Lilly"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Humalog (insulin lispro) er et hurtigvirkende insulin laget av Eli Lilly"
@@ -3955,10 +6259,16 @@
             "value" : "Humalog (insulina lispro) to szybko działająca insulina firmy Eli Lilly"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Humalog (insulina lispro) este o insulină cu acțiune rapidă produsă de Eli Lilly"
+            "state" : "new",
+            "value" : "Humalog (insulin lispro) is a rapid-acting insulin made by Eli Lilly"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Humalog (insulin lispro) is a rapid-acting insulin made by Eli Lilly"
           }
         },
         "ru" : {
@@ -3967,10 +6277,46 @@
             "value" : "Хумалог (инсулин лизпро) - это инсулин быстрого действия, производимый компанией Eli Lilly."
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Humalog je rýchlo pôsobiaci inzulín lispro vyrábaný spoločnosťou Eli Lilly"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Humalog (insulin lispro) är ett snabbverkande insulin tillverkat av Eli Lilly"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Humalog (insülin lispro), Eli Lilly tarafından üretilen hızlı etkili bir insülindir"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Humalog (інсулін лізпро) — інсулін швидкої дії, виготовлений компанією Eli Lilly"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Humalog (insulin lispro) là một loại insulin tác dụng nhanh do Eli Lilly sản xuất"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Humalog (insulin lispro) is a rapid-acting insulin made by Eli Lilly"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Humalog (insulin lispro) is a rapid-acting insulin made by Eli Lilly"
           }
         }
       }
@@ -4016,7 +6362,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Insulin Model"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Insulin Model"
           }
         },
@@ -4026,13 +6378,7 @@
             "value" : "Modello di azione dell'Insulina"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インスリンモデル"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Insulin modell"
@@ -4050,16 +6396,16 @@
             "value" : "Model insuliny"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Model"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Modelo de Insulina"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelul de insulină"
           }
         },
         "ru" : {
@@ -4086,10 +6432,22 @@
             "value" : "İnsülin Modeli"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Model"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chủng loại Insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Model"
           }
         },
         "zh-Hans" : {
@@ -4112,7 +6470,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulinfølsomheder"
+            "value" : "Insulin Sensitivitet"
           }
         },
         "de" : {
@@ -4124,25 +6482,31 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sensibilidad a la insulina"
+            "value" : "Factor de sensibilidad"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insuliiniherkkyydet"
+            "value" : "Insuliinin herkkyys"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Facteurs de sensibilité à l'insuline"
+            "value" : "Sensibilité à l'Insuline"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Insulin Sensitivities"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inzulin érzékenység"
           }
         },
         "it" : {
@@ -4151,13 +6515,7 @@
             "value" : "Sensibilità insulinica"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インスリン効果値"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Insulinfølsomhet"
@@ -4166,31 +6524,37 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulinegevoeligheden"
+            "value" : "Insuline gevoeligheden"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wrażliwość na insulinę (ISF)"
+            "value" : "Wrażliwość na insulinę"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sensibilidade a Insulina"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sensibilidades a Insulina"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Factor de sensibilitate la insulină"
+            "value" : "Sensibilidade a Insulina"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Факторы чувствительности инсулина"
+            "value" : "Чувствительность к инсулину"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inzulínová citlivosť"
           }
         },
         "sv" : {
@@ -4205,10 +6569,22 @@
             "value" : "İnsülin Duyarlılığı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чутливість до інсуліну"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Độ nhạy của Insulin"
+            "value" : "Độ nhạy Insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Sensitivities"
           }
         },
         "zh-Hans" : {
@@ -4222,6 +6598,12 @@
     "Invalid Configuration" : {
       "comment" : "Generic pump error description",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Invalid Configuration"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4254,7 +6636,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Invalid Configuration"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Invalid Configuration"
           }
         },
@@ -4264,13 +6652,7 @@
             "value" : "Configurazione non valida"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "コンフィグレーションが無効"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ugyldig konfigurasjon"
@@ -4288,22 +6670,28 @@
             "value" : "Nieprawidłowa konfiguracja"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Invalid Configuration"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Configuração Inválida"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurație invalidă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Неверная конфигурация"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Invalid Configuration"
           }
         },
         "sv" : {
@@ -4318,10 +6706,22 @@
             "value" : "Geçersiz Konfigürasyon"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Invalid Configuration"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cấu hình không hiệu lực"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Invalid Configuration"
           }
         },
         "zh-Hans" : {
@@ -4336,16 +6736,136 @@
       "comment" : "Recovery instruction for a certain bolus failure",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It is safe to retry"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It is safe to retry"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It is safe to retry"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It is safe to retry"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It is safe to retry"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It is safe to retry"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It is safe to retry"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It is safe to retry"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "È sicuro riprovare"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Det er trygt å prøve på nytt"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It is safe to retry"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It is safe to retry"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It is safe to retry"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It is safe to retry"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It is safe to retry"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It is safe to retry"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Det är säkert att försöka igen"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It is safe to retry"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It is safe to retry"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "An toàn để thử lại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It is safe to retry"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It is safe to retry"
           }
         }
       }
@@ -4353,61 +6873,103 @@
     "Lyumjev" : {
       "comment" : "Brand name for lyumjev insulin type\nTitle for Lyumjev insulin type",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Lyumjev"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Lyumjev"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Lyumjev"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Lyumjev"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Lyumjev"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Lyumjev"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Lyumjev"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Lyumjev"
           }
         },
-        "ro" : {
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
+        "sk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lyumjev"
           }
         },
-        "ru" : {
+        "sv" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lyumjev"
@@ -4415,7 +6977,31 @@
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
             "state" : "translated",
+            "value" : "Lyumjev"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Lyumjev"
           }
         }
@@ -4424,6 +7010,12 @@
     "Lyumjev is a mealtime insulin lispro formulation with the addition of citrate and treprostinil made by Eli Lilly" : {
       "comment" : "Description for lyumjev insulin type",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lyumjev هو تركيبة من أنسولين ليزبرو مخصصة لوقت الوجبات، مع إضافة السيترات والتريبروستينيل، من إنتاج شركة Eli Lilly"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4442,19 +7034,37 @@
             "value" : "Lyumjev es una formulación de insulina Lispro que incluye la adición de citrato y treprostinil fabricada por Eli Lilly"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev is a mealtime insulin lispro formulation with the addition of citrate and treprostinil made by Eli Lilly"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lyumjev est une formulation d'insuline lispro prandiale avec ajout de citrate et de tréprostinil fabriqué par Eli Lilly"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev is a mealtime insulin lispro formulation with the addition of citrate and treprostinil made by Eli Lilly"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev is a mealtime insulin lispro formulation with the addition of citrate and treprostinil made by Eli Lilly"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lyumjev è una formulazione di insulina lispro da assumere durante i pasti con aggiunta di citrato e treprostinil prodotta da Eli Lilly"
+            "value" : "Lyumjev e' una formulazione veloce di insulina lispro (humalog) con due additivi: un citrato e Treprostinil, prodotta dalla compagnia Eli Lilly "
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lyumjev er en insulin lispro-formulering for måltider med tillegg av citrat og treprostinil laget av Eli Lilly"
@@ -4472,10 +7082,16 @@
             "value" : "Lyumjev to preparat insuliny lispro do posiłków z dodatkiem cytrynianu i treprostinilu wyprodukowany przez firmę Eli Lilly."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lyumjev este o formulă de insulină lispro la masă, cu adaos de citrat și treprostinil, produse de Eli Lilly"
+            "state" : "new",
+            "value" : "Lyumjev is a mealtime insulin lispro formulation with the addition of citrate and treprostinil made by Eli Lilly"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev is a mealtime insulin lispro formulation with the addition of citrate and treprostinil made by Eli Lilly"
           }
         },
         "ru" : {
@@ -4484,10 +7100,46 @@
             "value" : "Lyumjev представляет собой лекарственную форму инсулина лизпро для приема пищи с добавлением цитрата и трепростинила производства Eli Lilly."
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lyumjev je bolusový inzulín lispro s prídavkom citrátu a treprostinilu vyrábaný spoločnosťou Eli Lilly"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lyumjev är ett snabbverkande insulin med tillägg av citrat och treprostinil som gjorts av Eli Lilly"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lyumjev, Eli Lilly tarafından üretilen sitrat ve treprostinil ilaveli bir öğün insülin lispro formülasyonudur"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lyumjev є лікарською формою інсуліну лізпро для прийому їжі з додаванням цитрату і трепростинилу виробництва Eli Lilly."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lyumjev là một công thức insulin lispro dùng cho bữa ăn có bổ sung citrate và treprostinil do Eli Lilly sản xuất"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev is a mealtime insulin lispro formulation with the addition of citrate and treprostinil made by Eli Lilly"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev is a mealtime insulin lispro formulation with the addition of citrate and treprostinil made by Eli Lilly"
           }
         }
       }
@@ -4495,6 +7147,12 @@
     "Make sure your pump is within communication range of your phone." : {
       "comment" : "Recovery suggestion for uncertain delivery",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Make sure your pump is within communication range of your phone."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4525,13 +7183,25 @@
             "value" : "Assurez-vous que votre pompe soit à portée de communication de votre téléphone."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Make sure your pump is within communication range of your phone."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Make sure your pump is within communication range of your phone."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Assicurati che la pompa si trovi nel raggio di comunicazione del tuo telefono."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kontroller at pumpen er innenfor kommunikasjonsområdet til telefonen."
@@ -4549,16 +7219,28 @@
             "value" : "Upewnij się, że pompa jest połączona z Twoim telefonem."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asigură-te că pompa ta se află în raza de comunicare a telefonului."
+            "state" : "new",
+            "value" : "Make sure your pump is within communication range of your phone."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Make sure your pump is within communication range of your phone."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Убедитесь, что помпа находится в пределах досягаемости вашего телефона."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uisti sa, že tvoja pumpa je v dosahu komunikácie s tvojím telefónom."
           }
         },
         "sv" : {
@@ -4572,12 +7254,42 @@
             "state" : "translated",
             "value" : "Pompanızın telefonunuzun iletişim menzilinde olduğundan emin olun."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Make sure your pump is within communication range of your phone."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hãy đảm bảo bơm của bạn nằm trong phạm vi kết nối với điện thoại."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Make sure your pump is within communication range of your phone."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Make sure your pump is within communication range of your phone."
+          }
         }
       }
     },
     "Maximum Basal Rate" : {
       "comment" : "Title text for maximum basal rate configuration",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4610,7 +7322,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Maximum Basal Rate"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Maximum Basal Rate"
           }
         },
@@ -4620,13 +7338,7 @@
             "value" : "Velocità basale massima"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最大基礎レート"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maksimal basaldose"
@@ -4644,22 +7356,28 @@
             "value" : "Maksymalna dawka podstawowa"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Taxa Basal Máxima"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rată bazală maximă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Максимальная скорость базала"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximálna bazálna dávka"
           }
         },
         "sv" : {
@@ -4674,10 +7392,28 @@
             "value" : "Maksimum Bazal Oranı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lượng Basal tối đa"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate"
           }
         }
       }
@@ -4685,6 +7421,12 @@
     "Maximum Basal Rate is the highest temporary basal rate %1$@ is allowed to set." : {
       "comment" : "Descriptive text for maximum basal rate (1: app name)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the highest temporary basal rate %1$@ is allowed to set."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4703,10 +7445,28 @@
             "value" : "Tasa Basal Máxima es la tasa basal temporal más alta que %1$@ puede establecer."
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the highest temporary basal rate %1$@ is allowed to set."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Le débit basal maximum est le débit de base temporaire le plus élevé que %1$@ est autorisé à définir."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the highest temporary basal rate %1$@ is allowed to set."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the highest temporary basal rate %1$@ is allowed to set."
           }
         },
         "it" : {
@@ -4715,7 +7475,7 @@
             "value" : "La velocità basale massima è la velocità basale temporanea più alta che %1$@ può impostare."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maksimal basaldose er den høyeste midlertidige basaldosen %1$@ er tillatt å angi."
@@ -4733,10 +7493,16 @@
             "value" : "Maksymalna dawka podstawowa to najwyższa tymczasowa dawka podstawowa, jaką %1$@ może ustawić."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rata bazală maximă este cea mai mare rată bazală temporară pe care %1$@ are voie să o seteze."
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the highest temporary basal rate %1$@ is allowed to set."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the highest temporary basal rate %1$@ is allowed to set."
           }
         },
         "ru" : {
@@ -4745,10 +7511,46 @@
             "value" : "Максимальная базальная скорость — это самая высокая ВБС, которую может установить %1$@."
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximálna bazálna rýchlosť je najvyššia dočasná bazálna dávka, ktorú je povolené nastaviť pre %1$@."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximal basaldos är den högsta temporära basaldosen på %1$@ som är tillåten att ställa in."
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maksimum Bazal Oranı, %1$@ 'ın ayarlamasına izin verilen en yüksek geçici bazal orandır."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the highest temporary basal rate %1$@ is allowed to set."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tốc độ insulin nền tối đa là mức tạm thời cao nhất mà %1$@ được phép thiết lập."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the highest temporary basal rate %1$@ is allowed to set."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the highest temporary basal rate %1$@ is allowed to set."
           }
         }
       }
@@ -4756,6 +7558,12 @@
     "Maximum Bolus" : {
       "comment" : "Title text for maximum bolus configuration",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4788,7 +7596,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Maximum Bolus"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Maximum Bolus"
           }
         },
@@ -4798,13 +7612,7 @@
             "value" : "Bolo massimo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最大ボーラス"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maksimal bolus"
@@ -4822,22 +7630,28 @@
             "value" : "Maksymalny bolus"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bolus Máximo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bolus maxim"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Максимальный Болюс"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximálny bolus"
           }
         },
         "sv" : {
@@ -4852,10 +7666,28 @@
             "value" : "Maksimum Bolus"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Liều Bolus tối đa"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus"
           }
         }
       }
@@ -4863,6 +7695,12 @@
     "Maximum Bolus is the highest bolus amount you can deliver at one time to cover carbs or bring down high glucose." : {
       "comment" : "Descriptive text for maximum bolus",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus is the highest bolus amount you can deliver at one time to cover carbs or bring down high glucose."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4893,13 +7731,25 @@
             "value" : "Le bolus maximum est la quantité de bolus la plus élevée que vous pouvez délivrer en une fois pour couvrir les glucides ou abaisser le taux de glucose élevé."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus is the highest bolus amount you can deliver at one time to cover carbs or bring down high glucose."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus is the highest bolus amount you can deliver at one time to cover carbs or bring down high glucose."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il bolo massimo è la quantità di bolo più alta che puoi erogare in una singola volta per coprire i carboidrati o ridurre la glicemia alta."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maksimal bolus er den høyeste bolusmengden du kan gi på en gang for å dekke karbohydrater eller redusere høyt blodsukker."
@@ -4917,16 +7767,28 @@
             "value" : "Maksymalny bolus to największa wielkość bolusa, jaką można podać w jednym czasie, aby pokryć węglowodany lub obniżyć wysoki poziom glukozy."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bolusul maxim este cea mai mare cantitate de insulina pe care o poți livra instantaneu pentru a acoperi carbohidrați sau pentru a corecta o glicemie mare."
+            "state" : "new",
+            "value" : "Maximum Bolus is the highest bolus amount you can deliver at one time to cover carbs or bring down high glucose."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus is the highest bolus amount you can deliver at one time to cover carbs or bring down high glucose."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Максимальный болюс - это наибольший болюс, который вы можете ввести за один раз, чтобы покрыть углеводы или снизить высокий уровень глюкозы."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximálny bolus je najvyššia dávka bolusu, ktorú môžeš podať naraz na pokrytie sacharidov alebo zníženie vysokej glykémie."
           }
         },
         "sv" : {
@@ -4940,27 +7802,117 @@
             "state" : "translated",
             "value" : "Maksimum Bolus, karbonhidratları karşılamak veya yüksek KŞ'ni düşürmek için tek seferde verebileceğiniz en yüksek bolus miktarıdır."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus is the highest bolus amount you can deliver at one time to cover carbs or bring down high glucose."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liều bolus tối đa là lượng bolus cao nhất bạn có thể tiêm trong một lần để bù carbohydrate hoặc hạ đường huyết cao."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus is the highest bolus amount you can deliver at one time to cover carbs or bring down high glucose."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus is the highest bolus amount you can deliver at one time to cover carbs or bring down high glucose."
+          }
         }
       }
     },
     "mg/dL/min" : {
       "comment" : "The short unit display string for milligrams per liter per minute",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mg/dL/min"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mg/dL/min"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mg/dL/min"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mg/dL/min"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mg/dL/min"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mg/dL/min"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mg/dL/min"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mg/dL/min"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "mg/dl/min"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "mg/dL/min"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "mg/dL/min"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "mg/dL/min"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mg/dL/min"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "mg/dL/min"
           }
         },
@@ -4969,12 +7921,60 @@
             "state" : "translated",
             "value" : "мг/дл/мин"
           }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mg/dL/min"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mg/dl/min"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mg/dL/min"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mg/dL/min"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mg/dL/min"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mg/dL/min"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mg/dL/min"
+          }
         }
       }
     },
     "mg/dL/U" : {
       "comment" : "The short unit display string for milligrams per deciliter per U",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mg/dL/U"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4989,41 +7989,41 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "mg/dL/U"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "mg/dL/U"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "mg/dL/U"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "mg/dL/U"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "mg/dL/U"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "mg/dL/U"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mg/dL/U"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "mg/dL/E"
@@ -5041,22 +8041,28 @@
             "value" : "mg/dL/J"
           }
         },
-        "pt-BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "mg/dL/U"
           }
         },
-        "ro" : {
+        "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "mg/dL/U"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "mg/dL/U"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mg/dL/J"
           }
         },
         "sv" : {
@@ -5071,9 +8077,21 @@
             "value" : "mg/dL/Ü"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mg/dL/U"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "mg/dL/U"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "mg/dL/U"
           }
         },
@@ -5114,7 +8132,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "mmol/L"
           }
         },
@@ -5126,6 +8144,12 @@
         },
         "he" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "mmol/L"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
             "state" : "translated",
             "value" : "mmol/L"
           }
@@ -5136,13 +8160,7 @@
             "value" : "mmol/L"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mmol/L"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "mmol/L"
@@ -5151,31 +8169,31 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "mmol/L"
+            "value" : "mmol/l"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "mmol/L"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "mmol/L"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "mmol/L"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "mmol/L"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "mmol/L"
+            "value" : "ммоль/л"
           }
         },
         "sk" : {
@@ -5187,13 +8205,19 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "mmol/L"
+            "value" : "mmol/l"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "mmol/L"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ммол/Л"
           }
         },
         "vi" : {
@@ -5202,10 +8226,16 @@
             "value" : "mmol/L"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mmol/L"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "毫摩尔/升"
+            "state" : "new",
+            "value" : "mmol/L"
           }
         }
       }
@@ -5213,21 +8243,87 @@
     "mmol/L/min" : {
       "comment" : "The short unit display string for millimoles per liter per minute",
       "localizations" : {
-        "it" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "mmol/L/min"
           }
         },
-        "nb" : {
+        "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "mmol/L/min"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mmol/L/min"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mmol/L/min"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mmol/L/min"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mmol/L/min"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mmol/L/min"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mmol/L/min"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mmol/L/min"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mmol/L/min"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "mmol/L/min"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "mmol/L/min"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mmol/L/min"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "mmol/L/min"
           }
         },
@@ -5236,12 +8332,60 @@
             "state" : "translated",
             "value" : "ммоль/л/мин"
           }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mmol/L/min"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mmol/l/min"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mmol/L/min"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mmol/L/min"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mmol/L/min"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mmol/L/min"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mmol/L/min"
+          }
         }
       }
     },
     "mmol/L/U" : {
       "comment" : "The short unit display string for millimoles per liter per U",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mmol/L/U"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5256,41 +8400,41 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "mmol/L/U"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "mmol/L/U"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "mmol/L/U"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "mmol/L/U"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "mmol/L/U"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "mmol/L/U"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "mmol/L/U"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "mmol/L/E"
@@ -5308,22 +8452,28 @@
             "value" : "mmol/L/J"
           }
         },
-        "pt-BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "mmol/L/U"
           }
         },
-        "ro" : {
+        "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "mmol/L/U"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "mmol/L/U"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mmol/L/J"
           }
         },
         "sv" : {
@@ -5338,9 +8488,21 @@
             "value" : "mmol/L/Ü"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "mmol/L/U"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "mmol/L/U"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "mmol/L/U"
           }
         },
@@ -5355,6 +8517,12 @@
     "Needs Attention" : {
       "comment" : "Sensor state description for the non-valid state",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Needs Attention"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5387,7 +8555,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Needs Attention"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Needs Attention"
           }
         },
@@ -5397,13 +8571,7 @@
             "value" : "Richiede attenzione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "注意してください"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trenger tilsyn"
@@ -5421,22 +8589,28 @@
             "value" : "Potrzebuje uwagi"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Needs Attention"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Precisa de Atenção"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Necesită atenție"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Требует внимания"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vyžaduje pozornosť"
           }
         },
         "sv" : {
@@ -5451,10 +8625,22 @@
             "value" : "İlgilenmeniz gerekiyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Needs Attention"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cần chú ý"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Needs Attention"
           }
         },
         "zh-Hans" : {
@@ -5468,6 +8654,12 @@
     "No Update" : {
       "comment" : "Description of no software update needed",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Update"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5486,10 +8678,28 @@
             "value" : "Sin actualización"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Update"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pas de mise à jour"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Update"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Update"
           }
         },
         "it" : {
@@ -5498,7 +8708,7 @@
             "value" : "Nessun aggiornamento"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ingen oppdatering"
@@ -5516,10 +8726,16 @@
             "value" : "Brak aktualizacji"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicio actualizare"
+            "state" : "new",
+            "value" : "No Update"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Update"
           }
         },
         "ru" : {
@@ -5528,10 +8744,46 @@
             "value" : "Нет обновлений"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Žiadna aktualizácia"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingen uppdatering"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Güncelleme yok"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Update"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có Cập nhật"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Update"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Update"
           }
         }
       }
@@ -5539,6 +8791,12 @@
     "No values found" : {
       "comment" : "Describes an error for no data found in a CarbStore request",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No values found"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5571,7 +8829,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "No values found"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "No values found"
           }
         },
@@ -5581,13 +8845,7 @@
             "value" : "Nessun valore trovato"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "値が見つかりません"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ingen verdier funnet"
@@ -5605,22 +8863,28 @@
             "value" : "Nie znaleziono wartości"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No values found"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nenhum valor encontrado"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu s-au găsit valori"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Данные не найдены"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenašli sa žiadne hodnoty"
           }
         },
         "sv" : {
@@ -5635,10 +8899,22 @@
             "value" : "Değer bulunamadı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No values found"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Không tìm thấy giá trị nào"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No values found"
           }
         },
         "zh-Hans" : {
@@ -5652,21 +8928,27 @@
     "Novolog" : {
       "comment" : "Brand name for novolog insulin type",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Novolog"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Novolog"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Novolog"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Novolog"
           }
         },
@@ -5678,37 +8960,55 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Novolog"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Novolog"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Novolog"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Novolog"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Novolog"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Novolog"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Novolog"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Novolog"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Novolog"
           }
         },
@@ -5716,6 +9016,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Новолог"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Novolog"
           }
         },
         "sv" : {
@@ -5726,7 +9032,31 @@
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Novolog"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Novolog"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
             "state" : "translated",
+            "value" : "Novolog"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Novolog"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Novolog"
           }
         }
@@ -5735,9 +9065,15 @@
     "Novolog (insulin aspart)" : {
       "comment" : "Title for Novolog insulin type",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Novolog (insulin aspart)"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Novolog (insulin aspart)"
           }
         },
@@ -5765,21 +9101,33 @@
             "value" : "Novolog (insuline asparte)"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Novolog (insulin aspart)"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Novolog (insulin aspart)"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Novolog (insulina aspart)"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Novolog (insulin aspart)"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Novolog (insulin aspart)"
           }
         },
@@ -5789,16 +9137,28 @@
             "value" : "Novolog (insulina aspart)"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Novolog (insulină aspart)"
+            "state" : "new",
+            "value" : "Novolog (insulin aspart)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Novolog (insulin aspart)"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Новолог (инсулин аспарт)"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Novolog (inzulín aspartát)"
           }
         },
         "sv" : {
@@ -5812,12 +9172,42 @@
             "state" : "translated",
             "value" : "Novolog (insülin aspart)"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Novolog (insulin aspart)"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Novolog (insulin aspart)"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Novolog (insulin aspart)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Novolog (insulin aspart)"
+          }
         }
       }
     },
     "NovoLog (insulin aspart) is a rapid-acting insulin made by Novo Nordisk" : {
       "comment" : "Description for novolog insulin type",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NovoLog (الأنسولين أسبارت) هو أنسولين سريع المفعول من إنتاج شركة Novo Nordisk"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5836,10 +9226,28 @@
             "value" : "NovoLog (insulina Aspart) es una insulina de acción rápida fabricada por Novo Nordisk"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "NovoLog (insulin aspart) is a rapid-acting insulin made by Novo Nordisk"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "NovoLog (insuline asparte) est une insuline à action rapide fabriquée par Novo Nordisk"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "NovoLog (insulin aspart) is a rapid-acting insulin made by Novo Nordisk"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "NovoLog (insulin aspart) is a rapid-acting insulin made by Novo Nordisk"
           }
         },
         "it" : {
@@ -5848,7 +9256,7 @@
             "value" : "NovoLog (insulina aspart) è un'insulina ad azione rapida prodotta da Novo Nordisk"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "NovoLog (insulin aspart) er et hurtigvirkende insulin laget av Novo Nordisk"
@@ -5866,10 +9274,16 @@
             "value" : "NovoLog (insulina aspart) to szybko działająca insulina firmy Novo Nordisk."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "NovoLog (insulină aspart) este o insulină cu acțiune rapidă produsă de Novo Nordisk"
+            "state" : "new",
+            "value" : "NovoLog (insulin aspart) is a rapid-acting insulin made by Novo Nordisk"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "NovoLog (insulin aspart) is a rapid-acting insulin made by Novo Nordisk"
           }
         },
         "ru" : {
@@ -5878,10 +9292,46 @@
             "value" : "NovoLog (инсулин аспарт) - инсулин быстрого действия производства Novo Nordisk"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NovoLog je rýchlo pôsobiaci inzulín aspartát vyrábaný spoločnosťou Novo Nordisk"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NovoLog (insulin aspart) är ett snabbverkande insulin tillverkat av Novo Nordisk"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "NovoLog (insülin aspart), Novo Nordisk tarafından üretilen hızlı etkili bir insülindir."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NovoLog (інсулін аспарт) — інсулін швидкої дії, виготовлений компанією Novo Nordisk"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NovoLog (insulin aspart) là một loại insulin tác dụng nhanh do Novo Nordisk sản xuất"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "NovoLog (insulin aspart) is a rapid-acting insulin made by Novo Nordisk"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "NovoLog (insulin aspart) is a rapid-acting insulin made by Novo Nordisk"
           }
         }
       }
@@ -5892,13 +9342,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "موافق"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+            "value" : "حسناً"
           }
         },
         "da" : {
@@ -5921,7 +9365,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "OK"
           }
         },
@@ -5933,7 +9377,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "OK"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "OK"
           }
         },
@@ -5943,13 +9393,7 @@
             "value" : "OK"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ok"
@@ -5958,31 +9402,31 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ok"
+            "value" : "OK"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "OK"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "OK"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "OK"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "OK"
+            "value" : "ОК"
           }
         },
         "sk" : {
@@ -6003,16 +9447,28 @@
             "value" : "Tamam"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ОК"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "OK"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "OK"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "好的"
+            "value" : "Ok"
           }
         }
       }
@@ -6020,6 +9476,12 @@
     "One or more of the values you have entered is outside of what is typically recommended for most people." : {
       "comment" : "Descriptive text for saving settings outside the recommended range",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "One or more of the values you have entered is outside of what is typically recommended for most people."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6050,13 +9512,25 @@
             "value" : "Une ou plusieurs des valeurs que vous avez entrées sont en dehors de ce qui est généralement recommandé pour la plupart des personnes."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "One or more of the values you have entered is outside of what is typically recommended for most people."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "One or more of the values you have entered is outside of what is typically recommended for most people."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uno o più dei valori inseriti non rientrano in quelli generalmente consigliati per la maggior parte delle persone."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "En verdi du har lagt inn er lavere enn det som vanligvis anbefales for de fleste."
@@ -6074,16 +9548,28 @@
             "value" : "Co najmniej jedna z wprowadzonych wartości wykracza poza to, co jest zwykle zalecane dla większości osób."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unele dintre valorile introduse sunt în afara a ceea ce este recomandat de obicei pentru majoritatea oamenilor."
+            "state" : "new",
+            "value" : "One or more of the values you have entered is outside of what is typically recommended for most people."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "One or more of the values you have entered is outside of what is typically recommended for most people."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Одно или несколько введенных вами значений выходят за рамки того, что обычно рекомендуется для большинства людей."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "One or more of the values you have entered is outside of what is typically recommended for most people."
           }
         },
         "sv" : {
@@ -6097,6 +9583,30 @@
             "state" : "translated",
             "value" : "Girdiğiniz değerlerden biri veya daha fazlası, çoğu insan için tipik olarak önerilen değerlerin dışındadır."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "One or more of the values you have entered is outside of what is typically recommended for most people."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Một hoặc nhiều giá trị bạn nhập nằm ngoài mức thường được khuyến nghị cho hầu hết mọi người."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "One or more of the values you have entered is outside of what is typically recommended for most people."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "One or more of the values you have entered is outside of what is typically recommended for most people."
+          }
         }
       }
     },
@@ -6104,16 +9614,136 @@
       "comment" : "The error recovery suggestion when Health sharing was denied",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please re-enable sharing in Health"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please re-enable sharing in Health"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please re-enable sharing in Health"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please re-enable sharing in Health"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please re-enable sharing in Health"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please re-enable sharing in Health"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please re-enable sharing in Health"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please re-enable sharing in Health"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Per favore, riattiva la condivisione in Salute"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vennligst aktiver deling i Helse-appen på nytt"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please re-enable sharing in Health"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please re-enable sharing in Health"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please re-enable sharing in Health"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please re-enable sharing in Health"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please re-enable sharing in Health"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please re-enable sharing in Health"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tillåt delning i Hälsa igen"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please re-enable sharing in Health"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please re-enable sharing in Health"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xin hãy cấp quyền chia sẻ lại trong ứng dụng Health"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please re-enable sharing in Health"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please re-enable sharing in Health"
           }
         }
       }
@@ -6123,7 +9753,7 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Pre-Meal"
           }
         },
@@ -6159,7 +9789,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pre-Meal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pre-Meal"
           }
         },
@@ -6169,13 +9805,7 @@
             "value" : "Pre-pasto"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "食前"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pre-måltid"
@@ -6183,7 +9813,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Pre-Meal"
           }
         },
@@ -6193,22 +9823,28 @@
             "value" : "Przed posiłkiem"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pre-Meal"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pré-Refeição"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preprandial"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "До еды"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pre-Meal"
           }
         },
         "sv" : {
@@ -6223,10 +9859,28 @@
             "value" : "Yemek öncesi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pre-Meal"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trước bữa ăn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pre-Meal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pre-Meal"
           }
         }
       }
@@ -6234,6 +9888,12 @@
     "Recommended Update" : {
       "comment" : "Description of supported software update needed",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Recommended Update"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6252,10 +9912,28 @@
             "value" : "Actualización recomendada"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Recommended Update"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mise à jour recommandée"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Recommended Update"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Recommended Update"
           }
         },
         "it" : {
@@ -6264,7 +9942,7 @@
             "value" : "Aggiornamento consigliato"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Anbefalt oppdatering"
@@ -6282,10 +9960,16 @@
             "value" : "Zalecana aktualizacja"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizare recomandată"
+            "state" : "new",
+            "value" : "Recommended Update"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Recommended Update"
           }
         },
         "ru" : {
@@ -6294,10 +9978,46 @@
             "value" : "Рекомендуемое обновление"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Recommended Update"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rekommenderad uppdatering"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Önerilen Güncelleme"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Recommended Update"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đề nghị được cập nhật"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Recommended Update"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Recommended Update"
           }
         }
       }
@@ -6305,6 +10025,12 @@
     "Resumed" : {
       "comment" : "Title for resume dose type",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resumed"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6335,13 +10061,25 @@
             "value" : "Reprendre"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resumed"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resumed"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ripresa"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gjenopptatt"
@@ -6359,16 +10097,28 @@
             "value" : "Wznowione"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reluat"
+            "state" : "new",
+            "value" : "Resumed"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resumed"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Возобновлено"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resumed"
           }
         },
         "sv" : {
@@ -6382,12 +10132,42 @@
             "state" : "translated",
             "value" : "Devam ettirildi"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resumed"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiếp tục"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resumed"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resumed"
+          }
         }
       }
     },
     "Rising" : {
       "comment" : "Glucose trend up",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rising"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6420,7 +10200,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Rising"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Rising"
           }
         },
@@ -6430,13 +10216,7 @@
             "value" : "Aumento"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "上昇"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stiger"
@@ -6454,22 +10234,28 @@
             "value" : "Wzrost"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rising"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Subindo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "În creștere"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Повышение"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rising"
           }
         },
         "sv" : {
@@ -6484,10 +10270,22 @@
             "value" : "Yükseliyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rising"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang tăng"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rising"
           }
         },
         "zh-Hans" : {
@@ -6501,6 +10299,12 @@
     "Rising fast" : {
       "comment" : "Glucose trend up-up",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rising fast"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6533,7 +10337,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Rising fast"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Rising fast"
           }
         },
@@ -6543,13 +10353,7 @@
             "value" : "Aumento rapido"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "急上昇"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stiger fort"
@@ -6567,22 +10371,28 @@
             "value" : "Szybki wzrost"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rising fast"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Subindo rápido"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "În creștere rapidă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Быстрое повышение"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rising fast"
           }
         },
         "sv" : {
@@ -6597,10 +10407,22 @@
             "value" : "Hızlı yükseliyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rising fast"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang tăng nhanh"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rising fast"
           }
         },
         "zh-Hans" : {
@@ -6614,6 +10436,12 @@
     "Rising very fast" : {
       "comment" : "Glucose trend up-up-up",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rising very fast"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6646,7 +10474,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Rising very fast"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Rising very fast"
           }
         },
@@ -6656,13 +10490,7 @@
             "value" : "Aumento molto rapido"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "超急上昇"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stiger veldig fort"
@@ -6680,22 +10508,28 @@
             "value" : "Bardzo szybki wzrost"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rising very fast"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Subindo muito rápido"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "În creștere foarte rapidă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Очень быстрое повышение"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rising very fast"
           }
         },
         "sv" : {
@@ -6710,10 +10544,22 @@
             "value" : "Çok hızlı yükseliyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rising very fast"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang tăng rất nhanh"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rising very fast"
           }
         },
         "zh-Hans" : {
@@ -6727,6 +10573,12 @@
     "Some of the values you have entered are outside of what is typically recommended for most people." : {
       "comment" : "Descriptive text for guardrail high value warning for schedule interface",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Some of the values you have entered are outside of what is typically recommended for most people."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6757,13 +10609,25 @@
             "value" : "Des valeurs que vous avez entrées sont en dehors de ce qui est généralement recommandé pour la plupart des personnes."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Some of the values you have entered are outside of what is typically recommended for most people."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Some of the values you have entered are outside of what is typically recommended for most people."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alcuni dei valori immessi non rientrano nei valori generalmente consigliati per la maggior parte delle persone."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Noen av verdiene du har lagt inn er utenfor det som vanligvis anbefales for de fleste."
@@ -6781,16 +10645,28 @@
             "value" : "Niektóre z wprowadzonych wartości wykraczają poza to, co jest zwykle zalecane dla większości osób."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Câteva dintre valorile introduse sunt în afara a ceea ce este recomandat de obicei pentru majoritatea oamenilor."
+            "state" : "new",
+            "value" : "Some of the values you have entered are outside of what is typically recommended for most people."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Some of the values you have entered are outside of what is typically recommended for most people."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Некоторые из введенных вами значений выходят за рамки того, что обычно рекомендуется для большинства людей."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Some of the values you have entered are outside of what is typically recommended for most people."
           }
         },
         "sv" : {
@@ -6804,16 +10680,40 @@
             "state" : "translated",
             "value" : "Girdiğiniz değerlerden bazıları, çoğu insan için tipik olarak önerilen değerlerin dışındadır."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Some of the values you have entered are outside of what is typically recommended for most people."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Một số giá trị bạn đã nhập nằm ngoài mức thường được khuyến nghị cho hầu hết mọi người."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Some of the values you have entered are outside of what is typically recommended for most people."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Some of the values you have entered are outside of what is typically recommended for most people."
+          }
         }
       }
     },
     "Suspended" : {
       "comment" : "Title for suspend dose type",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pozastaveno"
+            "state" : "new",
+            "value" : "Suspended"
           }
         },
         "da" : {
@@ -6848,7 +10748,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Suspended"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Suspended"
           }
         },
@@ -6858,13 +10764,7 @@
             "value" : "Sospeso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時停止"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Suspendert"
@@ -6882,16 +10782,16 @@
             "value" : "Wstrzymane"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspended"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Suspenso"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suspendat"
           }
         },
         "ru" : {
@@ -6918,10 +10818,22 @@
             "value" : "Askıya alındı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Призупинено"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đã tạm ngưng"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspended"
           }
         },
         "zh-Hans" : {
@@ -6935,10 +10847,16 @@
     "Temp Basal" : {
       "comment" : "Title for temp basal dose type",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temp Basal"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Midlertidig basal"
+            "value" : "Midlertidig Basal"
           }
         },
         "de" : {
@@ -6955,14 +10873,26 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilapäinen basaali"
+            "state" : "new",
+            "value" : "Temp Basal"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Débit basal temporaire"
+            "value" : "Basal Temp."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temp Basal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temp Basal"
           }
         },
         "it" : {
@@ -6971,7 +10901,7 @@
             "value" : "Basale temporanea"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Midlertidig basal"
@@ -6980,25 +10910,31 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tijdelijk Basaal"
+            "value" : "Tijdelijk basaal"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tymczasowa dawka podstawowa"
+            "state" : "new",
+            "value" : "Temp Basal"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bazală temporară"
+            "state" : "new",
+            "value" : "Temp Basal"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temp Basal"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ВБС"
+            "value" : "Врем. базал"
           }
         },
         "sk" : {
@@ -7016,7 +10952,31 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Geçici Bazal"
+            "value" : "Geçici Bazal Oranı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тимчасовий  Базал"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temp Basal"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temp Basal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "临时基础率"
           }
         }
       }
@@ -7024,6 +10984,12 @@
     "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes." : {
       "comment" : "Descriptive text for pre-meal correction range override",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7054,13 +11020,25 @@
             "value" : "Diminue temporairement votre cible de glycémie avant un repas pour influer sur les pics d'hyperglycémie post-repas."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Abbassa temporaneamente il tuo target glicemico prima di un pasto per influenzare i picchi glicemici postprandiali."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reduser glukosemålet ditt midlertidig før et måltid for å påvirke glukosetoppene etter måltidet."
@@ -7078,16 +11056,28 @@
             "value" : "Tymczasowo obniż docelowy poziom glukozy przed posiłkiem, aby ograniczyć gwałtowny wzrost glukozy po posiłku."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reduceți temporar glicemia țintă înainte de masă pentru a avea un impact asupra vârfurilor postprandiale."
+            "state" : "new",
+            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Временно понизьте целевое значение уровня глюкозы перед едой, чтобы уменьшить пики глюкозы после еды."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
           }
         },
         "sv" : {
@@ -7101,12 +11091,42 @@
             "state" : "translated",
             "value" : "Yemek sonrası KŞ artışlarını engellemek için yemekten önce KŞ hedefinizi geçici olarak düşürün."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tạm thời hạ mục tiêu đường huyết trước bữa ăn để giảm mức tăng đường huyết sau ăn."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
+          }
         }
       }
     },
     "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events." : {
       "comment" : "Descriptive text for workout correction range override",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7137,13 +11157,25 @@
             "value" : "Augmente temporairement votre cible de glycémie avant, pendant ou après l'activité physique pour réduire le risque d'hypoglycémie."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aumenta temporaneamente il target glicemico prima, durante o dopo l'attività fisica per ridurre il rischio di eventi ipoglicemici."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Øk blodsukkermålet ditt midlertidig før, under eller etter fysisk aktivitet for å redusere risikoen for hendelser med lavt blodsukker."
@@ -7161,16 +11193,28 @@
             "value" : "Tymczasowo zwiększ docelowy poziom glukozy przed, w trakcie lub po aktywności fizycznej, aby zmniejszyć ryzyko wystąpienia niskiego poziomu glukozy (Hipoglikemia)."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creșteți temporar valoarea ținta a glicemiei înainte, în timpul sau după activitatea fizică pentru a reduce riscul de apariție a hipoglicemiei."
+            "state" : "new",
+            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Временно повышайте целевой уровень глюкозы до, во время или после физической активности, чтобы снизить риск развития событий, связанных с низким уровнем глюкозы."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
           }
         },
         "sv" : {
@@ -7184,12 +11228,42 @@
             "state" : "translated",
             "value" : "Düşük KŞ riskini azaltmak için fiziksel aktivite öncesinde, sırasında veya sonrasında KŞ hedefinizi geçici olarak yükseltin."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tạm thời nâng mục tiêu đường huyết trước, trong hoặc sau khi hoạt động thể chất để giảm nguy cơ hạ đường huyết."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
+          }
         }
       }
     },
     "The value you have entered is higher than what is typically recommended for most people." : {
       "comment" : "Descriptive text for guardrail high value warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The value you have entered is higher than what is typically recommended for most people."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7220,13 +11294,25 @@
             "value" : "La valeur que vous avez saisie est supérieure à ce qui est généralement recommandé pour la plupart des personnes."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The value you have entered is higher than what is typically recommended for most people."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The value you have entered is higher than what is typically recommended for most people."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il valore inserito è superiore a quello generalmente consigliato per la maggior parte delle persone."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verdien du har lagt inn er høyere enn det som vanligvis anbefales for de fleste."
@@ -7244,16 +11330,28 @@
             "value" : "Wprowadzona wartość jest wyższa niż zwykle zalecana dla większości osób."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valoarea pe care ați introdus-o este mai mare decât cea recomandată de obicei pentru majoritatea oamenilor."
+            "state" : "new",
+            "value" : "The value you have entered is higher than what is typically recommended for most people."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The value you have entered is higher than what is typically recommended for most people."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Введенное вами значение выше, чем то, которое обычно рекомендуется для большинства людей."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The value you have entered is higher than what is typically recommended for most people."
           }
         },
         "sv" : {
@@ -7267,12 +11365,42 @@
             "state" : "translated",
             "value" : "Girdiğiniz değer, çoğu insan için tipik olarak önerilenden daha yüksektir."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The value you have entered is higher than what is typically recommended for most people."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giá trị bạn nhập cao hơn mức thường được khuyến nghị cho hầu hết mọi người."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The value you have entered is higher than what is typically recommended for most people."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The value you have entered is higher than what is typically recommended for most people."
+          }
         }
       }
     },
     "The value you have entered is lower than what is typically recommended for most people." : {
       "comment" : "Descriptive text for guardrail low value warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The value you have entered is lower than what is typically recommended for most people."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7303,13 +11431,25 @@
             "value" : "La valeur que vous avez saisie est inférieure à ce qui est généralement recommandé pour la plupart des personnes."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The value you have entered is lower than what is typically recommended for most people."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The value you have entered is lower than what is typically recommended for most people."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il valore inserito è inferiore a quello generalmente consigliato per la maggior parte delle persone."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verdien du har lagt inn er lavere enn det som vanligvis anbefales for de fleste."
@@ -7327,16 +11467,28 @@
             "value" : "Wprowadzona wartość jest niższa niż zwykle zalecana dla większości osób."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valoarea pe care ați introdus-o este mai mica decât cea recomandată de obicei pentru majoritatea oamenilor."
+            "state" : "new",
+            "value" : "The value you have entered is lower than what is typically recommended for most people."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The value you have entered is lower than what is typically recommended for most people."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Введенное вами значение ниже того, которое обычно рекомендуется для большинства людей."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The value you have entered is lower than what is typically recommended for most people."
           }
         },
         "sv" : {
@@ -7350,12 +11502,42 @@
             "state" : "translated",
             "value" : "Girdiğiniz değer, çoğu insan için tipik olarak önerilenden daha düşüktür."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The value you have entered is lower than what is typically recommended for most people."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giá trị bạn nhập thấp hơn mức thường được khuyến nghị cho hầu hết mọi người."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The value you have entered is lower than what is typically recommended for most people."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The value you have entered is lower than what is typically recommended for most people."
+          }
         }
       }
     },
     "The values you have entered are outside of what is typically recommended for most people." : {
       "comment" : "Descriptive text for guardrail high value warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The values you have entered are outside of what is typically recommended for most people."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7386,13 +11568,25 @@
             "value" : "Les valeurs que vous avez saisies sont en dehors de ce qui est généralement recommandé pour la plupart des personnes."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The values you have entered are outside of what is typically recommended for most people."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The values you have entered are outside of what is typically recommended for most people."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "I valori che hai inserito non rientrano in quelli generalmente consigliati per la maggior parte delle persone."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verdiene du har lagt inn er utenfor det som vanligvis anbefales for de fleste."
@@ -7410,16 +11604,28 @@
             "value" : "Wprowadzone wartości wykraczają poza to, co jest zwykle zalecane dla większości osób."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valorile introduse sunt în afara a ceea ce este recomandat de obicei pentru majoritatea oamenilor."
+            "state" : "new",
+            "value" : "The values you have entered are outside of what is typically recommended for most people."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The values you have entered are outside of what is typically recommended for most people."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Введенные вами значения выходят за рамки того, что обычно рекомендуется для большинства людей."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The values you have entered are outside of what is typically recommended for most people."
           }
         },
         "sv" : {
@@ -7433,6 +11639,30 @@
             "state" : "translated",
             "value" : "Girdiğiniz değerler, çoğu insan için tipik olarak önerilen değerlerin dışındadır."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The values you have entered are outside of what is typically recommended for most people."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Các giá trị bạn nhập nằm ngoài mức thường được khuyến nghị cho hầu hết mọi người."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The values you have entered are outside of what is typically recommended for most people."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The values you have entered are outside of what is typically recommended for most people."
+          }
         }
       }
     },
@@ -7442,7 +11672,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "وحدة"
+            "value" : "U"
           }
         },
         "da" : {
@@ -7454,7 +11684,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "IE"
+            "value" : " IE"
           }
         },
         "es" : {
@@ -7465,7 +11695,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "U"
           }
         },
@@ -7477,6 +11707,12 @@
         },
         "he" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "U"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
             "state" : "translated",
             "value" : "U"
           }
@@ -7487,13 +11723,7 @@
             "value" : "U"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "U"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "E"
@@ -7507,32 +11737,32 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "J"
+            "state" : "new",
+            "value" : "U"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "U"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "U"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ед"
+            "value" : "Ед"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "j"
+            "value" : "J"
           }
         },
         "sv" : {
@@ -7547,9 +11777,27 @@
             "value" : "Ü"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "U"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "U"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "U"
           }
         }
@@ -7573,19 +11821,19 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "IE/h"
+            "value" : "IE/Std"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U/hra"
+            "value" : "U/h"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "U/h"
+            "state" : "new",
+            "value" : "U/hr"
           }
         },
         "fr" : {
@@ -7596,8 +11844,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "U/hr"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "U/óra"
           }
         },
         "it" : {
@@ -7606,13 +11860,7 @@
             "value" : "U/ora"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "U/時"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "E/t"
@@ -7626,44 +11874,62 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "J/h"
+            "state" : "new",
+            "value" : "U/hr"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U/hr"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "U/hr"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "U/oră"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U/hr"
+            "value" : "Ед/ч"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "J/hod"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "E/timme"
+            "value" : "IE/h"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ü/sa"
+            "value" : "Ü/Sa"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "U/год"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U/giờ"
+            "value" : "U/hr"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U/hr"
           }
         },
         "zh-Hans" : {
@@ -7677,6 +11943,12 @@
     "Uncertain Delivery" : {
       "comment" : "Error description for uncertain delivery",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Uncertain Delivery"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7707,13 +11979,25 @@
             "value" : "Administration incertaine"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Uncertain Delivery"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Uncertain Delivery"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erogazione incerta"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Usikker levering"
@@ -7731,16 +12015,28 @@
             "value" : "Niepewne podanie"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Livrare incertă"
+            "state" : "new",
+            "value" : "Uncertain Delivery"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Uncertain Delivery"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Неопределенная подача"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neisté podanie"
           }
         },
         "sv" : {
@@ -7754,12 +12050,42 @@
             "state" : "translated",
             "value" : "Belirsiz İletim"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Uncertain Delivery"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiêm không chắc chắn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Uncertain Delivery"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Uncertain Delivery"
+          }
         }
       }
     },
     "Unit" : {
       "comment" : "The long unit display string for a singular international unit of insulin",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unit"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7792,7 +12118,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Unit"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Unit"
           }
         },
@@ -7802,13 +12134,7 @@
             "value" : "Unità"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unit"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enhet"
@@ -7826,21 +12152,27 @@
             "value" : "Jednostka"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unit"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Unidade"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unități"
-          }
-        },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Unit"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Unit"
           }
         },
@@ -7856,9 +12188,21 @@
             "value" : "Ünite"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unit"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đơn vị"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Unit"
           }
         },
@@ -7873,6 +12217,12 @@
     "Unit/hour" : {
       "comment" : "The long unit display string for a singular international unit of insulin per hour",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unit/hour"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7905,7 +12255,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Unit/hour"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Unit/hour"
           }
         },
@@ -7915,13 +12271,7 @@
             "value" : "Unità/ora"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unit/hour"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enhet/time"
@@ -7939,21 +12289,27 @@
             "value" : "Jednostka/godzinę"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unit/hour"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Unidade/hora"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unități/oră"
-          }
-        },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Unit/hour"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Unit/hour"
           }
         },
@@ -7969,10 +12325,22 @@
             "value" : "Ünite/saat"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unit/hour"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Unit/giờ"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unit/hour"
           }
         },
         "zh-Hans" : {
@@ -7986,6 +12354,12 @@
     "Units" : {
       "comment" : "The long unit display string for international units of insulin",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Units"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8018,7 +12392,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Units"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Units"
           }
         },
@@ -8028,13 +12408,7 @@
             "value" : "Unità"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "単位"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enheter"
@@ -8052,16 +12426,16 @@
             "value" : "Jednostki"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Units"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Unidades"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unități"
           }
         },
         "ru" : {
@@ -8088,9 +12462,21 @@
             "value" : "Ünite"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Units"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đơn vị"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Units"
           }
         },
@@ -8105,6 +12491,12 @@
     "Units/hour" : {
       "comment" : "The long unit display string for international units of insulin per hour",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Units/hour"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8137,7 +12529,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Units/hour"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Units/hour"
           }
         },
@@ -8147,13 +12545,7 @@
             "value" : "Unità/ora"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "U/時"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enheter/time"
@@ -8171,21 +12563,27 @@
             "value" : "Jednostki/godzinę"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Units/hour"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Unidades/hora"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unități/oră"
-          }
-        },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Units/hour"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Units/hour"
           }
         },
@@ -8201,10 +12599,22 @@
             "value" : "Ünite/saat"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Units/hour"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Units/giờ"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Units/hour"
           }
         },
         "zh-Hans" : {
@@ -8218,6 +12628,12 @@
     "Update Available" : {
       "comment" : "Description of informational software update needed",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update Available"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8236,10 +12652,28 @@
             "value" : "Actualización disponible"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update Available"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mise à jour disponible"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update Available"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update Available"
           }
         },
         "it" : {
@@ -8248,7 +12682,7 @@
             "value" : "Aggiornamento disponibile"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Oppdatering tilgjengelig"
@@ -8266,10 +12700,16 @@
             "value" : "Dostępna aktualizacja"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizare disponibilă"
+            "state" : "new",
+            "value" : "Update Available"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update Available"
           }
         },
         "ru" : {
@@ -8278,10 +12718,46 @@
             "value" : "Доступно обновление"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update Available"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uppdatering tillgänglig"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Güncelleme Mevcut"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update Available"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Có bản cập nhật mới"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update Available"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update Available"
           }
         }
       }
@@ -8327,7 +12803,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Workout"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Workout"
           }
         },
@@ -8337,13 +12819,7 @@
             "value" : "Allenamento"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "運動"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Treningsøkt"
@@ -8361,22 +12837,28 @@
             "value" : "Wysiłek fizyczny"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Exercício"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activitate sportivă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Физическая нагрузка"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tréning"
           }
         },
         "sv" : {
@@ -8391,9 +12873,21 @@
             "value" : "Egzersiz"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Tập luyện"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Workout"
           }
         },
@@ -8408,6 +12902,12 @@
     "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs." : {
       "comment" : "Descriptive text for basal rate",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8438,13 +12938,25 @@
             "value" : "Votre débit basal d'insuline est le nombre d'unités par heure que vous souhaitez utiliser pour couvrir vos besoins vitaux d'insuline."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "La velocità basale d'insulina è il numero di unità all'ora che si desidera utilizzare per coprire il tuo fabbisogno d'insulina basale."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Din basaldose av insulin er antall enheter pr. time du vil bruke for å dekke ditt bakgrunnsinsulinbehov."
@@ -8462,16 +12974,28 @@
             "value" : "Dawka podstawowa insuliny to liczba jednostek na godzinę, którą chcesz wykorzystać do pokrycia podstawowego zapotrzebowania na insulinę."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rata bazală de insulină este numărul de unități pe oră pe care doriți să le utilizați pentru a acoperi necesarul bazal de insulina al organismului."
+            "state" : "new",
+            "value" : "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ваша базальная норма инсулина - это количество единиц в час, которое вы хотите использовать для покрытия своих фоновых потребностей в инсулине."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tvoja bazálna dávka inzulínu je počet jednotiek za hodinu, ktoré chceš použiť na pokrytie svojich základných potrieb inzulínu."
           }
         },
         "sv" : {
@@ -8485,12 +13009,42 @@
             "state" : "translated",
             "value" : "Bazal İnsülin Oranınız, arka plan insülin ihtiyaçlarınızı karşılamak için kullanmak istediğiniz  saat başına ünite miktarıdır."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tốc độ insulin nền của bạn là số đơn vị mỗi giờ được dùng để đáp ứng nhu cầu insulin nền của cơ thể."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs."
+          }
         }
       }
     },
     "Your Carb Ratio is the number of grams of carbohydrates covered by one unit of insulin." : {
       "comment" : "Descriptive text for carb ratio",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Carb Ratio is the number of grams of carbohydrates covered by one unit of insulin."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8521,13 +13075,25 @@
             "value" : "Votre ratio insuline-glucides est le nombre de grammes de glucides couverts par une unité d'insuline."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Carb Ratio is the number of grams of carbohydrates covered by one unit of insulin."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Carb Ratio is the number of grams of carbohydrates covered by one unit of insulin."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il tuo rapporto carboidrati è il numero di grammi di carboidrati coperti da un'unità d'insulina."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Karbforholdet ditt er antall gram karbohydrater som dekkes av én enhet insulin."
@@ -8545,16 +13111,28 @@
             "value" : "Twój Współczynnik Węglowodanowy to liczba gramów węglowodanów rekompensowanych przez jedną jednostkę insuliny."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Raportul carbohidrați/insulina este numărul de grame de carbohidrați acoperiți de o unitate de insulină."
+            "state" : "new",
+            "value" : "Your Carb Ratio is the number of grams of carbohydrates covered by one unit of insulin."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Carb Ratio is the number of grams of carbohydrates covered by one unit of insulin."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ваш углеводный коэффициент - это количество граммов углеводов, покрываемых одной единицей инсулина."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tvoj pomer sacharidov je počet gramov sacharidov pokrytých jednou jednotkou inzulínu."
           }
         },
         "sv" : {
@@ -8568,12 +13146,42 @@
             "state" : "translated",
             "value" : "Karbonhidrat İnsülin Oranınız, bir ünite insülinin kaç gram karbonhidrat karşılayacağını ifade eder."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Carb Ratio is the number of grams of carbohydrates covered by one unit of insulin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tỷ lệ carb của bạn là số gam carbohydrate được bù bởi một đơn vị insulin."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Carb Ratio is the number of grams of carbohydrates covered by one unit of insulin."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Carb Ratio is the number of grams of carbohydrates covered by one unit of insulin."
+          }
         }
       }
     },
     "Your Insulin Sensitivities refer to the drop in glucose expected from one unit of insulin." : {
       "comment" : "Descriptive text for insulin sensitivity",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Insulin Sensitivities refer to the drop in glucose expected from one unit of insulin."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8604,13 +13212,25 @@
             "value" : "Vos sensibilités à l'insuline se réfèrent à la baisse de glycémie prévue entrainée par une unité d'insuline."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Insulin Sensitivities refer to the drop in glucose expected from one unit of insulin."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Insulin Sensitivities refer to the drop in glucose expected from one unit of insulin."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "La tua sensibilità insulinica si riferisce al calo di glicemia previsto da un'unità d'insulina."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Din insulinfølsomhet refererer til fallet i blodsukker som forventes fra én enhet insulin."
@@ -8628,16 +13248,28 @@
             "value" : "Wrażliwość na insulinę odnosi się do oczekiwanego spadku glukozy po jednej jednostce insuliny."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Factorul de sensibilitate la insulină se referă la scăderea glicemiei determinata de o unitate de insulină."
+            "state" : "new",
+            "value" : "Your Insulin Sensitivities refer to the drop in glucose expected from one unit of insulin."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Insulin Sensitivities refer to the drop in glucose expected from one unit of insulin."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ваша чувствительность к инсулину означает снижение уровня глюкозы, ожидаемое от одной единицы инсулина."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tvoja inzulínová senzitivita udáva pokles glykémie očakávaný po jednej jednotke inzulínu."
           }
         },
         "sv" : {
@@ -8650,6 +13282,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "İnsülin Duyarlılık faktörünüz, bir ünite insülinden beklenen KŞ düşüşünü ifade eder."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Insulin Sensitivities refer to the drop in glucose expected from one unit of insulin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Độ nhạy insulin của bạn là mức giảm đường huyết dự kiến từ một đơn vị insulin."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Insulin Sensitivities refer to the drop in glucose expected from one unit of insulin."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Insulin Sensitivities refer to the drop in glucose expected from one unit of insulin."
           }
         }
       }

--- a/LoopKit/Resources/Localizable.xcstrings
+++ b/LoopKit/Resources/Localizable.xcstrings
@@ -96,8 +96,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ Range"
+            "state" : "translated",
+            "value" : "%@ rozsah"
           }
         },
         "sv" : {
@@ -114,8 +114,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ Range"
+            "state" : "translated",
+            "value" : "%@ Діапазон"
           }
         },
         "vi" : {
@@ -204,8 +204,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ U bolus failed"
+            "state" : "translated",
+            "value" : "%1$@ E bolus mislukt"
           }
         },
         "pl" : {
@@ -234,8 +234,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ U bolus failed"
+            "state" : "translated",
+            "value" : "%1$@ U bolus zlyhal"
           }
         },
         "sv" : {
@@ -252,8 +252,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ U bolus failed"
+            "state" : "translated",
+            "value" : "%1$@ U Болюс не відбувся"
           }
         },
         "vi" : {
@@ -342,8 +342,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ U bolus may not have succeeded"
+            "state" : "translated",
+            "value" : "%1$@ U bolus is mogelijk niet gelukt"
           }
         },
         "pl" : {
@@ -390,8 +390,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ U bolus may not have succeeded"
+            "state" : "translated",
+            "value" : "%1$@ U можлива невдача подачі болюса"
           }
         },
         "vi" : {
@@ -527,8 +527,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ will deliver basal and recommend bolus insulin only if your glucose is predicted to be above this limit for the next three hours."
+            "state" : "translated",
+            "value" : "%1$@ вводитиме базальний інсулін та рекомендуватиме болюсний інсулін лише тоді, коли прогнозується, що рівень глюкози перевищуватиме цю межу протягом наступних трьох годин."
           }
         },
         "vi" : {
@@ -801,8 +801,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "A value you have entered is higher than what is typically recommended for most people."
+            "state" : "translated",
+            "value" : "Введене вами значення вище, ніж те, що зазвичай рекомендується для більшості людей."
           }
         },
         "vi" : {
@@ -938,8 +938,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "A value you have entered is lower than what is typically recommended for most people."
+            "state" : "translated",
+            "value" : "Введене вами значення нижче за те, що зазвичай рекомендується для більшості людей."
           }
         },
         "vi" : {
@@ -1027,7 +1027,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Afrezza"
           }
         },
@@ -1075,7 +1075,7 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Afrezza"
           }
         },
@@ -1301,7 +1301,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Apidra"
           }
         },
@@ -1349,7 +1349,7 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Apidra"
           }
         },
@@ -1486,8 +1486,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Apidra (insulin glulisine)"
+            "state" : "translated",
+            "value" : "Apidra (інсулін glulisine)"
           }
         },
         "vi" : {
@@ -1623,8 +1623,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Apidra (insulin glulisine) is a rapid-acting insulin made by Sanofi-aventis "
+            "state" : "translated",
+            "value" : "Apidra (інсулін glulisine) це інсулін швидкої дії, вироблений компанією Sanofi-aventis"
           }
         },
         "vi" : {
@@ -1713,8 +1713,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Authorization Denied"
+            "state" : "translated",
+            "value" : "Autorisatie geweigerd"
           }
         },
         "pl" : {
@@ -1761,8 +1761,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Authorization Denied"
+            "state" : "translated",
+            "value" : "Авторизацію відхилено"
           }
         },
         "vi" : {
@@ -2399,8 +2399,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Check your pump before retrying"
+            "state" : "translated",
+            "value" : "Controleer je pomp voordat je het nogmaals probeert"
           }
         },
         "pl" : {
@@ -2447,8 +2447,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Check your pump before retrying"
+            "state" : "translated",
+            "value" : "Перевірте помпу перед повторною спробою"
           }
         },
         "vi" : {
@@ -2543,8 +2543,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Authorization Denied"
+            "state" : "translated",
+            "value" : "Autorisatie geweigerd"
           }
         },
         "pl" : {
@@ -2591,8 +2591,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Authorization Denied"
+            "state" : "translated",
+            "value" : "Авторизацію відхилено"
           }
         },
         "vi" : {
@@ -2735,8 +2735,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This sample can be deleted from the Health app"
+            "state" : "translated",
+            "value" : "Цей зразок можна видалити з програми «Здоров'я»"
           }
         },
         "vi" : {
@@ -2872,8 +2872,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Communication Failure"
+            "state" : "translated",
+            "value" : "Помилка з’єднання"
           }
         },
         "vi" : {
@@ -3009,8 +3009,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Communications interrupted during insulin delivery command."
+            "state" : "translated",
+            "value" : "Зв'язок перервано під час команди подачі інсуліну."
           }
         },
         "vi" : {
@@ -3146,8 +3146,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Connection Failure"
+            "state" : "translated",
+            "value" : "Помилка підключення"
           }
         },
         "vi" : {
@@ -3283,8 +3283,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Correction Range"
+            "state" : "translated",
+            "value" : "Діапазон корекції"
           }
         },
         "vi" : {
@@ -3420,8 +3420,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Correction Range is the glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin and helping you calculate your boluses."
+            "state" : "translated",
+            "value" : "Діапазон корекції – це значення глюкози (або діапазон значень), до якого ви хочете %1$@ прагнути під час коригування базального інсуліну та розрахунку болюсів."
           }
         },
         "vi" : {
@@ -3557,8 +3557,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Critical Update"
+            "state" : "translated",
+            "value" : "Критичне оновлення"
           }
         },
         "vi" : {
@@ -3831,8 +3831,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Device Refused"
+            "state" : "translated",
+            "value" : "Пристрій відхилено"
           }
         },
         "vi" : {
@@ -3920,8 +3920,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Device Status Critical"
+            "state" : "translated",
+            "value" : "Apparaat status kritiek"
           }
         },
         "pl" : {
@@ -3968,8 +3968,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Device Status Critical"
+            "state" : "translated",
+            "value" : "Стан пристрою Критичний"
           }
         },
         "vi" : {
@@ -4057,8 +4057,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Device Status Normal"
+            "state" : "translated",
+            "value" : "Apparaat status normaal"
           }
         },
         "pl" : {
@@ -4105,8 +4105,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Device Status Normal"
+            "state" : "translated",
+            "value" : "Стан пристрою Нормальний"
           }
         },
         "vi" : {
@@ -4194,8 +4194,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Device Status Warning"
+            "state" : "translated",
+            "value" : "Apparaat status waarschuwing"
           }
         },
         "pl" : {
@@ -4242,8 +4242,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Device Status Warning"
+            "state" : "translated",
+            "value" : "Попередження про стан пристрою"
           }
         },
         "vi" : {
@@ -4379,8 +4379,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Ensure carb data exists for the specified date"
+            "state" : "translated",
+            "value" : "Переконайтеся, що дані про вуглеводи існують для вказаної дати"
           }
         },
         "vi" : {
@@ -4516,8 +4516,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Falling"
+            "state" : "translated",
+            "value" : "Падіння"
           }
         },
         "vi" : {
@@ -4653,8 +4653,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Falling fast"
+            "state" : "translated",
+            "value" : "Швидке падіння"
           }
         },
         "vi" : {
@@ -4790,8 +4790,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Falling very fast"
+            "state" : "translated",
+            "value" : "Дуже швидке падіння"
           }
         },
         "vi" : {
@@ -4879,7 +4879,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Fiasp"
           }
         },
@@ -4927,7 +4927,7 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Fiasp"
           }
         },
@@ -5201,8 +5201,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Flat"
+            "state" : "translated",
+            "value" : "Стабільний"
           }
         },
         "vi" : {
@@ -5338,8 +5338,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from different models for the peak activity."
+            "state" : "translated",
+            "value" : "Для швидкодіючого інсуліну %1$@ припускається, що він активно працює протягом 6 годин. Ви можете вибрати одну з різних моделей для досягнення пікової активності."
           }
         },
         "vi" : {
@@ -5612,8 +5612,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Glucose Safety Limit"
+            "state" : "translated",
+            "value" : "Безпечний ліміт BG"
           }
         },
         "vi" : {
@@ -5749,8 +5749,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Hour"
+            "state" : "translated",
+            "value" : "Година"
           }
         },
         "vi" : {
@@ -5886,8 +5886,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Hours"
+            "state" : "translated",
+            "value" : "Годин"
           }
         },
         "vi" : {
@@ -5975,7 +5975,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Humalog"
           }
         },
@@ -6023,7 +6023,7 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Humalog"
           }
         },
@@ -6112,8 +6112,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Humalog (insulin lispro)"
+            "state" : "translated",
+            "value" : "Humalog (insuline lispro)"
           }
         },
         "pl" : {
@@ -6160,8 +6160,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Humalog (insulin lispro)"
+            "state" : "translated",
+            "value" : "Humalog (шнсулін lispro)"
           }
         },
         "vi" : {
@@ -6434,8 +6434,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Insulin Model"
+            "state" : "translated",
+            "value" : "Модель інсуліну"
           }
         },
         "vi" : {
@@ -6708,8 +6708,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Invalid Configuration"
+            "state" : "translated",
+            "value" : "Недопустима конфігурація"
           }
         },
         "vi" : {
@@ -6798,8 +6798,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "It is safe to retry"
+            "state" : "translated",
+            "value" : "Het is veilig om opnieuw te proberen"
           }
         },
         "pl" : {
@@ -6846,8 +6846,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "It is safe to retry"
+            "state" : "translated",
+            "value" : "Можна безпечно повторити спробу"
           }
         },
         "vi" : {
@@ -6935,7 +6935,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Lyumjev"
           }
         },
@@ -6983,7 +6983,7 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Lyumjev"
           }
         },
@@ -7257,8 +7257,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Make sure your pump is within communication range of your phone."
+            "state" : "translated",
+            "value" : "Переконайтеся, що помпа знаходиться в зоні зв'язку вашого телефону."
           }
         },
         "vi" : {
@@ -7394,8 +7394,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum Basal Rate"
+            "state" : "translated",
+            "value" : "Максимальна швидкість базалу"
           }
         },
         "vi" : {
@@ -7531,8 +7531,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum Basal Rate is the highest temporary basal rate %1$@ is allowed to set."
+            "state" : "translated",
+            "value" : "Максимальна базальна доза – це найвища тимчасова базальна доза, яку можна встановити %1$@."
           }
         },
         "vi" : {
@@ -7668,8 +7668,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum Bolus"
+            "state" : "translated",
+            "value" : "Максимум Болюса"
           }
         },
         "vi" : {
@@ -7805,8 +7805,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum Bolus is the highest bolus amount you can deliver at one time to cover carbs or bring down high glucose."
+            "state" : "translated",
+            "value" : "Максимальний болюс – це найбільша кількість болюсного введення, яку можна ввести за один раз, щоб покрити вуглеводи або знизити високий рівень BG."
           }
         },
         "vi" : {
@@ -7894,7 +7894,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "mg/dL/min"
           }
         },
@@ -7942,7 +7942,7 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "mg/dL/min"
           }
         },
@@ -8079,7 +8079,7 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "mg/dL/U"
           }
         },
@@ -8305,8 +8305,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "mmol/L/min"
+            "state" : "translated",
+            "value" : "mmol/L/E"
           }
         },
         "pl" : {
@@ -8353,7 +8353,7 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "mmol/L/min"
           }
         },
@@ -8490,7 +8490,7 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "mmol/L/U"
           }
         },
@@ -8627,8 +8627,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Needs Attention"
+            "state" : "translated",
+            "value" : "Потребує уваги"
           }
         },
         "vi" : {
@@ -8764,8 +8764,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "No Update"
+            "state" : "translated",
+            "value" : "Без оновлення"
           }
         },
         "vi" : {
@@ -8990,7 +8990,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Novolog"
           }
         },
@@ -9127,8 +9127,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Novolog (insulin aspart)"
+            "state" : "translated",
+            "value" : "Novolog (insuline aspart)"
           }
         },
         "pl" : {
@@ -9676,8 +9676,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Please re-enable sharing in Health"
+            "state" : "translated",
+            "value" : "Activeer het delen in gezondheid opnieuw"
           }
         },
         "pl" : {
@@ -9813,8 +9813,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Pre-Meal"
+            "state" : "translated",
+            "value" : "Voor de maaltijd"
           }
         },
         "pl" : {
@@ -9843,8 +9843,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Pre-Meal"
+            "state" : "translated",
+            "value" : "Pred jedlom"
           }
         },
         "sv" : {
@@ -12172,8 +12172,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Unit"
+            "state" : "translated",
+            "value" : "Jednotka"
           }
         },
         "sv" : {
@@ -12309,8 +12309,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Unit/hour"
+            "state" : "translated",
+            "value" : "Jednotka/hodina"
           }
         },
         "sv" : {
@@ -12583,8 +12583,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Units/hour"
+            "state" : "translated",
+            "value" : "Jednotky/hodina"
           }
         },
         "sv" : {
@@ -12720,8 +12720,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Update Available"
+            "state" : "translated",
+            "value" : "Dostupná aktualizácia"
           }
         },
         "sv" : {

--- a/LoopKit/Resources/Localizable.xcstrings
+++ b/LoopKit/Resources/Localizable.xcstrings
@@ -5868,8 +5868,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Hours"
+            "state" : "translated",
+            "value" : "Hodín"
           }
         },
         "sv" : {
@@ -8901,8 +8901,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "No values found"
+            "state" : "translated",
+            "value" : "Значень не знайдено"
           }
         },
         "vi" : {
@@ -9038,7 +9038,7 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Novolog"
           }
         },
@@ -9175,8 +9175,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Novolog (insulin aspart)"
+            "state" : "translated",
+            "value" : "Novolog (інсулін aspart)"
           }
         },
         "vi" : {
@@ -9586,8 +9586,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "One or more of the values you have entered is outside of what is typically recommended for most people."
+            "state" : "translated",
+            "value" : "Одне або декілька введених вами значень виходять за межі того, що зазвичай рекомендується для більшості людей."
           }
         },
         "vi" : {
@@ -9724,8 +9724,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Please re-enable sharing in Health"
+            "state" : "translated",
+            "value" : "Будь ласка, знову ввімкніть спільний доступ у додатку \"Health\""
           }
         },
         "vi" : {
@@ -9861,8 +9861,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Pre-Meal"
+            "state" : "translated",
+            "value" : "Перед їжою"
           }
         },
         "vi" : {
@@ -9998,8 +9998,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Recommended Update"
+            "state" : "translated",
+            "value" : "Рекомендоване оновлення"
           }
         },
         "vi" : {
@@ -10135,8 +10135,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Resumed"
+            "state" : "translated",
+            "value" : "Відновити"
           }
         },
         "vi" : {
@@ -10272,8 +10272,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Rising"
+            "state" : "translated",
+            "value" : "Зростаючий"
           }
         },
         "vi" : {
@@ -10409,8 +10409,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Rising fast"
+            "state" : "translated",
+            "value" : "Швидко зростає"
           }
         },
         "vi" : {
@@ -10546,8 +10546,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Rising very fast"
+            "state" : "translated",
+            "value" : "Дуже швидко зростає"
           }
         },
         "vi" : {
@@ -10683,8 +10683,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Some of the values you have entered are outside of what is typically recommended for most people."
+            "state" : "translated",
+            "value" : "Деякі з введених вами значень виходять за межі тих, що зазвичай рекомендуються для більшості людей."
           }
         },
         "vi" : {
@@ -11094,8 +11094,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
+            "state" : "translated",
+            "value" : "Тимчасово знизьте цільовий рівень глюкози перед їжею, щоб вплинути на піки BG після їжі."
           }
         },
         "vi" : {
@@ -11231,8 +11231,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
+            "state" : "translated",
+            "value" : "Тимчасово підвищуйте цільовий рівень глюкози до, під час або після фізичної активності, щоб зменшити ризик виникнення ситуацій, пов’язаних з низьким рівнем BG."
           }
         },
         "vi" : {
@@ -11368,8 +11368,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The value you have entered is higher than what is typically recommended for most people."
+            "state" : "translated",
+            "value" : "Введене вами значення вище, ніж те, що зазвичай рекомендується для більшості людей."
           }
         },
         "vi" : {
@@ -11505,8 +11505,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The value you have entered is lower than what is typically recommended for most people."
+            "state" : "translated",
+            "value" : "Введене вами значення нижче за те, що зазвичай рекомендується для більшості людей."
           }
         },
         "vi" : {
@@ -11642,8 +11642,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The values you have entered are outside of what is typically recommended for most people."
+            "state" : "translated",
+            "value" : "Деякі з введених вами значень виходять за межі тих, що зазвичай рекомендуються для більшості людей."
           }
         },
         "vi" : {
@@ -12053,8 +12053,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Uncertain Delivery"
+            "state" : "translated",
+            "value" : "Невизначена доставка"
           }
         },
         "vi" : {
@@ -12190,8 +12190,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Unit"
+            "state" : "translated",
+            "value" : "Одиниця виміру"
           }
         },
         "vi" : {
@@ -12327,8 +12327,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Unit/hour"
+            "state" : "translated",
+            "value" : "Одиниця за годину"
           }
         },
         "vi" : {
@@ -12464,8 +12464,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Units"
+            "state" : "translated",
+            "value" : "Одиниці"
           }
         },
         "vi" : {
@@ -12601,8 +12601,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Units/hour"
+            "state" : "translated",
+            "value" : "Одиниці за годину"
           }
         },
         "vi" : {
@@ -12738,8 +12738,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Update Available"
+            "state" : "translated",
+            "value" : "Доступне оновлення"
           }
         },
         "vi" : {
@@ -12875,8 +12875,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Workout"
+            "state" : "translated",
+            "value" : "Тренування"
           }
         },
         "vi" : {
@@ -13012,8 +13012,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs."
+            "state" : "translated",
+            "value" : "Ваша базальна доза (ТБШ) інсуліну – це кількість одиниць інсуліну на годину, яку ви хочете використовувати для покриття фонових потреб в інсуліні."
           }
         },
         "vi" : {
@@ -13149,8 +13149,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Carb Ratio is the number of grams of carbohydrates covered by one unit of insulin."
+            "state" : "translated",
+            "value" : "Ваш вуглеводний коефіцієнт – це кількість грамів вуглеводів, що покриваються однією одиницею інсуліну."
           }
         },
         "vi" : {
@@ -13286,8 +13286,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Insulin Sensitivities refer to the drop in glucose expected from one unit of insulin."
+            "state" : "translated",
+            "value" : "Ваша чутливість до інсуліну стосується зниження рівня глюкози, очікуваного від однієї одиниці інсуліну."
           }
         },
         "vi" : {

--- a/LoopKitUI/Resources/Localizable.xcstrings
+++ b/LoopKitUI/Resources/Localizable.xcstrings
@@ -476,7 +476,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "-"
           }
         },
@@ -612,7 +612,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "－"
           }
         },
@@ -749,7 +749,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "–"
           }
         },
@@ -885,7 +885,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "···"
           }
         },
@@ -1021,7 +1021,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%@"
           }
         },
@@ -1157,8 +1157,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ carbs, %@ absorption"
+            "state" : "translated",
+            "value" : "%@ koolhydraten, %@ absorptie"
           }
         },
         "pl" : {
@@ -1187,8 +1187,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ carbs, %@ absorption"
+            "state" : "translated",
+            "value" : "%@ sacharidov, %@ absorpcia"
           }
         },
         "sv" : {
@@ -1706,7 +1706,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@ – %2$@ %3$@"
           }
         },
@@ -1843,7 +1843,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@ %2$@"
           }
         },
@@ -2665,7 +2665,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@: <b>%2$@</b> %3$@"
           }
         },
@@ -2802,7 +2802,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@/min"
           }
         },
@@ -3212,7 +3212,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%lld"
           }
         },
@@ -3266,7 +3266,7 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%lld"
           }
         },
@@ -3348,7 +3348,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%lld, "
           }
         },
@@ -3402,7 +3402,7 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%lld, "
           }
         },
@@ -3484,7 +3484,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "🍽"
           }
         },
@@ -3514,7 +3514,7 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "🍽"
           }
         },
@@ -3538,7 +3538,7 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "🍽"
           }
         },
@@ -3621,8 +3621,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "🍽 Pre-Meal"
+            "state" : "translated",
+            "value" : "🍽 Voor de maaltijd"
           }
         },
         "pl" : {
@@ -3651,8 +3651,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "🍽 Pre-Meal"
+            "state" : "translated",
+            "value" : "🍽 Pred jedlom"
           }
         },
         "sv" : {
@@ -3675,8 +3675,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "🍽 Pre-Meal"
+            "state" : "translated",
+            "value" : "🍽 Trước bữa ăn"
           }
         },
         "yy-YY" : {
@@ -3757,7 +3757,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "🏃‍♂️"
           }
         },
@@ -3787,7 +3787,7 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "🏃‍♂️"
           }
         },
@@ -3811,7 +3811,7 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "🏃‍♂️"
           }
         },
@@ -3924,8 +3924,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "🏃‍♂️ Workout"
+            "state" : "translated",
+            "value" : "🏃‍♂️ Cvičenie"
           }
         },
         "sv" : {
@@ -3948,8 +3948,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "🏃‍♂️ Workout"
+            "state" : "translated",
+            "value" : "🏃‍♂️ Tập luyện"
           }
         },
         "yy-YY" : {
@@ -4085,8 +4085,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "A Correction Range is different. This will be a narrower range."
+            "state" : "translated",
+            "value" : "Phạm vi hiệu chỉnh khác với trước. Đây sẽ là một phạm vi hẹp hơn."
           }
         },
         "yy-YY" : {
@@ -4198,8 +4198,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "A value of 0 U/hr means you will be scheduled to receive no basal insulin."
+            "state" : "translated",
+            "value" : "Hodnota 0 J/h znamená, že nebudeš mať naplánované žiadne podávanie bazálneho inzulínu."
           }
         },
         "sv" : {
@@ -4222,8 +4222,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "A value of 0 U/hr means you will be scheduled to receive no basal insulin."
+            "state" : "translated",
+            "value" : "Giá trị 0 U/giờ có nghĩa là bạn sẽ được thiết lập để không nhận insulin nền."
           }
         },
         "yy-YY" : {
@@ -4472,8 +4472,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Active Duration"
+            "state" : "translated",
+            "value" : "Aktívne trvanie"
           }
         },
         "sv" : {
@@ -4496,8 +4496,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Active Duration"
+            "state" : "translated",
+            "value" : "Thời gian hoạt động"
           }
         },
         "yy-YY" : {
@@ -5128,7 +5128,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Afrezza"
           }
         },
@@ -5176,7 +5176,7 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Afrezza"
           }
         },
@@ -5569,8 +5569,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Authenticate to save therapy setting"
+            "state" : "translated",
+            "value" : "Autentifikuj sa na uloženie nastavenia terapie"
           }
         },
         "sv" : {
@@ -5593,8 +5593,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Authenticate to save therapy setting"
+            "state" : "translated",
+            "value" : "Xác thực để lưu cài đặt điều trị"
           }
         },
         "yy-YY" : {
@@ -5980,8 +5980,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Basal, bolus, and correction insulin dose amounts are decreased by %@%%."
+            "state" : "translated",
+            "value" : "Množstvá bazálneho, bolusového a korekčného inzulínu sú znížené o %@%%."
           }
         },
         "sv" : {
@@ -6117,8 +6117,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Basal, bolus, and correction insulin dose amounts are increased by %@%%."
+            "state" : "translated",
+            "value" : "Množstvá bazálneho, bolusového a korekčného inzulínu sú zvýšené o %@%%."
           }
         },
         "sv" : {
@@ -6254,8 +6254,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Basal, bolus, and correction insulin dose amounts are unaffected."
+            "state" : "translated",
+            "value" : "Množstvá bazálneho, bolusového a korekčného inzulínu nie sú ovplyvnené."
           }
         },
         "sv" : {
@@ -6941,8 +6941,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Changes will only apply this time you enable the override. The default settings of %@ will not be affected."
+            "state" : "translated",
+            "value" : "Zmeny sa použijú iba tentokrát, keď zapneš prepísanie. Predvolené nastavenia %@ nebudú ovplyvnené."
           }
         },
         "sv" : {
@@ -7102,8 +7102,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Changes will only apply this time you enable the preset. The default settings of %@ will not be affected."
+            "state" : "translated",
+            "value" : "Các thay đổi chỉ áp dụng cho lần này khi bạn bật cấu hình sẵn. Các cài đặt mặc định của %@ sẽ không bị ảnh hưởng."
           }
         },
         "yy-YY" : {
@@ -8222,8 +8222,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Completed."
+            "state" : "translated",
+            "value" : "Đã hoàn thành."
           }
         },
         "yy-YY" : {
@@ -8496,8 +8496,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirm Setting"
+            "state" : "translated",
+            "value" : "Xác nhận Cài đặt"
           }
         },
         "yy-YY" : {
@@ -8716,8 +8716,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Correct the highlighted unsupported value(s)."
+            "state" : "translated",
+            "value" : "Corrigeer de gemarkeerde niet-ondersteunde waarde(s)."
           }
         },
         "pl" : {
@@ -8770,8 +8770,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Correct the highlighted unsupported value(s)."
+            "state" : "translated",
+            "value" : "Hãy sửa các giá trị không được hỗ trợ đã được đánh dấu."
           }
         },
         "yy-YY" : {
@@ -9044,8 +9044,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Correction Values"
+            "state" : "translated",
+            "value" : "Các giá trị hiệu chỉnh"
           }
         },
         "yy-YY" : {
@@ -9455,8 +9455,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Custom Preset"
+            "state" : "translated",
+            "value" : "Cấu hình sẵn tùy chỉnh"
           }
         },
         "yy-YY" : {
@@ -10279,8 +10279,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Delivery Limits are safety guardrails for your insulin delivery."
+            "state" : "translated",
+            "value" : "Giới hạn tiêm insulin là hàng rào an toàn cho việc tiêm insulin của bạn."
           }
         },
         "yy-YY" : {
@@ -10416,8 +10416,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Disable Preset"
+            "state" : "translated",
+            "value" : "Tắt cấu hình sẵn"
           }
         },
         "yy-YY" : {
@@ -10827,8 +10827,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Edit"
+            "state" : "translated",
+            "value" : "Sửa"
           }
         },
         "yy-YY" : {
@@ -11378,8 +11378,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Edits persist only until the preset is disabled. The default settings of %@ will not be affected."
+            "state" : "translated",
+            "value" : "Các chỉnh sửa chỉ duy trì cho đến khi cấu hình sẵn bị tắt. Các cài đặt mặc định của %@ sẽ không bị ảnh hưởng."
           }
         },
         "yy-YY" : {
@@ -11926,8 +11926,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "End Time"
+            "state" : "translated",
+            "value" : "Kết thúc"
           }
         },
         "yy-YY" : {
@@ -12063,8 +12063,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Enter %1$@ value"
+            "state" : "translated",
+            "value" : "Nhập giá trị %1$@"
           }
         },
         "yy-YY" : {
@@ -12696,7 +12696,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Fiasp"
           }
         },
@@ -12744,7 +12744,7 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Fiasp"
           }
         },
@@ -12832,8 +12832,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Food Type"
+            "state" : "translated",
+            "value" : "Type voeding"
           }
         },
         "pl" : {
@@ -12886,8 +12886,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Food Type"
+            "state" : "translated",
+            "value" : "Loại thực phẩm"
           }
         },
         "yy-YY" : {
@@ -13023,8 +13023,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from %2$@ different models for how the app measures the insulin’s peak activity."
+            "state" : "translated",
+            "value" : "Với insulin tác dụng nhanh, %1$@ giả định rằng nó hoạt động trong 6 giờ. Bạn có thể chọn từ %2$@ mô hình khác nhau để ứng dụng tính toán hoạt động đỉnh của insulin."
           }
         },
         "yy-YY" : {
@@ -13160,8 +13160,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "For this range, choose the specific glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin."
+            "state" : "translated",
+            "value" : "Với phạm vi này, hãy chọn giá trị đường huyết cụ thể (hoặc khoảng giá trị) mà bạn muốn %1$@ hướng tới khi điều chỉnh insulin nền."
           }
         },
         "yy-YY" : {
@@ -13297,8 +13297,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Get help with Therapy Settings"
+            "state" : "translated",
+            "value" : "Nhận trợ giúp về Cài đặt điều trị"
           }
         },
         "yy-YY" : {
@@ -13434,8 +13434,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Go Back"
+            "state" : "translated",
+            "value" : "Quay lại"
           }
         },
         "yy-YY" : {
@@ -13571,8 +13571,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "High Basal Rate"
+            "state" : "translated",
+            "value" : "Tỷ lệ liều basal Cao"
           }
         },
         "yy-YY" : {
@@ -13708,8 +13708,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "High Carb Ratio"
+            "state" : "translated",
+            "value" : "Tỷ lệ Carb Cao"
           }
         },
         "yy-YY" : {
@@ -13845,8 +13845,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "High Correction Value"
+            "state" : "translated",
+            "value" : "Giá trị Hiệu chỉnh Cao"
           }
         },
         "yy-YY" : {
@@ -13982,8 +13982,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "High Glucose Safety Limit"
+            "state" : "translated",
+            "value" : "Giới hạn an toàn đường huyết Cao"
           }
         },
         "yy-YY" : {
@@ -14119,8 +14119,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "High Insulin Sensitivity"
+            "state" : "translated",
+            "value" : "Độ nhạy Insulin Cao"
           }
         },
         "yy-YY" : {
@@ -14256,8 +14256,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "High Maximum Basal Rate"
+            "state" : "translated",
+            "value" : "Tỷ lệ liều Basal Tối đa Cao"
           }
         },
         "yy-YY" : {
@@ -14393,8 +14393,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "High Maximum Bolus"
+            "state" : "translated",
+            "value" : "Liều Bolus tối đa Cao"
           }
         },
         "yy-YY" : {
@@ -14530,8 +14530,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "High Pre-Meal Value"
+            "state" : "translated",
+            "value" : "Giá trị trước bữa ăn Cao"
           }
         },
         "yy-YY" : {
@@ -14667,8 +14667,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "High Workout Value"
+            "state" : "translated",
+            "value" : "Giá trị khi tập luyện Cao"
           }
         },
         "yy-YY" : {
@@ -14941,8 +14941,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "If these settings look good to you, tap Save Settings to continue."
+            "state" : "translated",
+            "value" : "Nếu các cài đặt này phù hợp, hãy nhấn Lưu cài đặt để tiếp tục."
           }
         },
         "yy-YY" : {
@@ -15078,8 +15078,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "If you've used a CGM before, you're likely familiar with target range as a wide range of values you'd like for your glucose notification alerts, such as 70-180 mg/dL or 90-200 mg/dL."
+            "state" : "translated",
+            "value" : "Nếu bạn đã từng sử dụng CGM, bạn có thể đã quen với phạm vi mục tiêu là một phạm vi giá trị rộng mà bạn muốn dùng cho cảnh báo đường huyết, chẳng hạn 70–180 mg/dL hoặc 90–200 mg/dL."
           }
         },
         "yy-YY" : {
@@ -15214,8 +15214,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "info"
+            "state" : "translated",
+            "value" : "thông tin"
           }
         },
         "yy-YY" : {
@@ -15345,8 +15345,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Insulin Model"
+            "state" : "translated",
+            "value" : "Модель інсуліну"
           }
         },
         "vi" : {
@@ -15762,8 +15762,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Interrupted %1$@: <b>%2$@</b> of %3$@ %4$@"
+            "state" : "translated",
+            "value" : "Đã gián đoạn %1$@: <b>%2$@</b> trên %3$@ %4$@"
           }
         },
         "yy-YY" : {
@@ -15899,8 +15899,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "It can be set as low as %1$@. It can be set as high as %2$@."
+            "state" : "translated",
+            "value" : "Có thể đặt thấp nhất là %1$@. Có thể đặt cao nhất là %2$@."
           }
         },
         "yy-YY" : {
@@ -16036,8 +16036,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Low Basal Rate"
+            "state" : "translated",
+            "value" : "Tỷ lệ liều basal Thấp"
           }
         },
         "yy-YY" : {
@@ -16173,8 +16173,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Low Carb Ratio"
+            "state" : "translated",
+            "value" : "Tỷ lệ Carb Thấp"
           }
         },
         "yy-YY" : {
@@ -16310,8 +16310,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Low Correction Value"
+            "state" : "translated",
+            "value" : "Giá trị Hiệu chỉnh Thấp"
           }
         },
         "yy-YY" : {
@@ -16447,8 +16447,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Low Glucose Safety Limit"
+            "state" : "translated",
+            "value" : "Giới hạn an toàn đường huyết Thấp"
           }
         },
         "yy-YY" : {
@@ -16584,8 +16584,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Low Insulin Sensitivity"
+            "state" : "translated",
+            "value" : "Độ nhạy Insulin Thấp"
           }
         },
         "yy-YY" : {
@@ -16721,8 +16721,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Low Maximum Basal Rate"
+            "state" : "translated",
+            "value" : "Tỷ lệ liều Basal Tối đa Thấp"
           }
         },
         "yy-YY" : {
@@ -16858,8 +16858,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Low Maximum Bolus"
+            "state" : "translated",
+            "value" : "Liều Bolus tối đa Thấp"
           }
         },
         "yy-YY" : {
@@ -16995,8 +16995,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Low Pre-Meal Value"
+            "state" : "translated",
+            "value" : "Giá trị trước bữa ăn Thấp"
           }
         },
         "yy-YY" : {
@@ -17132,8 +17132,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Low Workout Value"
+            "state" : "translated",
+            "value" : "Giá trị khi tập luyện Thấp"
           }
         },
         "yy-YY" : {
@@ -17215,7 +17215,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Lyumjev"
           }
         },
@@ -17263,7 +17263,7 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Lyumjev"
           }
         },
@@ -17352,7 +17352,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "max"
           }
         },
@@ -17538,8 +17538,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum Basal Rate"
+            "state" : "translated",
+            "value" : "Максимальна швидкість базалу"
           }
         },
         "vi" : {
@@ -17681,8 +17681,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum Basal Rate is the maximum automatically adjusted basal rate that %1$@ is allowed to enact to help reach your correction range."
+            "state" : "translated",
+            "value" : "Tỷ lệ tiêm insulin nền tối đa là tỷ lệ tiêm nền được điều chỉnh tự động cao nhất mà %1$@ được phép thực hiện để giúp đạt phạm vi hiệu chỉnh của bạn."
           }
         },
         "yy-YY" : {
@@ -17813,8 +17813,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum Bolus"
+            "state" : "translated",
+            "value" : "Максимум Болюса"
           }
         },
         "vi" : {
@@ -17956,8 +17956,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum Bolus is the highest bolus amount that you will allow %1$@ to recommend at one time to cover carbs or bring down high glucose."
+            "state" : "translated",
+            "value" : "Bolus tối đa là lượng bolus cao nhất mà bạn cho phép %1$@ đề xuất tại một thời điểm để bù carbohydrate hoặc hạ đường huyết cao."
           }
         },
         "yy-YY" : {
@@ -18641,8 +18641,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "New Entry"
+            "state" : "translated",
+            "value" : "Mục nhập mới"
           }
         },
         "yy-YY" : {
@@ -18915,8 +18915,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "No Basal Insulin"
+            "state" : "translated",
+            "value" : "Không có insulin nền(basal)"
           }
         },
         "yy-YY" : {
@@ -18997,8 +18997,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Nothing to See Here!"
+            "state" : "translated",
+            "value" : "Hier is niets te zien!"
           }
         },
         "pl" : {
@@ -19051,8 +19051,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Nothing to See Here!"
+            "state" : "translated",
+            "value" : "Không có gì để xem ở đây cả!"
           }
         },
         "yy-YY" : {
@@ -19462,8 +19462,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Override History"
+            "state" : "translated",
+            "value" : "Lịch sử ghi đè"
           }
         },
         "yy-YY" : {
@@ -19958,8 +19958,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Pre-Meal"
+            "state" : "translated",
+            "value" : "Voor de maaltijd"
           }
         },
         "pl" : {
@@ -19988,8 +19988,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Pre-Meal"
+            "state" : "translated",
+            "value" : "Pred jedlom"
           }
         },
         "sv" : {
@@ -20149,8 +20149,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Pre-Meal Values"
+            "state" : "translated",
+            "value" : "Giá trị trước bữa ăn"
           }
         },
         "yy-YY" : {
@@ -20286,8 +20286,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Prescription"
+            "state" : "translated",
+            "value" : "Đơn thuốc"
           }
         },
         "yy-YY" : {
@@ -20560,8 +20560,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Progressing."
+            "state" : "translated",
+            "value" : "Đang tiến hành."
           }
         },
         "yy-YY" : {
@@ -20697,8 +20697,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump Event"
+            "state" : "translated",
+            "value" : "Sự kiện Pump"
           }
         },
         "yy-YY" : {
@@ -20834,8 +20834,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump Inoperable"
+            "state" : "translated",
+            "value" : "Pump không hoạt động"
           }
         },
         "yy-YY" : {
@@ -21793,8 +21793,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Review and Save Settings"
+            "state" : "translated",
+            "value" : "Xem lại và Lưu cài đặt"
           }
         },
         "yy-YY" : {
@@ -21930,8 +21930,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Review your therapy settings below. If you’d like to edit any of these settings, tap Back to go back to that screen."
+            "state" : "translated",
+            "value" : "Xem lại các cài đặt điều trị của bạn bên dưới. Nếu bạn muốn chỉnh sửa bất kỳ cài đặt nào, hãy nhấn Quay lại để trở về màn hình đó."
           }
         },
         "yy-YY" : {
@@ -22341,8 +22341,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Save Basal Rates?"
+            "state" : "translated",
+            "value" : "Lưu các tỷ lệ tiêm insulin nền?"
           }
         },
         "yy-YY" : {
@@ -22478,8 +22478,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Save Carb Ratios?"
+            "state" : "translated",
+            "value" : "Lưu các tỷ lệ carb?"
           }
         },
         "yy-YY" : {
@@ -22615,8 +22615,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Save Correction Range(s)?"
+            "state" : "translated",
+            "value" : "Lưu (các) phạm vi hiệu chỉnh?"
           }
         },
         "yy-YY" : {
@@ -22752,8 +22752,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Save Delivery Limits?"
+            "state" : "translated",
+            "value" : "Lưu các giới hạn tiêm insulin?"
           }
         },
         "yy-YY" : {
@@ -22889,8 +22889,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Save Glucose Safety Limit?"
+            "state" : "translated",
+            "value" : "Lưu giới hạn an toàn đường huyết?"
           }
         },
         "yy-YY" : {
@@ -23026,8 +23026,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Save Insulin Sensitivities?"
+            "state" : "translated",
+            "value" : "Lưu độ nhạy Insulin?"
           }
         },
         "yy-YY" : {
@@ -23163,8 +23163,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Save Pre-Meal Range?"
+            "state" : "translated",
+            "value" : "Lưu phạm vi mục tiêu trước bữa ăn?"
           }
         },
         "yy-YY" : {
@@ -23300,8 +23300,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Save Workout Range?"
+            "state" : "translated",
+            "value" : "Lưu phạm vi mục tiêu tập luyện?"
           }
         },
         "yy-YY" : {
@@ -23575,8 +23575,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "SCHEDULED OVERRIDE"
+            "state" : "translated",
+            "value" : "LỊCH TRÌNH GHI ĐÈ"
           }
         },
         "yy-YY" : {
@@ -23712,8 +23712,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "SCHEDULED PRESET"
+            "state" : "translated",
+            "value" : "LỊCH TRÌNH CẤU HÌNH SẴN"
           }
         },
         "yy-YY" : {
@@ -23848,8 +23848,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Selected"
+            "state" : "translated",
+            "value" : "Đã chọn"
           }
         },
         "yy-YY" : {
@@ -24122,8 +24122,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Some users choose a value 2, 3, or 4 times their highest scheduled basal rate."
+            "state" : "translated",
+            "value" : "Một số người dùng chọn giá trị gấp 2, 3 hoặc 4 lần tỷ lệ tiêm insulin nền đã lập lịch cao nhất của họ."
           }
         },
         "yy-YY" : {
@@ -24533,8 +24533,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Submitted by %1$@, %2$@"
+            "state" : "translated",
+            "value" : "Được gửi bởi %1$@, %2$@"
           }
         },
         "yy-YY" : {
@@ -24670,8 +24670,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Support"
+            "state" : "translated",
+            "value" : "Hỗ trợ"
           }
         },
         "yy-YY" : {
@@ -25080,8 +25080,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Switch Preview State"
+            "state" : "translated",
+            "value" : "Chuyển trạng thái xem trước"
           }
         },
         "yy-YY" : {
@@ -25217,8 +25217,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Symbol"
+            "state" : "translated",
+            "value" : "Ký hiệu"
           }
         },
         "yy-YY" : {
@@ -25354,8 +25354,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Tap '+' to create a new custom preset."
+            "state" : "translated",
+            "value" : "Nhấn '+' để tạo mới Cấu hình sẵn tùy chỉnh."
           }
         },
         "yy-YY" : {
@@ -25436,8 +25436,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Tap back to continue exploring the rest of the %@ interface."
+            "state" : "translated",
+            "value" : "Tik terug om de rest van de %@ interface te blijven verkennen."
           }
         },
         "pl" : {
@@ -25490,8 +25490,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Tap back to continue exploring the rest of the %@ interface."
+            "state" : "translated",
+            "value" : "Nhấn Quay lại để tiếp tục khám phá phần còn lại của giao diện %@."
           }
         },
         "yy-YY" : {
@@ -26258,7 +26258,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Test"
           }
         },
@@ -26312,8 +26312,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Test"
+            "state" : "translated",
+            "value" : "Thử nghiệm"
           }
         },
         "yy-YY" : {
@@ -26449,8 +26449,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "than your Correction Range."
+            "state" : "translated",
+            "value" : "so với phạm vi hiệu chỉnh của bạn."
           }
         },
         "yy-YY" : {
@@ -27136,8 +27136,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The rapid-acting adult model assumes peak activity at 75 minutes."
+            "state" : "translated",
+            "value" : "Rapid-acting adult giả định có thời điểm hoạt động đỉnh là 75 phút."
           }
         },
         "yy-YY" : {
@@ -27273,8 +27273,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The rapid-acting child model assumes peak activity at 65 minutes."
+            "state" : "translated",
+            "value" : "Rapid-acting child giả định có thời điểm hoạt động đỉnh là 65 phút."
           }
         },
         "yy-YY" : {
@@ -27410,8 +27410,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The schedule starts at midnight and cannot contain a rate of 0 U/hr."
+            "state" : "translated",
+            "value" : "Lịch trình bắt đầu từ nửa đêm và không được chứa tỷ lệ 0 U/giờ."
           }
         },
         "yy-YY" : {
@@ -27547,8 +27547,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Therapy Settings"
+            "state" : "translated",
+            "value" : "Cài đặt điều trị"
           }
         },
         "yy-YY" : {
@@ -27684,8 +27684,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This model assumes peak insulin activity at 19 minutes."
+            "state" : "translated",
+            "value" : "Mô hình này giả định thời điểm hoạt động đỉnh của insulin là 19 phút."
           }
         },
         "yy-YY" : {
@@ -27821,8 +27821,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This model assumes peak insulin activity at 55 minutes."
+            "state" : "translated",
+            "value" : "Mô hình này giả định thời điểm hoạt động đỉnh của insulin là 55 phút."
           }
         },
         "yy-YY" : {
@@ -27958,8 +27958,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This model assumes peak insulin activity at 65 minutes."
+            "state" : "translated",
+            "value" : "Mô hình này giả định thời điểm hoạt động đỉnh của insulin là 65 phút."
           }
         },
         "yy-YY" : {
@@ -28095,8 +28095,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This model assumes peak insulin activity at 75 minutes."
+            "state" : "translated",
+            "value" : "Mô hình này giả định thời điểm hoạt động đỉnh của insulin là 75 phút."
           }
         },
         "yy-YY" : {
@@ -28177,8 +28177,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This section of the %@ app is unavailable in this simulator."
+            "state" : "translated",
+            "value" : "Deze sectie van de %@ app is niet beschikbaar in deze simulator."
           }
         },
         "pl" : {
@@ -28231,8 +28231,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This section of the %@ app is unavailable in this simulator."
+            "state" : "translated",
+            "value" : "Phần này của ứng dụng %@ không khả dụng trong trình mô phỏng này."
           }
         },
         "yy-YY" : {
@@ -28368,8 +28368,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This setting will also determine a safety limit for automatic dosing. %1$@ will limit automatic delivery to keep the amount of active insulin below twice your maximum bolus."
+            "state" : "translated",
+            "value" : "Cài đặt này cũng sẽ xác định một giới hạn an toàn cho việc tiêm tự động. %1$@ sẽ giới hạn việc tiêm tự động để giữ lượng insulin đang hoạt động dưới gấp đôi bolus tối đa của bạn."
           }
         },
         "yy-YY" : {
@@ -28505,8 +28505,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This will typically be"
+            "state" : "translated",
+            "value" : "Thông thường, điều này sẽ là"
           }
         },
         "yy-YY" : {
@@ -28915,8 +28915,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "To be implemented"
+            "state" : "translated",
+            "value" : "Sẽ được triển khai"
           }
         },
         "yy-YY" : {
@@ -29464,8 +29464,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Unable to Save"
+            "state" : "translated",
+            "value" : "Không thể lưu"
           }
         },
         "yy-YY" : {
@@ -29875,8 +29875,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Unselected"
+            "state" : "translated",
+            "value" : "Chưa chọn"
           }
         },
         "yy-YY" : {
@@ -30094,8 +30094,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Unsupported %@"
+            "state" : "translated",
+            "value" : "Niet ondersteund %@"
           }
         },
         "pl" : {
@@ -30148,8 +30148,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Unsupported %@"
+            "state" : "translated",
+            "value" : "%@ không được hỗ trợ"
           }
         },
         "yy-YY" : {
@@ -30559,8 +30559,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "View Override"
+            "state" : "translated",
+            "value" : "Xem ghi đè"
           }
         },
         "yy-YY" : {
@@ -30642,7 +30642,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Walsh"
           }
         },
@@ -30696,8 +30696,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Walsh"
+            "state" : "translated",
+            "value" : "Mô hình Walsh"
           }
         },
         "yy-YY" : {
@@ -30971,8 +30971,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Work with your healthcare provider to choose a value that is higher than your highest scheduled basal rate, but as conservative or aggressive as you feel comfortable."
+            "state" : "translated",
+            "value" : "Hãy làm việc với nhà cung cấp dịch vụ y tế của bạn để chọn một giá trị cao hơn tỷ lệ tiêm insulin nền đã lập lịch cao nhất, nhưng mức độ thận trọng hoặc quyết liệt tùy theo bạn cảm thấy phù hợp."
           }
         },
         "yy-YY" : {
@@ -31245,8 +31245,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Workout Range is the glucose value or range of values you want %1$@ to target during activity. This range will be in effect when you activate the Workout Preset button."
+            "state" : "translated",
+            "value" : "Phạm vi khi tập luyện là giá trị đường huyết hoặc phạm vi giá trị mà bạn muốn %1$@ hướng tới trong quá trình hoạt động. Phạm vi này sẽ có hiệu lực khi bạn kích hoạt nút Cấu hình sẵn Tập luyện."
           }
         },
         "yy-YY" : {
@@ -31382,8 +31382,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Workout Values"
+            "state" : "translated",
+            "value" : "Giá trị khi tập luyện"
           }
         },
         "yy-YY" : {
@@ -31519,8 +31519,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "You can add different carb ratios for different times of day by using the ➕."
+            "state" : "translated",
+            "value" : "Bạn có thể thêm các tỷ lệ carb khác nhau cho các thời điểm trong ngày bằng cách sử dụng nút ➕."
           }
         },
         "yy-YY" : {
@@ -31656,8 +31656,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "You can add different insulin sensitivities for different times of day by using the ➕."
+            "state" : "translated",
+            "value" : "Bạn có thể thêm các độ nhạy insulin khác nhau cho các thời điểm trong ngày bằng cách sử dụng nút ➕."
           }
         },
         "yy-YY" : {
@@ -31793,8 +31793,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "You can add different ranges for different times of day by using the ➕."
+            "state" : "translated",
+            "value" : "Bạn có thể thêm các phạm vi khác nhau cho các thời điểm trong ngày bằng cách sử dụng nút ➕."
           }
         },
         "yy-YY" : {
@@ -31930,8 +31930,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "You can add entries for different times of day by using the ➕."
+            "state" : "translated",
+            "value" : "Bạn có thể thêm các mục cho các thời điểm khác nhau trong ngày bằng cách sử dụng nút ➕."
           }
         },
         "yy-YY" : {
@@ -32067,8 +32067,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "You can choose how %1$@ measures rapid acting insulin's peak activity according to one of these two insulin models."
+            "state" : "translated",
+            "value" : "Bạn có thể chọn cách %1$@ tính thời điểm hoạt động đỉnh của insulin tác dụng nhanh theo một trong hai mô hình insulin này."
           }
         },
         "yy-YY" : {
@@ -32204,8 +32204,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "You can edit a setting by tapping into any line item."
+            "state" : "translated",
+            "value" : "Bạn có thể chỉnh sửa một cài đặt bằng cách nhấn vào bất kỳ mục nào trong danh sách."
           }
         },
         "yy-YY" : {
@@ -32341,8 +32341,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "You can edit the setting by tapping into the line item."
+            "state" : "translated",
+            "value" : "Bạn có thể chỉnh sửa cài đặt bằng cách nhấn vào mục trong danh sách."
           }
         },
         "yy-YY" : {
@@ -32615,8 +32615,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "your Glucose Safety Limit"
+            "state" : "translated",
+            "value" : "giới hạn an toàn đường huyết của bạn"
           }
         },
         "yy-YY" : {
@@ -32752,8 +32752,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your healthcare provider can help you choose a Correction Range that's right for you."
+            "state" : "translated",
+            "value" : "Nhà cung cấp dịch vụ y tế của bạn có thể giúp bạn chọn một phạm vi hiệu chỉnh phù hợp với bạn."
           }
         },
         "yy-YY" : {
@@ -32889,8 +32889,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Insulin Sensitivity Factor (ISF) is the drop in glucose expected from one unit of insulin."
+            "state" : "translated",
+            "value" : "Độ nhạy insulin (ISF) của bạn là mức giảm đường huyết dự kiến từ một đơn vị insulin."
           }
         },
         "yy-YY" : {
@@ -33026,8 +33026,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Pre-Meal Range should be the glucose value (or range of values) you want %1$@ to target by the time you take your first bite of your meal. This range will be in effect when you activate the Pre-Meal Preset button."
+            "state" : "translated",
+            "value" : "Phạm vi trước bữa ăn của bạn nên là giá trị đường huyết (hoặc khoảng giá trị) mà bạn muốn %1$@ hướng tới vào lúc bạn ăn miếng đầu tiên. Phạm vi này sẽ có hiệu lực khi bạn kích hoạt nút Cấu hình sẵn Trước bữa ăn."
           }
         },
         "yy-YY" : {

--- a/LoopKitUI/Resources/Localizable.xcstrings
+++ b/LoopKitUI/Resources/Localizable.xcstrings
@@ -12862,8 +12862,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Food Type"
+            "state" : "translated",
+            "value" : "Typ jedla"
           }
         },
         "sv" : {
@@ -13410,8 +13410,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Go Back"
+            "state" : "translated",
+            "value" : "Naspäť"
           }
         },
         "sv" : {
@@ -20006,8 +20006,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Pre-Meal"
+            "state" : "translated",
+            "value" : "Перед їжою"
           }
         },
         "vi" : {
@@ -25895,8 +25895,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
+            "state" : "translated",
+            "value" : "Тимчасово знизьте цільовий рівень глюкози перед їжею, щоб вплинути на піки BG після їжі."
           }
         },
         "vi" : {
@@ -26032,8 +26032,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
+            "state" : "translated",
+            "value" : "Тимчасово підвищуйте цільовий рівень глюкози до, під час або після фізичної активності, щоб зменшити ризик виникнення ситуацій, пов’язаних з низьким рівнем BG."
           }
         },
         "vi" : {
@@ -29596,8 +29596,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Units"
+            "state" : "translated",
+            "value" : "Одиниці"
           }
         },
         "vi" : {
@@ -31102,8 +31102,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Workout"
+            "state" : "translated",
+            "value" : "Тренування"
           }
         },
         "vi" : {
@@ -32472,8 +32472,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs."
+            "state" : "translated",
+            "value" : "Ваша базальна доза (ТБШ) інсуліну – це кількість одиниць інсуліну на годину, яку ви хочете використовувати для покриття фонових потреб в інсуліні."
           }
         },
         "vi" : {

--- a/LoopKitUI/Resources/Localizable.xcstrings
+++ b/LoopKitUI/Resources/Localizable.xcstrings
@@ -2,11 +2,150 @@
   "sourceLanguage" : "en",
   "strings" : {
     "" : {
-
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ""
+          }
+        }
+      }
     },
     " higher " : {
       "comment" : "Information about workout range relative to correction range",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : " higher "
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37,13 +176,25 @@
             "value" : " plus élevé "
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : " higher "
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : " higher "
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : " superiore "
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "høyere"
@@ -61,16 +212,28 @@
             "value" : "wyżej"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : " mai mare "
+            "state" : "new",
+            "value" : " higher "
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : " higher "
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : " выше "
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " vyššie "
           }
         },
         "sv" : {
@@ -84,12 +247,42 @@
             "state" : "translated",
             "value" : " daha yüksek "
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : " higher "
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " cao hơn "
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : " higher "
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : " higher "
+          }
         }
       }
     },
     " lower " : {
       "comment" : "Information about pre-meal range relative to correction range",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : " lower "
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -120,13 +313,25 @@
             "value" : " moins élevé "
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : " lower "
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : " lower "
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : " inferiore "
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "nedre"
@@ -144,16 +349,28 @@
             "value" : " niżej "
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : " mai mic "
+            "state" : "new",
+            "value" : " lower "
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : " lower "
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : " ниже "
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " nižšie "
           }
         },
         "sv" : {
@@ -167,93 +384,123 @@
             "state" : "translated",
             "value" : " daha düşük "
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : " lower "
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " thấp hơn "
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : " lower "
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : " lower "
+          }
         }
       }
     },
     "-" : {
       "comment" : "Separator between min and max glucose values",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "-"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "-"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "-"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "-"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "-"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "-"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "-"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "-"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "-"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "-"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "-"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "-"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "-"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "-"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "-"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "-"
           }
         },
@@ -271,7 +518,31 @@
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "-"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "-"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
             "state" : "translated",
+            "value" : "-"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "-"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "-"
           }
         }
@@ -279,6 +550,12 @@
     },
     "－" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "－"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -287,35 +564,47 @@
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "－"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "－"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "－"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "－"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "－"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "－"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "－"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "–"
@@ -323,23 +612,35 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "－"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "－"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "-"
+            "state" : "new",
+            "value" : "－"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "－"
           }
         },
         "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "－"
+          }
+        },
+        "sk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "－"
@@ -348,12 +649,36 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "－"
+            "value" : "-"
           }
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "－"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "－"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
             "state" : "translated",
+            "value" : "–"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "－"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "－"
           }
         }
@@ -370,31 +695,31 @@
         },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "–"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "–"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "–"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "–"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "–"
           }
         },
@@ -404,33 +729,39 @@
             "value" : "-"
           }
         },
-        "it" : {
+        "hu" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "–"
           }
         },
-        "ja" : {
+        "it" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "—"
+            "state" : "new",
+            "value" : "–"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "–"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "–"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "–"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "–"
           }
         },
@@ -440,13 +771,13 @@
             "value" : "—"
           }
         },
-        "ro" : {
+        "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "–"
           }
         },
-        "ru" : {
+        "sk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "–"
@@ -460,7 +791,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "–"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "–"
           }
         },
@@ -468,6 +805,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "—"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "–"
           }
         },
         "zh-Hans" : {
@@ -480,63 +823,87 @@
     },
     "···" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "···"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "···"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "···"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "···"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "···"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "···"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "···"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "···"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "···"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "···"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "···"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "···"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "···"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "···"
           }
         },
@@ -546,6 +913,12 @@
             "value" : "---"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "···"
+          }
+        },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
@@ -554,7 +927,31 @@
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "···"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "···"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
             "state" : "translated",
+            "value" : "---"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "···"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "···"
           }
         }
@@ -562,67 +959,97 @@
     },
     "%@" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%@"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%@"
           }
         },
         "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@"
+          }
+        },
+        "sk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@"
@@ -636,7 +1063,31 @@
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "%@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
             "state" : "translated",
+            "value" : "%@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%@"
           }
         }
@@ -644,10 +1095,52 @@
     },
     "%@ carbs, %@ absorption" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ carbs, %@ absorption"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ kulhydrater, %@ absorption"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ carbs, %@ absorption"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ carbs, %@ absorption"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ carbs, %@ absorption"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ carbs, %@ absorption"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ carbs, %@ absorption"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ carbs, %@ absorption"
           }
         },
         "it" : {
@@ -656,10 +1149,16 @@
             "value" : "%@ carboidrati, %@ assorbimento"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ karbohydrater, %@ absorpsjon"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ carbs, %@ absorption"
           }
         },
         "pl" : {
@@ -668,10 +1167,64 @@
             "value" : "%@ węglowodanów, %@ wchłaniania"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ carbs, %@ absorption"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ carbs, %@ absorption"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ углеводов, %@ усвоения"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ carbs, %@ absorption"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ kolhydrater, %@ absorption"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ carbs, %@ absorption"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ carbs, %@ absorption"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ carbs, %@ hấp thụ"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ carbs, %@ absorption"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ carbs, %@ absorption"
           }
         }
       }
@@ -681,59 +1234,59 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@."
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@."
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@."
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@."
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@."
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%@."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%@."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@."
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ ."
@@ -741,31 +1294,31 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%@."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%@."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@."
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@."
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@."
           }
         },
@@ -777,25 +1330,37 @@
         },
         "sv" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@."
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%@."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%@."
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%@."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%@."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@."
           }
         }
@@ -805,9 +1370,15 @@
       "comment" : "The format for an insulin needs percentage.",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@%% of normal insulin"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@%% of normal insulin"
           }
         },
@@ -837,7 +1408,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%@%% of normal insulin"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%@%% of normal insulin"
           }
         },
@@ -847,13 +1424,7 @@
             "value" : "%@%% d'insulina normale"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@%% of normal insulin"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@%% av normalt insulin"
@@ -871,16 +1442,16 @@
             "value" : "%@%% normalnej insuliny"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@%% of normal insulin"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@%% de insulina normal"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@%% din insulină normală"
           }
         },
         "ru" : {
@@ -889,10 +1460,16 @@
             "value" : "%@%% нормального инсулина"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@%% of normal insulin"
+          }
+        },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@%% of normal insulin"
+            "value" : "%@%% av normalt insulinbehov"
           }
         },
         "tr" : {
@@ -901,10 +1478,22 @@
             "value" : "%@%% normal insulin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@%% of normal insulin"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@%% của insulin bình thường"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@%% of normal insulin"
           }
         },
         "zh-Hans" : {
@@ -918,6 +1507,12 @@
     "%@U" : {
       "comment" : "Format string for reservoir volume. (1: The localized volume)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@U"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -927,7 +1522,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@IE"
+            "value" : "%@U"
           }
         },
         "es" : {
@@ -950,7 +1545,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%@U"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%@U"
           }
         },
@@ -960,13 +1561,7 @@
             "value" : "%@U"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@U"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@E"
@@ -984,15 +1579,15 @@
             "value" : "%@J"
           }
         },
-        "pt-BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@U"
           }
         },
-        "ro" : {
+        "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@U"
           }
         },
@@ -1020,15 +1615,27 @@
             "value" : "%@Ü"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@U"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@U"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@U"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@U"
           }
         }
@@ -1039,91 +1646,91 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ – %2$@ %3$@"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ – %2$@ %3$@"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ – %2$@ %3$@"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ – %2$@ %3$@"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ – %2$@ %3$@"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ – %2$@ %3$@"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@ – %2$@ %3$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@ – %2$@ %3$@"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ – %2$@ %3$@"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ – %2$@ %3$@"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ – %2$@ %3$@"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ – %2$@ %3$@"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@ – %2$@ %3$@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@ – %2$@ %3$@"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ – %2$@ %3$@"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ – %2$@ %3$@"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ – %2$@ %3$@"
           }
         },
@@ -1141,7 +1748,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@ – %2$@ %3$@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@ – %2$@ %3$@"
           }
         },
@@ -1151,9 +1764,15 @@
             "value" : "%1$@ – %2$@ %3$@"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ – %2$@ %3$@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ – %2$@ %3$@"
           }
         }
@@ -1164,91 +1783,91 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ %2$@"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ %2$@"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ %2$@"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ %2$@"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ %2$@"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ %2$@"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@ %2$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@ %2$@"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ %2$@"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ %2$@"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ %2$@"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ %2$@"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@ %2$@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@ %2$@"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ %2$@"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ %2$@"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ %2$@"
           }
         },
@@ -1266,7 +1885,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@ %2$@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@ %2$@"
           }
         },
@@ -1275,16 +1900,28 @@
             "state" : "translated",
             "value" : "%1$@ %2$@"
           }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ %2$@"
+          }
         }
       }
     },
     "%1$@ assumes that the insulin it has delivered is actively working to lower your glucose for 6 hours. This setting cannot be changed." : {
       "comment" : "Information about insulin action duration (1: app name)",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ předpokládá, že inzulín, který podal, aktivně pracuje na snížení hladiny glukózy po dobu 6 hodin. Toto nastavení nelze změnit."
+            "state" : "new",
+            "value" : "%1$@ assumes that the insulin it has delivered is actively working to lower your glucose for 6 hours. This setting cannot be changed."
           }
         },
         "da" : {
@@ -1305,10 +1942,28 @@
             "value" : "%1$@ asume que la insulina que ha administrado está trabajando activamente para reducir el nivel de glucosa durante 6 horas. Esta configuración no se puede cambiar."
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ assumes that the insulin it has delivered is actively working to lower your glucose for 6 hours. This setting cannot be changed."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ suppose que l'insuline qu'il a délivrée agit activement pour réduire votre glycémie pendant 6 heures. Ce paramètre ne peut pas être modifié."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ assumes that the insulin it has delivered is actively working to lower your glucose for 6 hours. This setting cannot be changed."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ assumes that the insulin it has delivered is actively working to lower your glucose for 6 hours. This setting cannot be changed."
           }
         },
         "it" : {
@@ -1317,7 +1972,7 @@
             "value" : "%1$@ presuppone che l'insulina erogata stia attivamente lavorando per abbassare la glicemia per 6 ore. Questa impostazione non può essere modificata."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ antar at insulinet den har levert, jobber aktivt med å senke blodsukkeret i 6 timer. Denne innstillingen kan ikke endres."
@@ -1335,10 +1990,16 @@
             "value" : "%1$@ przyjmuje, że podana insulina obniża poziom glukozy przez 6 godzin. Nie można zmienić tego ustawienia."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ presupune că insulina pe care a livrat-o acționează pentru a vă scădea glicemia timp de 6 ore. Această setare nu poate fi schimbată."
+            "state" : "new",
+            "value" : "%1$@ assumes that the insulin it has delivered is actively working to lower your glucose for 6 hours. This setting cannot be changed."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ assumes that the insulin it has delivered is actively working to lower your glucose for 6 hours. This setting cannot be changed."
           }
         },
         "ru" : {
@@ -1347,10 +2008,46 @@
             "value" : "%1$@ предполагает, что доставленный им инсулин активно работает над снижением уровня глюкозы в течение 6 часов. Эта настройка не может быть изменена."
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ assumes that the insulin it has delivered is actively working to lower your glucose for 6 hours. This setting cannot be changed."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ antar att insulin doserat har en verkan i 6 timmar. Denna inställning går ej att ändra."
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ verdiği insülinin 6 saat boyunca glikozunuzu düşürmek için aktif olarak çalıştığını varsayar. Bu ayar değiştirilemez."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ assumes that the insulin it has delivered is actively working to lower your glucose for 6 hours. This setting cannot be changed."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ giả định rằng insulin đã bơm sẽ còn tác dụng hạ đường huyết trong 6 giờ. Cài đặt này không thể thay đổi."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ assumes that the insulin it has delivered is actively working to lower your glucose for 6 hours. This setting cannot be changed."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ assumes that the insulin it has delivered is actively working to lower your glucose for 6 hours. This setting cannot be changed."
           }
         }
       }
@@ -1358,6 +2055,12 @@
     "%1$@ or your Glucose Safety Limit, whichever is higher" : {
       "comment" : "Lower bound workout information text format (1: app name)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ or your Glucose Safety Limit, whichever is higher"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1388,13 +2091,25 @@
             "value" : "%1$@ ou votre limite de sécurité pour la glycémie, la valeur la plus élevée étant retenue"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ or your Glucose Safety Limit, whichever is higher"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ or your Glucose Safety Limit, whichever is higher"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ o il limite di sicurezza della glicemia, a seconda di quale sia il più alto"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ eller din sikkerhetsgrense for blodsukker, avhengig av hva som er høyest"
@@ -1412,16 +2127,28 @@
             "value" : "%1$@ lub bezpieczny limit stężenia glukozy, w zależności od tego, która wartość jest wyższa."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ sau limita dvs. de siguranță, oricare dintre acestea este mai mare"
+            "state" : "new",
+            "value" : "%1$@ or your Glucose Safety Limit, whichever is higher"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ or your Glucose Safety Limit, whichever is higher"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ или ваш безопасный предел ГК, в зависимости от того, что выше"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ or your Glucose Safety Limit, whichever is higher"
           }
         },
         "sv" : {
@@ -1435,12 +2162,42 @@
             "state" : "translated",
             "value" : "%1$@ veya KŞ Güvenlik Limitiniz, hangisi daha yüksekse"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ or your Glucose Safety Limit, whichever is higher"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ hoặc Giới hạn an toàn đường huyết của bạn, tùy theo giá trị nào cao hơn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ or your Glucose Safety Limit, whichever is higher"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ or your Glucose Safety Limit, whichever is higher"
+          }
         }
       }
     },
     "%1$@ supports 1 to %2$@ rates per day." : {
       "comment" : "Information about max number of basal rates (1: app name) (2: maximum schedule entry count)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ supports 1 to %2$@ rates per day."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1453,10 +2210,34 @@
             "value" : "%1$@ unterstützt 1 bis %2$@ Raten pro Tag."
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ supports 1 to %2$@ rates per day."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ supports 1 to %2$@ rates per day."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ gère entre 1 à %2$@ taux par jour."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ supports 1 to %2$@ rates per day."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ supports 1 to %2$@ rates per day."
           }
         },
         "it" : {
@@ -1465,7 +2246,7 @@
             "value" : "%1$@ supporta da 1 a %2$@ velocità al giorno."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ støtter 1 til %2$@ rater pr. dag."
@@ -1483,10 +2264,16 @@
             "value" : "%1$@ obsługuje od 1 do %2$@ dawek dziennie."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ acceptă rate de la 1 la %2$@ pe zi."
+            "state" : "new",
+            "value" : "%1$@ supports 1 to %2$@ rates per day."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ supports 1 to %2$@ rates per day."
           }
         },
         "ru" : {
@@ -1495,10 +2282,46 @@
             "value" : "%1$@ поддерживает от 1 до %2$@ изменений в день."
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ supports 1 to %2$@ rates per day."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ stöder 1 till %2$@ inställningar per dag."
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ günlük 1 ila %2$@ oranlarını destekler."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ supports 1 to %2$@ rates per day."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ hỗ trợ từ 1 đến %2$@ mức trong một ngày."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ supports 1 to %2$@ rates per day."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ supports 1 to %2$@ rates per day."
           }
         }
       }
@@ -1506,6 +2329,12 @@
     "%1$@ U" : {
       "comment" : "Reservoir entry (1: volume value)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1520,19 +2349,19 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ U"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ U"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ U"
           }
         },
@@ -1542,13 +2371,19 @@
             "value" : "U %1$@"
           }
         },
-        "it" : {
+        "hu" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ U"
           }
         },
-        "nb" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ E"
@@ -1566,22 +2401,28 @@
             "value" : "%1$@ J"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@ U"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@ U"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ U"
           }
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ j"
+            "state" : "new",
+            "value" : "%1$@ U"
           }
         },
         "sv" : {
@@ -1595,12 +2436,42 @@
             "state" : "translated",
             "value" : "%1$@ Ü"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ U"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U"
+          }
         }
       }
     },
     "%1$@ units remaining at %2$@" : {
       "comment" : "Accessibility format string for (1: localized volume)(2: time)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ units remaining at %2$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1633,26 +2504,26 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@ units remaining at %2$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@ units remaining at %2$@"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@ unità rimanenti a %2$@"
+            "value" : "%1$@ unità rimanenti alle ore %2$@"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%2$@の時点で %1$@ U 残っています"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ enheter som gjenstår på %2$@"
+            "value" : "%1$@ enheter gjenstår ved %2$@"
           }
         },
         "nl" : {
@@ -1667,16 +2538,16 @@
             "value" : "%1$@ jednostek pozostaje w %2$@"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ units remaining at %2$@"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ unidades restantes em %2$@"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ unități rămase la %2$@"
           }
         },
         "ru" : {
@@ -1703,15 +2574,27 @@
             "value" : "%1$@ ünite kaldı %2$@"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ одиниць залишилося на %2$@"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ units vẫn đang còn lúc %2$@"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ units remaining at %2$@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ units remaining at %2$@"
           }
         }
@@ -1720,43 +2603,61 @@
     "%1$@: <b>%2$@</b> %3$@" : {
       "comment" : "Description of a basal temp basal dose entry (1: title for dose type, 2: value (? if no value) in bold, 3: unit)\nDescription of a bolus dose entry (1: title for dose type, 2: value (? if no value) in bold, 3: unit)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@: <b>%2$@</b> %3$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@: <b>%2$@</b> %3$@"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@: <b>%2$@</b> %3$@"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@: <b>%2$@</b> %3$@"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@: <b>%2$@</b> %3$@"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@: <b>%2$@</b> %3$@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@: <b>%2$@</b> %3$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@: <b>%2$@</b> %3$@"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@: <b>%2$@</b> %3$@"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ : <b> %2$@ </b> %3$@"
@@ -1764,19 +2665,25 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@: <b>%2$@</b> %3$@"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@: <b>%2$@</b> %3$@"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@: <b>%2$@</b> %3$@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@: <b>%2$@</b> %3$@"
           }
         },
@@ -1784,6 +2691,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@:<b>%2$@</b> %3$@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@: <b>%2$@</b> %3$@"
           }
         },
         "sv" : {
@@ -1794,7 +2707,31 @@
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@: <b>%2$@</b> %3$@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@: <b>%2$@</b> %3$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
             "state" : "translated",
+            "value" : "%1$@: <b>%2$@</b> %3$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@: <b>%2$@</b> %3$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@: <b>%2$@</b> %3$@"
           }
         }
@@ -1805,85 +2742,85 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@/min"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@/min"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@/min"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@/min"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@/min"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@/min"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@/min"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@/min"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@/min"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@/分"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@/min"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@/min"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@/min"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@/min"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@/min"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@/min"
           }
         },
@@ -1891,6 +2828,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@/мин"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@/min"
           }
         },
         "sv" : {
@@ -1905,10 +2848,22 @@
             "value" : "%1$@/dk"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@/min"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@/phút"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@/min"
           }
         },
         "zh-Hans" : {
@@ -1922,55 +2877,61 @@
     "%1$@%2$@%3$@" : {
       "comment" : "String format for value with units (1: value, 2: separator, 3: units)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@%3$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@%2$@%3$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@%2$@%3$@"
+            "value" : "%1$@ %2$@ %3$@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@%2$@%3$@"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ %2$@ %3$@"
@@ -1978,31 +2939,31 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@%2$@%3$@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@%2$@%3$@"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
@@ -2014,25 +2975,37 @@
         },
         "sv" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@%2$@%3$@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@%2$@%3$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         }
@@ -2041,10 +3014,10 @@
     "%1$d percent complete." : {
       "comment" : "Format string for progress accessibility label (1: duration in seconds)",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$d procent dokončeno."
+            "state" : "new",
+            "value" : "%1$d percent complete."
           }
         },
         "da" : {
@@ -2059,6 +3032,18 @@
             "value" : "%1$d Prozent abgeschlossen."
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$d percent complete."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$d percent complete."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2071,13 +3056,19 @@
             "value" : "%1$d אחוז בוצע."
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$d percent complete."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$d percento completato."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$d prosent fullført."
@@ -2095,10 +3086,16 @@
             "value" : "Ukończono %1$d procent."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$d la sută complet."
+            "state" : "new",
+            "value" : "%1$d percent complete."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$d percent complete."
           }
         },
         "ru" : {
@@ -2107,65 +3104,149 @@
             "value" : "Выполнено на %1$d процентов."
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$d percent complete."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d procent klar."
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Yüzde %1$d tamamlandı."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$d percent complete."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d phần trăm đã hoàn thành."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$d percent complete."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$d percent complete."
           }
         }
       }
     },
     "%lld" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%lld"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%lld"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%lld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%lld"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%lld"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%lld"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%lld"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%lld"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%lld"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%lld"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%lld"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%lld"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%lld"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%lld"
           }
         },
         "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%lld"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%lld"
+          }
+        },
+        "sv" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld"
@@ -2173,7 +3254,31 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%lld"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%lld"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%lld"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%lld"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%lld"
           }
         }
@@ -2181,31 +3286,61 @@
     },
     "%lld, " : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%lld, "
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%lld, "
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%lld, "
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%lld, "
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%lld, "
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%lld, "
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%lld, "
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%lld, "
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%lld, "
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld,"
@@ -2213,23 +3348,41 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%lld, "
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%lld, "
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%lld, "
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%lld, "
           }
         },
         "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%lld, "
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%lld, "
+          }
+        },
+        "sv" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld, "
@@ -2237,7 +3390,31 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%lld, "
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%lld, "
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%lld, "
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%lld, "
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%lld, "
           }
         }
@@ -2245,75 +3422,99 @@
     },
     "🍽" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🍽"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "🍽"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "🍽"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "🍽"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "🍽"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "🍽"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "🍽"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "🍽"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "🍽"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "🍽"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "🍽"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "🍽"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "🍽"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "🍽"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "🍽"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "🍽"
           }
         },
@@ -2325,7 +3526,31 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "🍽"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🍽"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🍽"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🍽"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "🍽"
           }
         }
@@ -2334,6 +3559,12 @@
     "🍽 Pre-Meal" : {
       "comment" : "Premeal override preset title",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🍽 Pre-Meal"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2364,13 +3595,25 @@
             "value" : "🍽 Pré-Repas"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🍽 Pre-Meal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🍽 Pre-Meal"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "🍽 Pre-pasto"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "🍽 Før måltid"
@@ -2378,7 +3621,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "🍽 Pre-Meal"
           }
         },
@@ -2388,16 +3631,28 @@
             "value" : "🍽 Przed posiłkiem"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "🍽 Preprandial"
+            "state" : "new",
+            "value" : "🍽 Pre-Meal"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🍽 Pre-Meal"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "До еды"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🍽 Pre-Meal"
           }
         },
         "sv" : {
@@ -2411,68 +3666,116 @@
             "state" : "translated",
             "value" : "🍽 Yemek Öncesi"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🍽 Pre-Meal"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🍽 Pre-Meal"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🍽 Pre-Meal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🍽 Pre-Meal"
+          }
         }
       }
     },
     "🏃‍♂️" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🏃‍♂️"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "🏃‍♂️"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "🏃‍♂️"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "🏃‍♂️"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "🏃‍♂️"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "🏃‍♂️"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🏃‍♂️"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "🏃‍♂️"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "🏃‍♂️"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "🏃‍♂️"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "🏃‍♂️"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "🏃‍♂️"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "🏃‍♂️"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "🏃‍♂️"
           }
         },
@@ -2480,6 +3783,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "🏃‍"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🏃‍♂️"
           }
         },
         "sv" : {
@@ -2490,7 +3799,31 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "🏃‍♂️"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🏃‍♂️"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🏃‍♂️"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🏃‍♂️"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "🏃‍♂️"
           }
         }
@@ -2499,6 +3832,12 @@
     "🏃‍♂️ Workout" : {
       "comment" : "Workout override preset title",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🏃‍♂️ Workout"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2529,13 +3868,25 @@
             "value" : "Exercice"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🏃‍♂️ Workout"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🏃‍♂️ Workout"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "🏃‍♂️ Allenamento"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "🏃 ♂️ Treningsøkt"
@@ -2553,16 +3904,28 @@
             "value" : "🏃‍♂️ Trening"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "🏃‍♂️ Activitate sportivă"
+            "state" : "new",
+            "value" : "🏃‍♂️ Workout"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🏃‍♂️ Workout"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "🏃‍♂️ Тренировки"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🏃‍♂️ Workout"
           }
         },
         "sv" : {
@@ -2576,12 +3939,42 @@
             "state" : "translated",
             "value" : "🏃‍♂️ Egzersiz"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🏃‍♂️ Workout"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🏃‍♂️ Workout"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🏃‍♂️ Workout"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "🏃‍♂️ Workout"
+          }
         }
       }
     },
     "A Correction Range is different. This will be a narrower range." : {
       "comment" : "Information about differences between target range and correction range",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A Correction Range is different. This will be a narrower range."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2612,13 +4005,25 @@
             "value" : "Une plage de correction est différente. Il s'agit d'une plage plus étroite."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A Correction Range is different. This will be a narrower range."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A Correction Range is different. This will be a narrower range."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Un intervallo di correzione è diverso. Questo sarà un intervallo più ristretto."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Et korreksjonsområde er annerledes. Dette vil være et smalere område."
@@ -2636,16 +4041,28 @@
             "value" : "Obecna skala została ograniczona bezpieczniejszą wartością."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Un interval de corecție este diferit. Acesta ar trebui sa fie un interval mai îngust."
+            "state" : "new",
+            "value" : "A Correction Range is different. This will be a narrower range."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A Correction Range is different. This will be a narrower range."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Диапазон коррекции слишком широкий. Это должен быть более узкий диапазон."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A Correction Range is different. This will be a narrower range."
           }
         },
         "sv" : {
@@ -2660,6 +4077,24 @@
             "value" : "Düzeltme Aralığı farklıdır. Bu daha dar bir aralık olacaktır."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A Correction Range is different. This will be a narrower range."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A Correction Range is different. This will be a narrower range."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A Correction Range is different. This will be a narrower range."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2671,6 +4106,12 @@
     "A value of 0 U/hr means you will be scheduled to receive no basal insulin." : {
       "comment" : "Warning text for basal rate of 0 U/hr",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value of 0 U/hr means you will be scheduled to receive no basal insulin."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2701,13 +4142,25 @@
             "value" : "Une valeur de 0 U/hr veut dire que vous ne recevrez aucune insuline basale."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value of 0 U/hr means you will be scheduled to receive no basal insulin."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value of 0 U/hr means you will be scheduled to receive no basal insulin."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Un valore pari a 0 U/ora significa che non ti verrà erogata insulina basale."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "En verdi på 0 E/time betyr at du ikke vil få noe basalinsulin."
@@ -2725,16 +4178,28 @@
             "value" : "Wartość 0 jedn./godz. oznacza, że nie zaplanowano podawania insuliny bazowej."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "O valoare de 0 U/oră înseamnă că nu vei primi insulină bazală."
+            "state" : "new",
+            "value" : "A value of 0 U/hr means you will be scheduled to receive no basal insulin."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value of 0 U/hr means you will be scheduled to receive no basal insulin."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Значение 0 Ед/час означает, что Вы не будете получать базальный инсулин."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value of 0 U/hr means you will be scheduled to receive no basal insulin."
           }
         },
         "sv" : {
@@ -2748,12 +4213,42 @@
             "state" : "translated",
             "value" : "0 Ü/saat değeri, bazal insülin almayacağınız anlamına gelir."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value of 0 U/hr means you will be scheduled to receive no basal insulin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value of 0 U/hr means you will be scheduled to receive no basal insulin."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value of 0 U/hr means you will be scheduled to receive no basal insulin."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A value of 0 U/hr means you will be scheduled to receive no basal insulin."
+          }
         }
       }
     },
     "Absorption Time" : {
       "comment" : "Title of the carb entry absorption time cell",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Absorption Time"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2786,7 +4281,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Absorption Time"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Absorption Time"
           }
         },
@@ -2796,13 +4297,7 @@
             "value" : "Periodo di assorbimento"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "吸収時間"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Absorbsjonstid"
@@ -2820,22 +4315,28 @@
             "value" : "Czas absorpcji"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Absorption Time"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tempo de Absorção"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timp de absorbție"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Длительность усвоения"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Absorption Time"
           }
         },
         "sv" : {
@@ -2850,10 +4351,22 @@
             "value" : "Emilim Süresi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Absorption Time"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thời gian Hấp thụ"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Absorption Time"
           }
         },
         "zh-Hans" : {
@@ -2867,6 +4380,12 @@
     "Active Duration" : {
       "comment" : "The text for the override history duration",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Active Duration"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2897,13 +4416,25 @@
             "value" : "Durée active"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Active Duration"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Active Duration"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Durata attiva"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aktiv varighet"
@@ -2921,16 +4452,28 @@
             "value" : "Aktywny czas trwania"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Durata activă"
+            "state" : "new",
+            "value" : "Active Duration"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Active Duration"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Активная продолжительность"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Active Duration"
           }
         },
         "sv" : {
@@ -2944,12 +4487,42 @@
             "state" : "translated",
             "value" : "Aktif Süre"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Active Duration"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Active Duration"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Active Duration"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Active Duration"
+          }
         }
       }
     },
     "Activity" : {
       "comment" : "The title for the custom preset emoji activity section",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "النشاط"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2982,7 +4555,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Activity"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Activity"
           }
         },
@@ -2992,13 +4571,7 @@
             "value" : "Attività"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アクティビティ"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aktivitet"
@@ -3016,16 +4589,16 @@
             "value" : "Aktywność"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Activity"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Atividade"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activitate"
           }
         },
         "ru" : {
@@ -3052,10 +4625,22 @@
             "value" : "Aktivite"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Активність"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hoạt động"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Activity"
           }
         },
         "zh-Hans" : {
@@ -3069,6 +4654,12 @@
     "Add" : {
       "comment" : "Button text to confirm adding a new schedule item",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أضف"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3084,7 +4675,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Agregar"
+            "value" : "Añadir"
           }
         },
         "fi" : {
@@ -3099,13 +4690,25 @@
             "value" : "Ajouter"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hozzáad"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aggiungi"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Legg til"
@@ -3123,16 +4726,28 @@
             "value" : "Dodaj"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Adaugă"
+            "value" : "Adicionar"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicionar"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Добавить"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pridať"
           }
         },
         "sv" : {
@@ -3147,6 +4762,24 @@
             "value" : "Ekle"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Додати"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thêm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3158,10 +4791,10 @@
     "Add Account" : {
       "comment" : "The title of the button to add the credentials for a service",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Přidat účet"
+            "state" : "new",
+            "value" : "Add Account"
           }
         },
         "da" : {
@@ -3196,7 +4829,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Add Account"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Add Account"
           }
         },
@@ -3206,13 +4845,7 @@
             "value" : "Aggiungi account"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アカウントを追加"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Legg Til Konto"
@@ -3230,16 +4863,16 @@
             "value" : "Dodaj konto"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add Account"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Adicionar Conta"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adaugă cont"
           }
         },
         "ru" : {
@@ -3266,10 +4899,22 @@
             "value" : "Hesap Ekle"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add Account"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thêm Tài khoản"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add Account"
           }
         },
         "zh-Hans" : {
@@ -3286,7 +4931,7 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Add Carb Entry"
           }
         },
@@ -3322,7 +4967,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Add Carb Entry"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Add Carb Entry"
           }
         },
@@ -3332,13 +4983,7 @@
             "value" : "Aggiungi inserimento carboidrati"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "糖質の記入を追加"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Legg til karbohydrater"
@@ -3356,16 +5001,16 @@
             "value" : "Wprowadź węglowodany"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add Carb Entry"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Adicionar Carb"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adaugă carbohidrați"
           }
         },
         "ru" : {
@@ -3392,10 +5037,22 @@
             "value" : "Karb Girişi Ekle"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add Carb Entry"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Khai báo Carb"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add Carb Entry"
           }
         },
         "zh-Hans" : {
@@ -3409,61 +5066,103 @@
     "Afrezza" : {
       "comment" : "Title of insulin model preset - afrezza",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Afrezza"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Afrezza"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Afrezza"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Afrezza"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Afrezza"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Afrezza"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Afrezza"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Afrezza"
           }
         },
-        "ro" : {
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
+        "sk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afrezza"
           }
         },
-        "ru" : {
+        "sv" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afrezza"
@@ -3471,7 +5170,31 @@
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
             "state" : "translated",
+            "value" : "Afrezza"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Afrezza"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Afrezza"
           }
         }
@@ -3480,6 +5203,12 @@
     "Are you sure you want to delete all history entries?" : {
       "comment" : "Action sheet confirmation message for pump history deletion",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete all history entries?"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3516,19 +5245,19 @@
             "value" : "בטוח שברצונך למחוק את כל ערכי ההיסטוריה?"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete all history entries?"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sei sicuro di voler eliminare tutte le voci della cronologia?"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "入力履歴をすべて削除しますか?"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Er du sikker på at du vil slette alle historiske innslag?"
@@ -3546,22 +5275,28 @@
             "value" : "Czy jesteś pewien, że chcesz usunąć z Loop wszystkie dane historyczne pompy?"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete all history entries?"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tem certeza de que deseja excluir todas as entradas do histórico?"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sigur doriți să ștergeți toate înregistrările din istoric?"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Подтвердите удаление всех записей истории?"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete all history entries?"
           }
         },
         "sv" : {
@@ -3576,10 +5311,22 @@
             "value" : "Tüm geçmiş girişlerini silmek istediğinizden emin misiniz?"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete all history entries?"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bạn có chắc muốn xóa hết các dữ liệu cũ?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete all history entries?"
           }
         },
         "zh-Hans" : {
@@ -3593,6 +5340,12 @@
     "Are you sure you want to delete all reservoir values?" : {
       "comment" : "Action sheet confirmation message for reservoir deletion",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete all reservoir values?"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3629,19 +5382,19 @@
             "value" : "בטוח שברצונך למחוק את כל ערכי המאגר?"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete all reservoir values?"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sei sicuro di voler eliminare tutti i valori del serbatoio?"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "リザーバの値をすべて削除しますか?"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Er du sikker på at du vil slette alle reservoarverdier?"
@@ -3659,22 +5412,28 @@
             "value" : "Czy jesteś pewien, że chcesz usunąć wszystkie wartości zbiornika?"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete all reservoir values?"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tem certeza de que deseja excluir todos os valores do reservatório?"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sigur doriți să ștergeți toate valorile de rezervor?"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Подтвердите удаление всех записей резервуара?"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete all reservoir values?"
           }
         },
         "sv" : {
@@ -3689,10 +5448,22 @@
             "value" : "Tüm rezervuar değerlerini silmek istediğinizden emin misiniz?"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete all reservoir values?"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bạn có chắc muốn xóa hết mọi giá trị của ngăn chứa insulin?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete all reservoir values?"
           }
         },
         "zh-Hans" : {
@@ -3706,6 +5477,12 @@
     "Authenticate to save therapy setting" : {
       "comment" : "Authentication hint string for therapy settings",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authenticate to save therapy setting"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3736,13 +5513,25 @@
             "value" : "Authentifier pour enregistrer les paramètres thérapeutiques"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authenticate to save therapy setting"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authenticate to save therapy setting"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Autenticati per salvare le impostazioni della terapia"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Autentiser for å lagre behandlingsinnstillingen"
@@ -3760,16 +5549,28 @@
             "value" : "Uwierzytelnij, aby zapisać ustawienia terapii"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autentifică-te pentru a salva setările terapiei"
+            "state" : "new",
+            "value" : "Authenticate to save therapy setting"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authenticate to save therapy setting"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Аутентификация для сохранения настроек терапии"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authenticate to save therapy setting"
           }
         },
         "sv" : {
@@ -3783,16 +5584,40 @@
             "state" : "translated",
             "value" : "Tedavi ayarını kaydetmek için kimlik doğrulama"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authenticate to save therapy setting"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authenticate to save therapy setting"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authenticate to save therapy setting"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Authenticate to save therapy setting"
+          }
         }
       }
     },
     "Back" : {
       "comment" : "Back navigation button title",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zpět"
+            "value" : "رجوع"
           }
         },
         "da" : {
@@ -3825,13 +5650,25 @@
             "value" : "Retour"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Back"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Back"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Indietro"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tilbake"
@@ -3849,10 +5686,16 @@
             "value" : "Powrót"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Înapoi"
+            "state" : "new",
+            "value" : "Back"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Back"
           }
         },
         "ru" : {
@@ -3878,6 +5721,30 @@
             "state" : "translated",
             "value" : "Geri"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тому"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quay Lại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Back"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Back"
+          }
         }
       }
     },
@@ -3888,12 +5755,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "الضخ المستمر"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Úrovně bazálu"
           }
         },
         "da" : {
@@ -3928,7 +5789,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Basal Rates"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Basal Rates"
           }
         },
@@ -3938,13 +5805,7 @@
             "value" : "Velocità basali"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "基礎レート"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Basal-satser"
@@ -3962,16 +5823,16 @@
             "value" : "Dawka Podstawowa (Baza)"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal Rates"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Taxas Basais"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rate bazale"
           }
         },
         "ru" : {
@@ -3998,10 +5859,22 @@
             "value" : "Bazal Oranlar"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Швидкості Базалу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lịch biểu tiêm liều nền"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal Rates"
           }
         },
         "zh-Hans" : {
@@ -4015,6 +5888,12 @@
     "Basal, bolus, and correction insulin dose amounts are decreased by %@%%." : {
       "comment" : "Describes a percentage decrease in overall insulin needs",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal, bolus, and correction insulin dose amounts are decreased by %@%%."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4047,7 +5926,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Basal, bolus, and correction insulin dose amounts are decreased by %@%%."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Basal, bolus, and correction insulin dose amounts are decreased by %@%%."
           }
         },
@@ -4057,13 +5942,7 @@
             "value" : "Le quantità di dosi basali, di bolo e di correzione dell’insulina sono calate del %@%%."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "基礎、ボーラス、補正注入の量が %@%%減ります。"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Insulindoser for basal, bolus og korreksjon er redusert med %@%%."
@@ -4081,22 +5960,28 @@
             "value" : "Dawka podstawowa, bolus i korygująca dawka insuliny zostały zmniejszone o %@%%."
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal, bolus, and correction insulin dose amounts are decreased by %@%%."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "As quantidades basais, de bolus e de dose de insulina de correção diminuem em %@%%."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dozele de insulină bazale, de bolus și de corecție sunt scăzute cu %@%%."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "База, болюсы и болюсы на коррекцию снижены на%@%%."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal, bolus, and correction insulin dose amounts are decreased by %@%%."
           }
         },
         "sv" : {
@@ -4111,10 +5996,22 @@
             "value" : "Bazal, bolus ve düzeltme insülin doz miktarları %@%% azaltılır."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal, bolus, and correction insulin dose amounts are decreased by %@%%."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Liều Basal, bolus, và liều bổ sung đang giảm bằng %@%%."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal, bolus, and correction insulin dose amounts are decreased by %@%%."
           }
         },
         "zh-Hans" : {
@@ -4128,6 +6025,12 @@
     "Basal, bolus, and correction insulin dose amounts are increased by %@%%." : {
       "comment" : "Describes a percentage increase in overall insulin needs",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal, bolus, and correction insulin dose amounts are increased by %@%%."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4160,7 +6063,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Basal, bolus, and correction insulin dose amounts are increased by %@%%."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Basal, bolus, and correction insulin dose amounts are increased by %@%%."
           }
         },
@@ -4170,13 +6079,7 @@
             "value" : "Le quantità di dosi basali, di bolo e di correzione dell’insulina sono aumentate del %@%%."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "基礎、ボーラス、補正注入の量が %@%%増えます。"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Insulindoser for bassal, bolus og korreksjon er økt med %@%%"
@@ -4194,22 +6097,28 @@
             "value" : "Dawka podstawowa, bolus i korygująca dawka insuliny zostały zwiększone o %@%%."
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal, bolus, and correction insulin dose amounts are increased by %@%%."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "As quantidades basais, de bolus e de dose de insulina de correção aumentam em %@%%."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dozele de insulină bazale, de bolus și de corecție sunt crescute cu %@%%."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "База, болюсы и болюсы на коррекцию увеличены на %@%%."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal, bolus, and correction insulin dose amounts are increased by %@%%."
           }
         },
         "sv" : {
@@ -4224,10 +6133,22 @@
             "value" : "Bazal, bolus ve düzeltme insülin doz miktarları %@%% oranında artırılır."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal, bolus, and correction insulin dose amounts are increased by %@%%."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Liều Basal, bolus, và liều bổ sung đang tăng bằng %@%%."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal, bolus, and correction insulin dose amounts are increased by %@%%."
           }
         },
         "zh-Hans" : {
@@ -4241,6 +6162,12 @@
     "Basal, bolus, and correction insulin dose amounts are unaffected." : {
       "comment" : "Describes a lack of change in overall insulin needs",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal, bolus, and correction insulin dose amounts are unaffected."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4273,7 +6200,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Basal, bolus, and correction insulin dose amounts are unaffected."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Basal, bolus, and correction insulin dose amounts are unaffected."
           }
         },
@@ -4283,13 +6216,7 @@
             "value" : "Le quantità di dosi basali, di bolo e di correzione dell’insulina sono rimaste invariate."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "基礎、ボーラス、補正注入の量は変わりません。"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Insulindoser for basal, bolus og korreksjon er uendret."
@@ -4307,22 +6234,28 @@
             "value" : "Dawka podstawowa, bolus i korygująca dawka insuliny bez zmian."
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal, bolus, and correction insulin dose amounts are unaffected."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "As quantidades basais, de bolus e de dose de insulina de correção não são alteradas."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dozele de insulină bazale, de bolus și de corecție sunt neafectate."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "BБаза, болюсы и болюсы на коррекцию не изменились."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal, bolus, and correction insulin dose amounts are unaffected."
           }
         },
         "sv" : {
@@ -4337,10 +6270,22 @@
             "value" : "Bazal, bolus ve düzeltme insülin doz miktarları etkilenmez."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal, bolus, and correction insulin dose amounts are unaffected."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Liều Basal, bolus, và liều bổ sung không bị thay đổi."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal, bolus, and correction insulin dose amounts are unaffected."
           }
         },
         "zh-Hans" : {
@@ -4358,12 +6303,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "إلغاء"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zrušit"
           }
         },
         "da" : {
@@ -4387,7 +6326,7 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kumoa"
+            "value" : "Peru"
           }
         },
         "fr" : {
@@ -4398,29 +6337,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Cancel"
           }
         },
-        "hi" : {
+        "hu" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "निरस्त"
+            "value" : "Mégse"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Annulla"
+            "value" : "Cancella"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キャンセル"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Avbryt"
@@ -4438,16 +6371,16 @@
             "value" : "Anuluj"
           }
         },
-        "pt-BR" : {
+        "pt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cancelar"
           }
         },
-        "ro" : {
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Renunță"
+            "value" : "Cancelar"
           }
         },
         "ru" : {
@@ -4471,13 +6404,25 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "İptal"
+            "value" : "Vazgeç"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відмінити"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hủy bỏ"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cancel"
           }
         },
         "zh-Hans" : {
@@ -4492,112 +6437,136 @@
       "comment" : "The text for the override cancellation button",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cancel Override"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuller Override"
+            "state" : "new",
+            "value" : "Cancel Override"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Override abbrechen"
+            "state" : "new",
+            "value" : "Cancel Override"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar de Sobreescritura"
+            "state" : "new",
+            "value" : "Cancel Override"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kumoa tilapäisasetus"
+            "state" : "new",
+            "value" : "Cancel Override"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuler l'ajustement"
+            "state" : "new",
+            "value" : "Cancel Override"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Cancel Override"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Cancel Override"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Annulla Override"
+            "value" : "Annulla override"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "オーバーライドをキャンセル"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avbryt overstyring"
+            "state" : "new",
+            "value" : "Cancel Override"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Annuleer Override"
+            "value" : "Annuleer tijdelijk programma"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anuluj Cel Tymczasowy"
+            "state" : "new",
+            "value" : "Cancel Override"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cancel Override"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar Sobreposição"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oprește înlocuirea"
+            "state" : "new",
+            "value" : "Cancel Override"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Отмена ручного контроля"
+            "value" : "Отменить переопределение"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zrušiť profil"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Avbryt Override"
+            "value" : "Avbryt Undantag"
           }
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Cancel Override"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "Geçersiz Kılma İptal"
+            "value" : "Скасувати перевизначення"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hủy Chồng liều"
+            "value" : "Huỷ bỏ ghi đè"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cancel Override"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消覆盖"
+            "state" : "new",
+            "value" : "Cancel Override"
           }
         }
       }
@@ -4605,10 +6574,16 @@
     "Canceling Temp Basal" : {
       "comment" : "Title text for suspend resume button when temp basal canceling",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إلغاء الجرعة الأساسية المؤقتة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Annuller midlertidig basal"
+            "value" : "Afbryder midlertidig basal"
           }
         },
         "de" : {
@@ -4637,23 +6612,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Canceling Temp Basal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Canceling Temp Basal"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Annullamento basale temporanea in corso"
+            "value" : "Annullamento Basale Temp"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時基礎レートをキャンセルします"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Avbryter midlertidig basal"
@@ -4662,7 +6637,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tijdelijk Basaal Annuleren"
+            "value" : "Tijdelijk basaal annuleren"
           }
         },
         "pl" : {
@@ -4671,22 +6646,28 @@
             "value" : "Anulowanie tymczasowej dawki podstawowej"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Canceling Temp Basal"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cancelar Basal Temporária"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oprește bazala temporară"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Отмена врем базала"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ruší sa dočasný bazál"
           }
         },
         "sv" : {
@@ -4701,16 +6682,28 @@
             "value" : "Geçici Bazalı İptal Et"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скасування тимчасового базалу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang hủy liều Basal tạm thời"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Canceling Temp Basal"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消临时基础率"
+            "state" : "new",
+            "value" : "Canceling Temp Basal"
           }
         }
       }
@@ -4727,91 +6720,91 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kulhydratforhold"
+            "value" : "Kolhydratsratio"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "KH-Verhältnis"
+            "value" : "Kohlenhydratfaktoren"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ratios de carbohidratos"
+            "value" : "Ratio de carbohidratos"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hiilihydraattisuhteet"
+            "value" : "Hiilihydraattisuhde"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ratios Insuline-Glucides"
+            "value" : "Ratios de glucides"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Carb Ratios"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Szénhidrát arány"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Rapporti carboidrati"
+            "value" : "Rapporto carboidrati"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Carb Ratios"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Karb forhold"
+            "value" : "Karbohydratforhold"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Koolhydraatratio's"
+            "value" : "Koolhydraten ratio's"
           }
         },
         "pl" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Carb Ratios"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "Współczynniki węglowodanowe"
+            "value" : "Taxas de carbo"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Taxas de Carbs"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Raport carbohidrați/insulină"
+            "value" : "Taxas de carbo"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Соотношения углеводов"
+            "value" : "Углеводные коэффициенты"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Inzulínovo sacharidový pomer"
+            "value" : "Sacharidový pomer"
           }
         },
         "sv" : {
@@ -4826,16 +6819,28 @@
             "value" : "Karbonhidrat Oranları"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вуглеводні Коефіцієнти"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Tỷ lệ Carb"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Carb Ratios"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "碳水化合物吸收率"
+            "value" : "碳水化合物系数"
           }
         }
       }
@@ -4844,6 +6849,12 @@
       "comment" : "Footer text for customizing an override from a preset (1: preset name)",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changes will only apply this time you enable the override. The default settings of %@ will not be affected."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4876,7 +6887,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Changes will only apply this time you enable the override. The default settings of %@ will not be affected."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Changes will only apply this time you enable the override. The default settings of %@ will not be affected."
           }
         },
@@ -4886,13 +6903,7 @@
             "value" : "Le modifiche saranno applicate solo all’attivazione dell'Override. Le impostazioni predefinite di %@ rimarranno invariate."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オーバーライドの有効化は今回のみ適用されます。%@ の初期設定は変わりません。"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Endringer vil kun gjelde for denne gangen du aktiverer overstyring. Standardinstillinger for %@ vil ikke bli påvirket."
@@ -4910,22 +6921,28 @@
             "value" : "Zmiany będą obowiązywać wyłącznie podczas tego Celu Tymczasowego. Domyślne ustawienia %@ nie zostaną zmienione."
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changes will only apply this time you enable the override. The default settings of %@ will not be affected."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "As alterações serão aplicadas apenas desta vez que você ativar a sobreposição. As configurações padrão de %@ não serão afetadas."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modificările se vor aplica doar pe durata înlocuirii. Setările implicite de %@ nu vor fi afectate."
-          }
-        },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Изменения будут действительны только на время ручного контроля."
+            "state" : "new",
+            "value" : "Changes will only apply this time you enable the override. The default settings of %@ will not be affected."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changes will only apply this time you enable the override. The default settings of %@ will not be affected."
           }
         },
         "sv" : {
@@ -4940,10 +6957,22 @@
             "value" : "Değişiklikler yalnızca geçersiz kılmayı etkinleştirdiğiniz bu sefer uygulanacaktır. %@ varsayılan ayarları etkilenmeyecektir."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changes will only apply this time you enable the override. The default settings of %@ will not be affected."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Các thay đổi sẽ chỉ áp dụng thời điểm này khi bạn cho phép chồng liều. Các cài đặt gốc %@ sẽ không bị ảnh hưởng."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changes will only apply this time you enable the override. The default settings of %@ will not be affected."
           }
         },
         "zh-Hans" : {
@@ -4957,6 +6986,12 @@
     "Changes will only apply this time you enable the preset. The default settings of %@ will not be affected." : {
       "comment" : "Footer text for customizing from a preset (1: preset name)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changes will only apply this time you enable the preset. The default settings of %@ will not be affected."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4987,13 +7022,25 @@
             "value" : "Les modifications effectuées que la fois où vous activerez préréglage. Les réglages par défaut de %@ ne seront pas affectés."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changes will only apply this time you enable the preset. The default settings of %@ will not be affected."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changes will only apply this time you enable the preset. The default settings of %@ will not be affected."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Le modifiche saranno applicate solo all'attivazione del Preset. Le impostazioni predefinite di %@ rimarranno invariate."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Endringer vil kun gjelde for denne gangen du aktiverer forhåndsinnstillingen. Standardinnstillingene til %@ vil ikke bli påvirket."
@@ -5011,16 +7058,28 @@
             "value" : "Zmiany zostaną zastosowane tylko wtedy, gdy włączysz ustawienie wstępne. Domyślne ustawienia %@ nie zostaną naruszone."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modificările se vor aplica numai de această dată când activați presetarea. Setările implicite %@ nu vor fi afectate."
+            "state" : "new",
+            "value" : "Changes will only apply this time you enable the preset. The default settings of %@ will not be affected."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changes will only apply this time you enable the preset. The default settings of %@ will not be affected."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Изменения будут применяться только при включении пресета. Настройки по умолчанию %@ не будут затронуты."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changes will only apply this time you enable the preset. The default settings of %@ will not be affected."
           }
         },
         "sv" : {
@@ -5034,6 +7093,30 @@
             "state" : "translated",
             "value" : "Değişiklikler yalnızca ön ayarı bu kez etkinleştirdiğinizde geçerli olacaktır. Varsayılan %@ ayarları etkilenmeyecektir."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changes will only apply this time you enable the preset. The default settings of %@ will not be affected."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changes will only apply this time you enable the preset. The default settings of %@ will not be affected."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changes will only apply this time you enable the preset. The default settings of %@ will not be affected."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changes will only apply this time you enable the preset. The default settings of %@ will not be affected."
+          }
         }
       }
     },
@@ -5041,6 +7124,12 @@
       "comment" : "Carb entry section footer text explaining absorption time",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Choose a longer absorption time for larger meals, or those containing fats and proteins. This is only guidance to the algorithm and need not be exact."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5073,7 +7162,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Choose a longer absorption time for larger meals, or those containing fats and proteins. This is only guidance to the algorithm and need not be exact."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Choose a longer absorption time for larger meals, or those containing fats and proteins. This is only guidance to the algorithm and need not be exact."
           }
         },
@@ -5083,13 +7178,7 @@
             "value" : "Scegli un periodo di assorbimento più lungo per pasti più abbondanti o contenenti grassi e proteine. Queste sono solo indicazioni per l'algoritmo e non devono essere precise."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "量の多い食事や脂質やたんぱく質を含んだ食事には長い吸収時間を選んでください。これはアルゴリズムのための参考で、厳密である必要はありません。"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Velg en lengre absorpsjonstid for større måltider, eller de som inneholder fett og proteiner. Dette er bare veiledning til algoritmen og trenger ikke å være nøyaktig."
@@ -5107,22 +7196,28 @@
             "value" : "Wybierz dłuższy czas absorpcji dla większych, bogatobiałkowych lub wysokotłuszczowych posiłków. To tylko wskazówka dla algorytmu i nie musi być bardzo dokładna."
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Choose a longer absorption time for larger meals, or those containing fats and proteins. This is only guidance to the algorithm and need not be exact."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Escolha um tempo de absorção mais longo para refeições maiores ou aquelas que contenham gorduras e proteínas. Esta é apenas uma orientação para o algoritmo e não precisa ser exata."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alegeți o durată mai lungă de absorbție pentru mese mai mari sau pentru cele care conțin grăsimi și proteine. Nu e necesară o valoare exactă, scopul e să oferim doar o ghidare pentru algoritm."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Выберите более высокую длительность усвоения для обильной пищи или для пищи с белками и протеинами. Это единственное указание для алгоритма не нуждается в дополнительных уточнениях."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Choose a longer absorption time for larger meals, or those containing fats and proteins. This is only guidance to the algorithm and need not be exact."
           }
         },
         "sv" : {
@@ -5137,10 +7232,22 @@
             "value" : "Daha büyük öğünler veya yağ ve protein içeren besinler için daha uzun bir emilim süresi seçin. Bu değer yalnızca algoritmaya rehberlik eder ve kesin olması gerekmez."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Choose a longer absorption time for larger meals, or those containing fats and proteins. This is only guidance to the algorithm and need not be exact."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lựa chọn khoảng thời gian tiêu hóa dài hơn cho các bữa ăn no, hoặc những bữa ăn nhiều chất béo và protein. Đây chỉ là hướng dẫn cho thuật toán Algorithm và không cần phải chính xác."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Choose a longer absorption time for larger meals, or those containing fats and proteins. This is only guidance to the algorithm and need not be exact."
           }
         },
         "zh-Hans" : {
@@ -5154,6 +7261,12 @@
     "Close" : {
       "comment" : "Button text to close a modal\nText to close informational page",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إغلاق"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5184,13 +7297,25 @@
             "value" : "Fermer"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Close"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bezár"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Chiudi"
+            "value" : "Fine"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lukk"
@@ -5208,16 +7333,28 @@
             "value" : "Zamknij"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Închide"
+            "value" : "Fechar"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fechar"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Закрыть"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zatvoriť"
           }
         },
         "sv" : {
@@ -5231,6 +7368,30 @@
             "state" : "translated",
             "value" : "Kapat"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закрити"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đóng"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Close"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭"
+          }
         }
       }
     },
@@ -5238,6 +7399,12 @@
       "comment" : "The format string describing the date of a COB value. The first format argument is the localized date.",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "com.loudnate.CarbKit.COBDateLabel"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5274,19 +7441,19 @@
             "value" : "at %1$@"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "com.loudnate.CarbKit.COBDateLabel"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "a %1$@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ 時点"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "kl. %1$@"
@@ -5304,22 +7471,28 @@
             "value" : "o %1$@"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "com.loudnate.CarbKit.COBDateLabel"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "em %1$@"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "la %1$@"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "В %1$@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "com.loudnate.CarbKit.COBDateLabel"
           }
         },
         "sv" : {
@@ -5334,10 +7507,22 @@
             "value" : "%1$@"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "com.loudnate.CarbKit.COBDateLabel"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "lúc %1$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "com.loudnate.CarbKit.COBDateLabel"
           }
         },
         "zh-Hans" : {
@@ -5352,6 +7537,12 @@
       "comment" : "The format string describing the starting date of a total value. The first format argument is the localized date.",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "com.loudnate.CarbKit.totalDateLabel"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5388,19 +7579,19 @@
             "value" : "since %1$@"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "com.loudnate.CarbKit.totalDateLabel"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "da %1$@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ より"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "siden %1$@"
@@ -5418,22 +7609,28 @@
             "value" : "od %1$@"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "com.loudnate.CarbKit.totalDateLabel"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "desde %1$@"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "de la %1$@"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "после %1$@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "com.loudnate.CarbKit.totalDateLabel"
           }
         },
         "sv" : {
@@ -5448,10 +7645,22 @@
             "value" : "%1$@ den beri"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "com.loudnate.CarbKit.totalDateLabel"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "từ lúc %1$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "com.loudnate.CarbKit.totalDateLabel"
           }
         },
         "zh-Hans" : {
@@ -5466,6 +7675,12 @@
       "comment" : "The format string describing the date of an IOB value. The first format argument is the localized date.",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "at %1$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5504,7 +7719,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "at %1$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "at %1$@"
           }
         },
@@ -5514,13 +7735,7 @@
             "value" : "a %1$@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ 時点"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "kl. %1$@"
@@ -5538,22 +7753,28 @@
             "value" : "o %1$@"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "at %1$@"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "em %1$@"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "la %1$@"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "В %1$@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "at %1$@"
           }
         },
         "sv" : {
@@ -5568,10 +7789,22 @@
             "value" : "%1$@"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "at %1$@"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "lúc %1$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "at %1$@"
           }
         },
         "zh-Hans" : {
@@ -5586,6 +7819,12 @@
       "comment" : "The format string describing the starting date of a total value. The first format argument is the localized date.",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "since %1$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5624,7 +7863,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "since %1$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "since %1$@"
           }
         },
@@ -5634,13 +7879,7 @@
             "value" : "da %1$@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ より"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "siden %1$@"
@@ -5658,22 +7897,28 @@
             "value" : "od %1$@"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "since %1$@"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "desde %1$@"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "de la %1$@"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "после %1$@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "since %1$@"
           }
         },
         "sv" : {
@@ -5688,10 +7933,22 @@
             "value" : "%1$@ den beri"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "since %1$@"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "từ lúc %1$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "since %1$@"
           }
         },
         "zh-Hans" : {
@@ -5709,13 +7966,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "موافق"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+            "value" : "حسناً"
           }
         },
         "da" : {
@@ -5744,7 +7995,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "OK"
           }
         },
@@ -5756,7 +8007,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "OK"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "OK"
           }
         },
@@ -5766,13 +8023,7 @@
             "value" : "OK"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ok"
@@ -5781,31 +8032,31 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ok"
+            "value" : "OK"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "OK"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "OK"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "OK"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "OK"
+            "value" : "ОК"
           }
         },
         "sk" : {
@@ -5826,16 +8077,28 @@
             "value" : "Tamam"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ОК"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "OK"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "OK"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "好的"
+            "value" : "Ok"
           }
         }
       }
@@ -5843,6 +8106,12 @@
     "Completed." : {
       "comment" : "Accessibility label for ProgressIndicatorView when showIndeterminantProgress",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Completed."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5873,13 +8142,25 @@
             "value" : "Terminé."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Completed."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Completed."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Completato."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fullført."
@@ -5897,16 +8178,28 @@
             "value" : "Zakończony."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalizat."
+            "state" : "new",
+            "value" : "Completed."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Completed."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Завершено."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Completed."
           }
         },
         "sv" : {
@@ -5920,12 +8213,42 @@
             "state" : "translated",
             "value" : "Tamamlandı."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Completed."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Completed."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Completed."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Completed."
+          }
         }
       }
     },
     "Condition" : {
       "comment" : "The title for the custom preset emoji condition section",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Condition"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5952,13 +8275,19 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Condition"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Condition"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Condition"
           }
         },
@@ -5968,13 +8297,7 @@
             "value" : "Condizione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "コンディション"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Betingelse"
@@ -5992,22 +8315,28 @@
             "value" : "Warunek"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Condition"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Estado"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Condiție"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Условие"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Condition"
           }
         },
         "sv" : {
@@ -6022,10 +8351,22 @@
             "value" : "Kondisyon"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Condition"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Điều kiện"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Condition"
           }
         },
         "zh-Hans" : {
@@ -6039,6 +8380,12 @@
     "Confirm Setting" : {
       "comment" : "The button text for confirming the setting",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Confirm Setting"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6069,13 +8416,25 @@
             "value" : "Confirmer le réglage"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Confirm Setting"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Confirm Setting"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Conferma impostazione"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bekreft"
@@ -6093,16 +8452,28 @@
             "value" : "Potwierdź ustawienia"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirmați setările"
+            "state" : "new",
+            "value" : "Confirm Setting"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Confirm Setting"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Подтвердить настройки"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Confirm Setting"
           }
         },
         "sv" : {
@@ -6117,6 +8488,24 @@
             "value" : "Ayarı Onaylayın"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Confirm Setting"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Confirm Setting"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Confirm Setting"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6128,10 +8517,10 @@
     "Continue" : {
       "comment" : "Button text to confirm saving from alert popup when some schedule values are outside the recommended range\nButton to advance to setting editor\nText for continue action on confirmation alert\nTitle of the setup button to continue",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pokračovat"
+            "value" : "تابع"
           }
         },
         "da" : {
@@ -6143,7 +8532,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Weiter"
+            "value" : "Fortsetzen"
           }
         },
         "es" : {
@@ -6166,14 +8555,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Continue"
           }
         },
-        "hi" : {
+        "hu" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "जारी"
+            "state" : "new",
+            "value" : "Continue"
           }
         },
         "it" : {
@@ -6182,13 +8571,7 @@
             "value" : "Continua"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "次へ"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fortsett"
@@ -6197,7 +8580,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ga Verder"
+            "value" : "Vervolg"
           }
         },
         "pl" : {
@@ -6206,16 +8589,16 @@
             "value" : "Kontynuuj"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Continue"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Continuar"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuă"
           }
         },
         "ru" : {
@@ -6242,10 +8625,22 @@
             "value" : "Devam et"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продовжити"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tiếp tục"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Continue"
           }
         },
         "zh-Hans" : {
@@ -6259,10 +8654,52 @@
     "Correct the highlighted unsupported value(s)." : {
       "comment" : "Instruction to correct unsupported value",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correct the highlighted unsupported value(s)."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ret de fremhævede ikke-understøttede værdier."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correct the highlighted unsupported value(s)."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correct the highlighted unsupported value(s)."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correct the highlighted unsupported value(s)."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correct the highlighted unsupported value(s)."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correct the highlighted unsupported value(s)."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correct the highlighted unsupported value(s)."
           }
         },
         "it" : {
@@ -6271,10 +8708,16 @@
             "value" : "Correggi i valori non supportati evidenziati."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Korriger de(n) markerte verdien(e) som ikke støttes."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correct the highlighted unsupported value(s)."
           }
         },
         "pl" : {
@@ -6283,10 +8726,64 @@
             "value" : "Popraw podświetlone nieobsługiwane wartości."
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correct the highlighted unsupported value(s)."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correct the highlighted unsupported value(s)."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Исправьте выделенное значение (значения), которое не поддерживается."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correct the highlighted unsupported value(s)."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Korrigera det markerade värdet som inte stöds."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correct the highlighted unsupported value(s)."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correct the highlighted unsupported value(s)."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correct the highlighted unsupported value(s)."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correct the highlighted unsupported value(s)."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correct the highlighted unsupported value(s)."
           }
         }
       }
@@ -6294,6 +8791,12 @@
     "Correction range is the blood glucose range that you would like Loop to correct to." : {
       "comment" : "The section footer of correction range schedule",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction range is the blood glucose range that you would like Loop to correct to."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6326,7 +8829,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Correction range is the blood glucose range that you would like Loop to correct to."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Correction range is the blood glucose range that you would like Loop to correct to."
           }
         },
@@ -6336,13 +8845,7 @@
             "value" : "L'intervallo di correzione è l'intervallo di glicemia in base al quale si desidera che Loop esegua la correzione."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "目標グルコース範囲は、血糖値がこの範囲内に補正されるようループに設定する範囲です。"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Korreksjonsområde er området du ønsker at Loop skal korrigere blodsukker til."
@@ -6360,22 +8863,28 @@
             "value" : "Zakres korekty to zakres stężenia glukozy we krwi, względem którego chcesz skorygować algorytm Loop."
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction range is the blood glucose range that you would like Loop to correct to."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "A faixa de correção é o intervalo de glicose no sangue que você gostaria que o Loop corrigisse para."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Correction range is the blood glucose range that you would like Loop to correct to."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Диапазон коррекции это желательный диапазон значений ГК для обработки алгоритмом петли."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction range is the blood glucose range that you would like Loop to correct to."
           }
         },
         "sv" : {
@@ -6390,10 +8899,22 @@
             "value" : "Düzeltme aralığı, Loop'un düzeltmesini istediğiniz kan şekeri aralığıdır."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction range is the blood glucose range that you would like Loop to correct to."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Phạm vi điều chỉnh là phạm vi của đường huyết mà bạn muốn Loop hướng đến."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction range is the blood glucose range that you would like Loop to correct to."
           }
         },
         "zh-Hans" : {
@@ -6407,6 +8928,12 @@
     "Correction Values" : {
       "comment" : "Title text for multi-value correction value warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Values"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6437,13 +8964,25 @@
             "value" : "Valeurs de correction"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Values"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Values"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Valori di correzione"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Korreksjonsverdier"
@@ -6461,16 +9000,28 @@
             "value" : "Wartości korekty"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valori corecție"
+            "state" : "new",
+            "value" : "Correction Values"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Values"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Значения коррекции"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Values"
           }
         },
         "sv" : {
@@ -6484,12 +9035,42 @@
             "state" : "translated",
             "value" : "Düzeltme Değerleri"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Values"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Values"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Values"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correction Values"
+          }
         }
       }
     },
     "Custom" : {
       "comment" : "The text for a custom preset\nTitle for custom override history cell",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مخصص"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6511,7 +9092,7 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mukautettu"
+            "value" : "Muokattu"
           }
         },
         "fr" : {
@@ -6522,8 +9103,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Custom"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Egyéni"
           }
         },
         "it" : {
@@ -6532,16 +9119,10 @@
             "value" : "Personalizzato"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "カスタム"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilpasset"
+            "value" : "Egendefinert"
           }
         },
         "nl" : {
@@ -6553,25 +9134,31 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cel na teraz"
+            "value" : "Dostosuj"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Definir"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Personalizado"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personalizată"
+            "value" : "Definir"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Настраиваемый"
+            "value" : "Своя"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vlastné"
           }
         },
         "sv" : {
@@ -6586,10 +9173,22 @@
             "value" : "Özel"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Своя"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thói quen"
+            "value" : "Tùy chọn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom"
           }
         },
         "zh-Hans" : {
@@ -6641,7 +9240,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Custom Override"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Custom Override"
           }
         },
@@ -6651,13 +9256,7 @@
             "value" : "Override personalizzato"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "カスタムオーバーライド"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tilpasset overstyring"
@@ -6671,7 +9270,13 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Custom Override"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Custom Override"
           }
         },
@@ -6681,16 +9286,16 @@
             "value" : "Sobreposição Personalizada"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modificare personalizată"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Настраиваемое ручное управление"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom Override"
           }
         },
         "sv" : {
@@ -6705,10 +9310,22 @@
             "value" : "Özel Geçersiz kılma"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom Override"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thói quen Chồng liều"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom Override"
           }
         },
         "zh-Hans" : {
@@ -6722,6 +9339,12 @@
     "Custom Preset" : {
       "comment" : "The title for the custom preset entry screen\nThe title for the custom preset selection screen",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom Preset"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6752,13 +9375,25 @@
             "value" : "Préréglage personnalisé"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom Preset"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom Preset"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Preset personalizzato"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Egendefinert forhåndsinnstilling"
@@ -6776,16 +9411,28 @@
             "value" : "Cel Tymczasowy"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Presetare particularizată"
+            "state" : "new",
+            "value" : "Custom Preset"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom Preset"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пользовательский пресет"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom Preset"
           }
         },
         "sv" : {
@@ -6799,6 +9446,30 @@
             "state" : "translated",
             "value" : "Özel Ön Ayar"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom Preset"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom Preset"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom Preset"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom Preset"
+          }
         }
       }
     },
@@ -6806,6 +9477,12 @@
       "comment" : "Title of the carb entry date picker cell",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التاريخ"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6827,7 +9504,7 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aika"
+            "value" : "Päivä"
           }
         },
         "fr" : {
@@ -6838,8 +9515,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Date"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dátum"
           }
         },
         "it" : {
@@ -6848,13 +9531,7 @@
             "value" : "Data"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日付"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dato"
@@ -6872,13 +9549,13 @@
             "value" : "Data"
           }
         },
-        "pt-BR" : {
+        "pt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Data"
           }
         },
-        "ro" : {
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Data"
@@ -6899,7 +9576,7 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tid"
+            "value" : "Datum"
           }
         },
         "tr" : {
@@ -6908,10 +9585,22 @@
             "value" : "Tarih"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ngày"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Date"
           }
         },
         "zh-Hans" : {
@@ -6925,6 +9614,12 @@
     "Delete" : {
       "comment" : "Delete values for Pre-Meal, inactivates Pre-Meal icon\nTest for table cell delete button\nThe title of the button to remove the credentials for a service",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حذف"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6940,7 +9635,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Eliminar"
+            "value" : "Borrar"
           }
         },
         "fi" : {
@@ -6957,17 +9652,23 @@
         },
         "he" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "מחק"
+            "value" : "Törlés"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Elimina"
+            "value" : "Cancella"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Slett"
@@ -6982,13 +9683,19 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Usunąć"
+            "value" : "Usuń"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Șterge"
+            "value" : "Apagar"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apagar"
           }
         },
         "ru" : {
@@ -6997,16 +9704,46 @@
             "value" : "Удалить"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odstrániť"
+          }
+        },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ta bort"
+            "value" : "Radera"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sil"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Видалити"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除"
           }
         }
       }
@@ -7015,10 +9752,10 @@
       "comment" : "The title of the button to remove the credentials for a service",
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Smazat účet"
+            "state" : "new",
+            "value" : "Delete Account"
           }
         },
         "da" : {
@@ -7057,19 +9794,19 @@
             "value" : "מחק חשבון"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete Account"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Elimina account"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アカウントを削除"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Slett Konto"
@@ -7087,16 +9824,16 @@
             "value" : "Usuń konto"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete Account"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Remover Conta"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Șterge cont"
           }
         },
         "ru" : {
@@ -7123,10 +9860,22 @@
             "value" : "Hesabı sil"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete Account"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Xóa Tài khoản"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete Account"
           }
         },
         "zh-Hans" : {
@@ -7140,6 +9889,12 @@
     "Delete All" : {
       "comment" : "Button title to delete all objects",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete All"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7176,19 +9931,19 @@
             "value" : "מחק הכל"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete All"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Elimina tutto"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "すべて削除"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Slett alle"
@@ -7206,22 +9961,28 @@
             "value" : "Usuń wszystko"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete All"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Remover Todos"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Șterge tot"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Стереть все"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete All"
           }
         },
         "sv" : {
@@ -7236,10 +9997,22 @@
             "value" : "Hepsini sil"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete All"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Xóa hết"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete All"
           }
         },
         "zh-Hans" : {
@@ -7257,12 +10030,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "حدود الضخ"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limity podávání"
           }
         },
         "da" : {
@@ -7297,23 +10064,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Delivery Limits"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Delivery Limits"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Limiti erogazione"
+            "value" : "Limiti Erogazione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "注入限度"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Leveringsgrenser"
@@ -7331,16 +10098,16 @@
             "value" : "Limity podawania"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delivery Limits"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Limites de Entrega"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limite de livrare"
           }
         },
         "ru" : {
@@ -7367,10 +10134,22 @@
             "value" : "İletim Limitleri"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ліміти подачі"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Giới hạn liều tiêm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delivery Limits"
           }
         },
         "zh-Hans" : {
@@ -7384,6 +10163,12 @@
     "Delivery Limits are safety guardrails for your insulin delivery." : {
       "comment" : "Information about delivery limits",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delivery Limits are safety guardrails for your insulin delivery."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7414,13 +10199,25 @@
             "value" : "Les limites d'administration sont des garde-fous de sécurité de l'administration de l’insuline."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delivery Limits are safety guardrails for your insulin delivery."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delivery Limits are safety guardrails for your insulin delivery."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "I limiti d'erogazione sono limiti di sicurezza per l'erogazione d'insulina."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Leveringsgrenser er sikkerhetsrekkverk for insulinleveringen."
@@ -7438,16 +10235,28 @@
             "value" : "Limity podaży są barierami bezpieczeństwa dla podawania insuliny."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limitele de livrare sunt măsuri de siguranță pentru administrarea insulinei."
+            "state" : "new",
+            "value" : "Delivery Limits are safety guardrails for your insulin delivery."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delivery Limits are safety guardrails for your insulin delivery."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пределы подачи - это защита от ввода лишнего инсулина."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delivery Limits are safety guardrails for your insulin delivery."
           }
         },
         "sv" : {
@@ -7461,12 +10270,42 @@
             "state" : "translated",
             "value" : "İletim Limitleri, insülin iletiminiz için güvenlik korkuluklarıdır."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delivery Limits are safety guardrails for your insulin delivery."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delivery Limits are safety guardrails for your insulin delivery."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delivery Limits are safety guardrails for your insulin delivery."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delivery Limits are safety guardrails for your insulin delivery."
+          }
         }
       }
     },
     "Disable Preset" : {
       "comment" : "The text for the custom preset disable button",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disable Preset"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7497,13 +10336,25 @@
             "value" : "Désactiver le préréglage"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disable Preset"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disable Preset"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Disattiva Preset"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Deaktiver forhåndsinnstilling"
@@ -7521,16 +10372,28 @@
             "value" : "Wyłącz ustawienie wstępne"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dezactivează presetarea"
+            "state" : "new",
+            "value" : "Disable Preset"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disable Preset"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Выключить пресет"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disable Preset"
           }
         },
         "sv" : {
@@ -7544,22 +10407,46 @@
             "state" : "translated",
             "value" : "Ön Ayarı Devre Dışı Bırak"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disable Preset"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disable Preset"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disable Preset"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disable Preset"
+          }
         }
       }
     },
     "Done" : {
       "comment" : "Text for dismiss button\nText for done button\nVideo player done button label",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hotovo"
+            "value" : "تمّ"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Udført"
+            "value" : "OK"
           }
         },
         "de" : {
@@ -7571,7 +10458,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Completado"
+            "value" : "Hecho"
           }
         },
         "fi" : {
@@ -7586,13 +10473,25 @@
             "value" : "Terminé"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Done"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kész"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fine"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ferdig"
@@ -7601,19 +10500,25 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gereed"
+            "value" : "OK"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gotowe"
+            "state" : "new",
+            "value" : "Done"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Realizat"
+            "value" : "OK"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
         "ru" : {
@@ -7631,13 +10536,37 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Färdig"
+            "value" : "Klar"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tamamlandı"
+            "value" : "Tamam"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Готово"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xong"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Done"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成"
           }
         }
       }
@@ -7645,6 +10574,12 @@
     "Duration" : {
       "comment" : "The text for the custom preset duration setting\nThe text for the override duration setting",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "المدة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7677,8 +10612,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Duration"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Időtartam"
           }
         },
         "it" : {
@@ -7687,13 +10628,7 @@
             "value" : "Durata"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "期間"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Varighet"
@@ -7711,22 +10646,28 @@
             "value" : "Czas trwania"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duração"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Duração"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Durată"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Продолжительность"
+            "value" : "Длительность"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trvanie"
           }
         },
         "sv" : {
@@ -7741,10 +10682,22 @@
             "value" : "Süre"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тривалість"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Khoảng thời gian"
+            "value" : "Duration"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Duration"
           }
         },
         "zh-Hans" : {
@@ -7758,6 +10711,12 @@
     "Edit" : {
       "comment" : "Text for edit button\nThe title for the enabled custom preset editing screen",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7788,13 +10747,25 @@
             "value" : "Éditer"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Modifica"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rediger"
@@ -7812,16 +10783,28 @@
             "value" : "Edytuj"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Editare"
+            "state" : "new",
+            "value" : "Edit"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Редактировать"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit"
           }
         },
         "sv" : {
@@ -7835,6 +10818,30 @@
             "state" : "translated",
             "value" : "Düzenle"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit"
+          }
         }
       }
     },
@@ -7842,6 +10849,12 @@
       "comment" : "The title of the view controller to edit an existing carb entry",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit Carb Entry"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7874,7 +10887,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Edit Carb Entry"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Edit Carb Entry"
           }
         },
@@ -7884,13 +10903,7 @@
             "value" : "Modifica inserimento carboidrati"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "糖質の記入を編集"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rediger karbohydrater"
@@ -7908,22 +10921,28 @@
             "value" : "Edytuj wprowadzone węglowodany"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit Carb Entry"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Editar Carb"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Editează carbohidrați"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Редактировать запись углеводов"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit Carb Entry"
           }
         },
         "sv" : {
@@ -7938,10 +10957,22 @@
             "value" : "Karb Girişini Düzenle"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit Carb Entry"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chỉnh sửa Carb"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit Carb Entry"
           }
         },
         "zh-Hans" : {
@@ -7956,6 +10987,12 @@
       "comment" : "The title for the override editing screen",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit Override"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7988,7 +11025,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Edit Override"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Edit Override"
           }
         },
@@ -7998,13 +11041,7 @@
             "value" : "Modifica Override"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オーバーライドを編集"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rediger overstyring"
@@ -8022,22 +11059,28 @@
             "value" : "Edytuj Cel Tymczasowy"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit Override"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Editar Sobreposição"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Editează înlocuirea"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Редактировать ручной контроль"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit Override"
           }
         },
         "sv" : {
@@ -8052,10 +11095,22 @@
             "value" : "Geçersiz Kılmayı Düzenle"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit Override"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hiệu chỉnh chồng liều"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit Override"
           }
         },
         "zh-Hans" : {
@@ -8070,6 +11125,12 @@
       "comment" : "Footer text for editing an active override (1: preset name)",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Editing affects only the active override. The default settings of %@ will not be affected."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8102,7 +11163,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Editing affects only the active override. The default settings of %@ will not be affected."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Editing affects only the active override. The default settings of %@ will not be affected."
           }
         },
@@ -8112,13 +11179,7 @@
             "value" : "La modifica riguarda solo l'Override attivo. Le impostazioni predefinite di %@ resteranno invariate."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オーバーライドの編集は今回のみ適用されます。%@ の初期設定は変わりません。"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Redigering påvirker kun den aktive overstyringen. Standardinnstillingen %@ vil ikke bbli påvirket."
@@ -8136,22 +11197,28 @@
             "value" : " Edycja wpływa wyłącznie na aktywne pominięcie. Domyślne ustawienia %@ nie zostaną zmienione."
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Editing affects only the active override. The default settings of %@ will not be affected."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "A edição afeta apenas a sobreposição ativa. As configurações padrão de %@ não serão afetadas."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Editarea afectează doar înlocuirea activă. Setările implicite de %@ nu vor fi afectate."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Изменения затронут только активную версию. Значения по умолчанию %@ не изменятся."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Editing affects only the active override. The default settings of %@ will not be affected."
           }
         },
         "sv" : {
@@ -8166,10 +11233,22 @@
             "value" : "Düzenleme yalnızca etkin geçersiz kılmayı etkiler. %@ varsayılan ayarlar etkilenmeyecektir."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Editing affects only the active override. The default settings of %@ will not be affected."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Việc hiệu chỉnh chỉ ảnh hưởng đến chồng liều đang hoạt động. Các cài đặt gốc của %@ sẽ không bị ảnh hưởng."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Editing affects only the active override. The default settings of %@ will not be affected."
           }
         },
         "zh-Hans" : {
@@ -8183,6 +11262,12 @@
     "Edits persist only until the preset is disabled. The default settings of %@ will not be affected." : {
       "comment" : "Footer text for editing an enabled custom preset (1: preset name)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edits persist only until the preset is disabled. The default settings of %@ will not be affected."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8213,13 +11298,25 @@
             "value" : "Les modifications ne persistent que jusqu'à ce que le préréglage soit désactivé. Les réglages par défaut de %@ ne seront pas affectés."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edits persist only until the preset is disabled. The default settings of %@ will not be affected."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edits persist only until the preset is disabled. The default settings of %@ will not be affected."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Le modifiche persistono solo finché il Preset non viene disattivato. Le impostazioni predefinite di %@ non vengono modificate."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Endringer gjelder kun til forhåndsinnstillingen er deaktivert. Standardinnstillingene til %@ vil ikke bli påvirket."
@@ -8237,16 +11334,28 @@
             "value" : "Zmiany są zachowywane tylko do momentu wyłączenia ustawienia wstępnego. Domyślne ustawienia %@ nie zostaną naruszone."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modificările persistă numai până când presetarea este dezactivată. Setările implicite %@ nu vor fi afectate."
+            "state" : "new",
+            "value" : "Edits persist only until the preset is disabled. The default settings of %@ will not be affected."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edits persist only until the preset is disabled. The default settings of %@ will not be affected."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Изменения сохраняются только до отключения пресета. Настройки по умолчанию %@ не будут затронуты."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edits persist only until the preset is disabled. The default settings of %@ will not be affected."
           }
         },
         "sv" : {
@@ -8260,34 +11369,64 @@
             "state" : "translated",
             "value" : "Düzenlemeler yalnızca ön ayar devre dışı bırakılana kadar devam eder. %@ varsayılan ayarları etkilenmeyecektir."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edits persist only until the preset is disabled. The default settings of %@ will not be affected."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edits persist only until the preset is disabled. The default settings of %@ will not be affected."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edits persist only until the preset is disabled. The default settings of %@ will not be affected."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edits persist only until the preset is disabled. The default settings of %@ will not be affected."
+          }
         }
       }
     },
     "Enable" : {
       "comment" : "The button text for enabling a temporary override",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aktiver"
+            "value" : "Aktivér"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aktivieren"
+            "value" : "Einschalten"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Activar"
+            "value" : "Habilitar"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ota käyttöön"
+            "state" : "new",
+            "value" : "Enable"
           }
         },
         "fr" : {
@@ -8296,13 +11435,25 @@
             "value" : "Activer"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Attiva"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aktiver"
@@ -8311,25 +11462,37 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Inschakelen"
+            "value" : "Activeer"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Włącz"
+            "state" : "new",
+            "value" : "Enable"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activează"
+            "state" : "new",
+            "value" : "Enable"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Включить"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Povoliť"
           }
         },
         "sv" : {
@@ -8340,8 +11503,32 @@
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "Etkinleştir"
+            "value" : "Увімкнути"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cho phép"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable"
           }
         }
       }
@@ -8349,6 +11536,12 @@
     "Enable Indefinitely" : {
       "comment" : "The text for the indefinite custom preset duration setting",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable Indefinitely"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8381,7 +11574,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Enable Indefinitely"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Enable Indefinitely"
           }
         },
@@ -8391,13 +11590,7 @@
             "value" : "Attiva a tempo indeterminato"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無期限を有効にする"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aktiver på ubestemt tid"
@@ -8415,22 +11608,28 @@
             "value" : "Włącz na czas nieokreślony"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable Indefinitely"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ativar Indefinidamente"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activează pe termen nedeterminat"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Активировать на неопределенное время"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable Indefinitely"
           }
         },
         "sv" : {
@@ -8445,10 +11644,22 @@
             "value" : "Süresiz Olarak Etkinleştir"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable Indefinitely"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cấp phép không giới hạn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable Indefinitely"
           }
         },
         "zh-Hans" : {
@@ -8462,6 +11673,12 @@
     "Enabled" : {
       "comment" : "The detail text describing an enabled setting",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enabled"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8489,28 +11706,28 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Activé"
+            "value" : "Activée"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Enabled"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Enabled"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Attivato"
+            "value" : "Abilitato"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有効"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aktivert"
@@ -8528,22 +11745,28 @@
             "value" : "Włączony"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enabled"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ativado"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activat"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Активировано"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zapnuté"
           }
         },
         "sv" : {
@@ -8558,10 +11781,22 @@
             "value" : "Etkin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Активовано"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Được cấp quyền"
+            "value" : "Cho phép"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enabled"
           }
         },
         "zh-Hans" : {
@@ -8575,6 +11810,12 @@
     "End Time" : {
       "comment" : "The text for the override start time",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "End Time"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8605,13 +11846,25 @@
             "value" : "Heure de fin"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "End Time"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "End Time"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Orario di fine"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluttid"
@@ -8629,16 +11882,28 @@
             "value" : "Koniec czasu"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timp de încheiere"
+            "state" : "new",
+            "value" : "End Time"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "End Time"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Время окончания"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "End Time"
           }
         },
         "sv" : {
@@ -8652,12 +11917,42 @@
             "state" : "translated",
             "value" : "Bitiş zamanı"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "End Time"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "End Time"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "End Time"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "End Time"
+          }
         }
       }
     },
     "Enter %1$@ value" : {
       "comment" : "Format string for accessibility label for value entry. (1: value label)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter %1$@ value"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8688,13 +11983,25 @@
             "value" : "Entrez la valeur %1$@"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter %1$@ value"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter %1$@ value"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Inserisci il valore %1$@"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Skriv inn %1$@ verdi"
@@ -8712,16 +12019,28 @@
             "value" : "Wprowadź wartość %1$@"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Introduceți valoarea %1$@"
+            "state" : "new",
+            "value" : "Enter %1$@ value"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter %1$@ value"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Введите %1$@ значение"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter %1$@ value"
           }
         },
         "sv" : {
@@ -8735,6 +12054,30 @@
             "state" : "translated",
             "value" : "%1$@ değer girin"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter %1$@ value"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter %1$@ value"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter %1$@ value"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter %1$@ value"
+          }
         }
       }
     },
@@ -8742,6 +12085,12 @@
       "comment" : "The placeholder text instructing users how to enter a maximum bolus",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter a number of units"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8774,7 +12123,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Enter a number of units"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Enter a number of units"
           }
         },
@@ -8784,13 +12139,7 @@
             "value" : "Inserisci un numero di unità"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "単位数を入力"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Skriv inn antall enheter"
@@ -8808,22 +12157,28 @@
             "value" : "Wprowadź liczbę jednostek"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter a number of units"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Digite um número de unidades"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Introduceți un număr de unități"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Введите кол-во единиц"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter a number of units"
           }
         },
         "sv" : {
@@ -8838,10 +12193,22 @@
             "value" : "Ünite değeri girin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter a number of units"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nhập số lượng của đơn vị/units"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter a number of units"
           }
         },
         "zh-Hans" : {
@@ -8856,6 +12223,12 @@
       "comment" : "The placeholder text instructing users how to enter a maximum basal rate",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter a rate in units per hour"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8888,7 +12261,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Enter a rate in units per hour"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Enter a rate in units per hour"
           }
         },
@@ -8898,13 +12277,7 @@
             "value" : "Inserisci velocità U/ora"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "毎時単位(U/h)を入力"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Velg en grense for maks enheter pr. time"
@@ -8922,22 +12295,28 @@
             "value" : "Maksymalna dawka w jednostkach na godzinę"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter a rate in units per hour"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Insira uma taxa em unidades por hora"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Introduceți o rată exprimată în unități per oră"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Введите скорость в ед/час"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter a rate in units per hour"
           }
         },
         "sv" : {
@@ -8952,10 +12331,22 @@
             "value" : "Her saat için ünite oranı girin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter a rate in units per hour"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nhập tỉ lệ của đơn vị/units trên giờ"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter a rate in units per hour"
           }
         },
         "zh-Hans" : {
@@ -8969,6 +12360,12 @@
     "Event History" : {
       "comment" : "Segmented button title for insulin delivery log event history",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سجل الأحداث"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9001,23 +12398,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Event History"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Event History"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cronologia degli eventi"
+            "value" : "Storico degli eventi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Event History"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hendelseshistorie"
@@ -9035,22 +12432,28 @@
             "value" : "Historia zdarzeń"
           }
         },
-        "pt-BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Event History"
           }
         },
-        "ro" : {
+        "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Istoric evenimente"
+            "state" : "new",
+            "value" : "Event History"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "История событий"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "História Udalostí"
           }
         },
         "sv" : {
@@ -9065,9 +12468,21 @@
             "value" : "Etkinlik Geçmişi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Журнал подій"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Lược sử tác vụ trước đó"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Event History"
           }
         },
@@ -9082,6 +12497,12 @@
     "Fast" : {
       "comment" : "Section title for fast absorbing food",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fast"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9114,7 +12535,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Fast"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Fast"
           }
         },
@@ -9124,13 +12551,7 @@
             "value" : "Veloce"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "速め"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rask"
@@ -9148,22 +12569,28 @@
             "value" : "Szybko"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fast"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rápida"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rapidă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Быстрая"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fast"
           }
         },
         "sv" : {
@@ -9178,10 +12605,22 @@
             "value" : "Hızlı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fast"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nhanh"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fast"
           }
         },
         "zh-Hans" : {
@@ -9197,89 +12636,95 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Fiasp"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fiasp"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Fiasp"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fiasp"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
         "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fiasp"
+          }
+        },
+        "sk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fiasp"
@@ -9293,7 +12738,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Fiasp"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Fiasp"
           }
         },
@@ -9303,9 +12754,15 @@
             "value" : "Fiasp"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fiasp"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fiasp"
           }
         }
@@ -9313,6 +12770,12 @@
     },
     "Food Type" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Food Type"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9325,10 +12788,34 @@
             "value" : "Essenstyp"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Food Type"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Food Type"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Type d'aliment"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Food Type"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Food Type"
           }
         },
         "it" : {
@@ -9337,10 +12824,16 @@
             "value" : "Tipo cibo"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Type mat"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Food Type"
           }
         },
         "pl" : {
@@ -9349,10 +12842,58 @@
             "value" : "Rodzaj żywności"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Food Type"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Food Type"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Тип еды"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Food Type"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Typ av mat"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Food Type"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Food Type"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Food Type"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Food Type"
           }
         },
         "zh-Hans" : {
@@ -9366,6 +12907,12 @@
     "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from %2$@ different models for how the app measures the insulin’s peak activity." : {
       "comment" : "Insulin model setting description (1: app name) (2: number of models)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from %2$@ different models for how the app measures the insulin’s peak activity."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9392,8 +12939,20 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pour l'insuline à action rapide, %1$@ suppose qu'elle agit activement pendant 6 heures. Vous pouvez choisir parmi différents modèles pour le pic d'activité mesuré par l'application."
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from %2$@ different models for how the app measures the insulin’s peak activity."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from %2$@ different models for how the app measures the insulin’s peak activity."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from %2$@ different models for how the app measures the insulin’s peak activity."
           }
         },
         "it" : {
@@ -9402,7 +12961,7 @@
             "value" : "Per l'insulina ad azione rapida, %1$@ presuppone che funzioni attivamente per 6 ore. Puoi scegliere tra %2$@ diversi modelli per il modo in cui l'app misura il picco di attività dell'insulina."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "For hurtigvirkende insulin antar %1$@ at det virker aktivt i 6 timer. Du kan velge mellom %2$@ forskjellige modeller for hvordan appen måler insulinets toppaktivitet."
@@ -9420,16 +12979,28 @@
             "value" : "W przypadku szybko działającej insuliny %1$@ zakłada, że działa aktywnie przez 6 godzin. Możesz wybierać spośród %2$@ różnych modeli pomiaru szczytowej aktywności insuliny przez aplikację."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pentru insulina cu acțiune rapida, %1$@ presupune că acționează timp de 6 ore. Puteți alege din %2$@ modele diferite pentru modul în care aplicația determina vârful de acțiune al insulinei."
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from %2$@ different models for how the app measures the insulin’s peak activity."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from %2$@ different models for how the app measures the insulin’s peak activity."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Для быстродействующего инсулина %1$@ предполагается, что он активно работает в течение 6 часов. Вы можете выбрать из %2$@ различных моделей того, как приложение измеряет пиковую активность инсулина."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from %2$@ different models for how the app measures the insulin’s peak activity."
           }
         },
         "sv" : {
@@ -9443,12 +13014,42 @@
             "state" : "translated",
             "value" : "Hızlı etkili insülin için, %1$@ 6 saat boyunca aktif olarak çalıştığını varsayar. Uygulamanın insülinin en yüksek etkisini nasıl ölçtüğüne ilişkin %2$@ farklı model arasından seçim yapabilirsiniz."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from %2$@ different models for how the app measures the insulin’s peak activity."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from %2$@ different models for how the app measures the insulin’s peak activity."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from %2$@ different models for how the app measures the insulin’s peak activity."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For fast acting insulin, %1$@ assumes it is actively working for 6 hours. You can choose from %2$@ different models for how the app measures the insulin’s peak activity."
+          }
         }
       }
     },
     "For this range, choose the specific glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin." : {
       "comment" : "Information about correction range format (1: app name)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For this range, choose the specific glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9479,13 +13080,25 @@
             "value" : "Pour cette plage, choisissez la valeur de glycémie (ou la plage de valeurs) spécifique que %1$@ va viser en ajustant votre insuline basale."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For this range, choose the specific glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For this range, choose the specific glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Per questo intervallo, scegli il valore glicemico specifico (o l'intervallo di valori) a cui vuoi che %1$@ miri per regolare la tua insulina basale."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "For dette området, velg den spesifikke sikkerhets grenseverdien (eller verdiområdet) som du vil at %1$@ skal sikte på for å justere basalinsulinet."
@@ -9503,16 +13116,28 @@
             "value" : "Dla tego zakresu wybierz konkretną wartość glukozy (lub zakres wartości), do której chce dążyć %1$@ podczas dostosowywania insuliny bazowej."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pentru acest interval, alegeți valoarea specifică a glicemiei (sau intervalul de valori) spre care doriți ca %1$@ să țintească în ajustarea insulinei bazale."
+            "state" : "new",
+            "value" : "For this range, choose the specific glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For this range, choose the specific glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Для этого диапазона выберите конкретное значение глюкозы (или диапазон значений), к которому вы хотите стремиться %1$@ при корректировке с помощью ВБС."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For this range, choose the specific glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin."
           }
         },
         "sv" : {
@@ -9527,6 +13152,24 @@
             "value" : "Bu aralık için, %1$@ bazal insülininizi ayarlarken hedeflemesini istediğiniz belirli KŞ değerini (veya değer aralığını) seçin."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For this range, choose the specific glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For this range, choose the specific glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "For this range, choose the specific glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9538,6 +13181,12 @@
     "Get help with Therapy Settings" : {
       "comment" : "Support button for Therapy Settings",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Get help with Therapy Settings"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9568,13 +13217,25 @@
             "value" : "Obtenir de l'aide avec les paramètres de thérapie"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Get help with Therapy Settings"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Get help with Therapy Settings"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ottieni assistenza per le impostazioni terapia"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Få hjelp med behandlingsinnstillinger"
@@ -9592,16 +13253,28 @@
             "value" : "Uzyskaj pomoc dotyczącą ustawień terapii"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obțineți ajutor cu Setările Terapiei"
+            "state" : "new",
+            "value" : "Get help with Therapy Settings"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Get help with Therapy Settings"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Получить помощь в настройках терапии"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Get help with Therapy Settings"
           }
         },
         "sv" : {
@@ -9615,12 +13288,42 @@
             "state" : "translated",
             "value" : "Tedavi Ayarları ile ilgili yardım alın"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Get help with Therapy Settings"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Get help with Therapy Settings"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Get help with Therapy Settings"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Get help with Therapy Settings"
+          }
         }
       }
     },
     "Go Back" : {
       "comment" : "Button text to return to editing a schedule after from alert popup when some schedule values are outside the recommended range\nText for go back action on confirmation alert",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Go Back"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9651,13 +13354,25 @@
             "value" : "Retour"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Go Back"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Go Back"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Torna indietro"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gå tilbake"
@@ -9675,16 +13390,28 @@
             "value" : "Wróć"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inapoi"
+            "state" : "new",
+            "value" : "Go Back"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Go Back"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вернуться назад"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Go Back"
           }
         },
         "sv" : {
@@ -9699,6 +13426,24 @@
             "value" : "Geri dön"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Go Back"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Go Back"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Go Back"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9710,6 +13455,12 @@
     "High Basal Rate" : {
       "comment" : "Title text for the high basal rate warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Basal Rate"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9740,13 +13491,25 @@
             "value" : "Débit basal élevé"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Basal Rate"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Basal Rate"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Velocità basale alta"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Høy basaldose"
@@ -9764,16 +13527,28 @@
             "value" : "Wysoka dawka podstawowa"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rată bazală ridicată"
+            "state" : "new",
+            "value" : "High Basal Rate"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Basal Rate"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Слишком большая база"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Basal Rate"
           }
         },
         "sv" : {
@@ -9787,12 +13562,42 @@
             "state" : "translated",
             "value" : "Yüksek Bazal Oran"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Basal Rate"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Basal Rate"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Basal Rate"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Basal Rate"
+          }
         }
       }
     },
     "High Carb Ratio" : {
       "comment" : "Title text for the high carb ratio warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Carb Ratio"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9823,13 +13628,25 @@
             "value" : "Ratio de glucide élevé"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Carb Ratio"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Carb Ratio"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rapporto carboidrati alto"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Høyt karbohydratforhold"
@@ -9847,16 +13664,28 @@
             "value" : "Wysoki współczynnik węglowodanowy"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Raport carbohidrați/insulina ridicat"
+            "state" : "new",
+            "value" : "High Carb Ratio"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Carb Ratio"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Слишком высокое соотношение углеводов"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Carb Ratio"
           }
         },
         "sv" : {
@@ -9870,12 +13699,42 @@
             "state" : "translated",
             "value" : "Yüksek Karb Oranı"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Carb Ratio"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Carb Ratio"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Carb Ratio"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Carb Ratio"
+          }
         }
       }
     },
     "High Correction Value" : {
       "comment" : "Title text for the high correction value warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Correction Value"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9906,13 +13765,25 @@
             "value" : "Valeur de correction élevée"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Correction Value"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Correction Value"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Valore di correzione alto"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Høy korreksjonsverdi"
@@ -9930,16 +13801,28 @@
             "value" : "Wysoka wartość korekty"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valoare de corecție ridicată"
+            "state" : "new",
+            "value" : "High Correction Value"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Correction Value"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Слишком высокая настройка диапазона коррекции"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Correction Value"
           }
         },
         "sv" : {
@@ -9953,12 +13836,42 @@
             "state" : "translated",
             "value" : "Yüksek Düzeltme Değeri"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Correction Value"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Correction Value"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Correction Value"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Correction Value"
+          }
         }
       }
     },
     "High Glucose Safety Limit" : {
       "comment" : "Title text for the high glucose safety limit warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Glucose Safety Limit"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9995,13 +13908,19 @@
             "value" : "ערך הבטיחות גבוה"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Glucose Safety Limit"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Limite glicemico di sicurezza alto"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sikkerhetsgrense for høyt blodsukker"
@@ -10019,16 +13938,28 @@
             "value" : "Limit bezpieczeństwa wysokiego stężenia glukozy"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limita superioara de siguranță a glicemiei"
+            "state" : "new",
+            "value" : "High Glucose Safety Limit"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Glucose Safety Limit"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Слишком высокий порог безопасности ГК"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Glucose Safety Limit"
           }
         },
         "sv" : {
@@ -10043,6 +13974,24 @@
             "value" : "Yüksek KŞ Güvenlik Limiti"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Glucose Safety Limit"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Glucose Safety Limit"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Glucose Safety Limit"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10054,6 +14003,12 @@
     "High Insulin Sensitivity" : {
       "comment" : "Title text for the high insulin sensitivity warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Insulin Sensitivity"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10084,13 +14039,25 @@
             "value" : "Sensibilité à l'insuline élevée"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Insulin Sensitivity"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Insulin Sensitivity"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sensibilità insulinica alta"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Høy insulinfølsomhet"
@@ -10108,16 +14075,28 @@
             "value" : "Wysoki Współczynnik Wrażliwości"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Factor de sensibilitate la insulină ridicat"
+            "state" : "new",
+            "value" : "High Insulin Sensitivity"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Insulin Sensitivity"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Слишком высокая чувствительность к инсулину"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Insulin Sensitivity"
           }
         },
         "sv" : {
@@ -10131,12 +14110,42 @@
             "state" : "translated",
             "value" : "Yüksek İnsülin Duyarlılığı"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Insulin Sensitivity"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Insulin Sensitivity"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Insulin Sensitivity"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Insulin Sensitivity"
+          }
         }
       }
     },
     "High Maximum Basal Rate" : {
       "comment" : "Title text for high maximum basal rate warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Maximum Basal Rate"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10167,13 +14176,25 @@
             "value" : "Débit basal maximum élevé"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Maximum Basal Rate"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Maximum Basal Rate"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Velocità basale massima alta"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Høy maksimal basaldose"
@@ -10191,16 +14212,28 @@
             "value" : "Wysoka maksymalna dawka podstawowa"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rată bazală maximă ridicata"
+            "state" : "new",
+            "value" : "High Maximum Basal Rate"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Maximum Basal Rate"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Слишком большая максимальная база"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Maximum Basal Rate"
           }
         },
         "sv" : {
@@ -10214,12 +14247,42 @@
             "state" : "translated",
             "value" : "Yüksek Maksimum Bazal Oranı"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Maximum Basal Rate"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Maximum Basal Rate"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Maximum Basal Rate"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Maximum Basal Rate"
+          }
         }
       }
     },
     "High Maximum Bolus" : {
       "comment" : "Title text for high maximum bolus warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Maximum Bolus"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10250,13 +14313,25 @@
             "value" : "Bolus maximum élevé"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Maximum Bolus"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Maximum Bolus"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bolo massimo alto"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Høy maksimal bolus"
@@ -10274,16 +14349,28 @@
             "value" : "Wysoki maksymalny bolus"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bolus maxim ridicat"
+            "state" : "new",
+            "value" : "High Maximum Bolus"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Maximum Bolus"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Слишком большой максимальный болюс"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Maximum Bolus"
           }
         },
         "sv" : {
@@ -10298,6 +14385,24 @@
             "value" : "Yüksek Maksimum Bolus"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Maximum Bolus"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Maximum Bolus"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Maximum Bolus"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10309,6 +14414,12 @@
     "High Pre-Meal Value" : {
       "comment" : "Title text for the low pre-meal value warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Pre-Meal Value"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10339,13 +14450,25 @@
             "value" : "Valeur pré-repas élevée"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Pre-Meal Value"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Pre-Meal Value"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Valore pre-pasto alto"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Høy verdi før måltid"
@@ -10363,16 +14486,28 @@
             "value" : "Wysoka wartość przed posiłkiem"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valoare mare preprandiala"
+            "state" : "new",
+            "value" : "High Pre-Meal Value"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Pre-Meal Value"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Слишком высокая настройка до еды"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Pre-Meal Value"
           }
         },
         "sv" : {
@@ -10386,12 +14521,42 @@
             "state" : "translated",
             "value" : "Yüksek Yemek Öncesi Değeri"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Pre-Meal Value"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Pre-Meal Value"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Pre-Meal Value"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Pre-Meal Value"
+          }
         }
       }
     },
     "High Workout Value" : {
       "comment" : "Title text for the high workout value warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Workout Value"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10422,13 +14587,25 @@
             "value" : "Valeur d'exercice haute"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Workout Value"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Workout Value"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Valore allenamento alto"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Høy treningsverdi"
@@ -10446,16 +14623,28 @@
             "value" : "Wysoka wartość treningu"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valoare mare antrenament"
+            "state" : "new",
+            "value" : "High Workout Value"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Workout Value"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Слишком высокая настройка для физнагрузки"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Workout Value"
           }
         },
         "sv" : {
@@ -10469,22 +14658,52 @@
             "state" : "translated",
             "value" : "Yüksek Egzersiz Değeri"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Workout Value"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Workout Value"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Workout Value"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "High Workout Value"
+          }
         }
       }
     },
     "History" : {
       "comment" : "The text for the override history",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "السّجل"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Historik"
+            "value" : "Historie"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Historie"
+            "value" : "Verlauf"
           }
         },
         "es" : {
@@ -10495,8 +14714,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Historia"
+            "state" : "new",
+            "value" : "History"
           }
         },
         "fr" : {
@@ -10505,16 +14724,28 @@
             "value" : "Historique"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elözmény"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cronologia"
+            "value" : "Storia"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Historie"
+            "value" : "Historikk"
           }
         },
         "nl" : {
@@ -10525,20 +14756,32 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Historia"
+            "state" : "new",
+            "value" : "History"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Istoric"
+            "value" : "Histórico"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Histórico"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "История"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "História"
           }
         },
         "sv" : {
@@ -10553,6 +14796,24 @@
             "value" : "Geçmiş"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Історія"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lịch sử"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10564,6 +14825,12 @@
     "If these settings look good to you, tap Save Settings to continue." : {
       "comment" : "Description of how to interact with summary screen",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If these settings look good to you, tap Save Settings to continue."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10594,13 +14861,25 @@
             "value" : "Si ces paramètres vous semblent bons, appuyez sur Enregistrer les paramètres pour continuer."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If these settings look good to you, tap Save Settings to continue."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If these settings look good to you, tap Save Settings to continue."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Se queste impostazioni ti sembrano soddisfacenti, tocca \"Salva impostazioni\" per continuare."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hvis disse innstillingene ser bra ut, trykk på Lagre innstillingene for å fortsette."
@@ -10618,16 +14897,28 @@
             "value" : "Jeśli te ustawienia Ci odpowiadają, stuknij Zapisz ustawienia, aby kontynuować."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dacă aceste setări arată bine pentru tine, apasă pe Salvează Setări pentru a continua."
+            "state" : "new",
+            "value" : "If these settings look good to you, tap Save Settings to continue."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If these settings look good to you, tap Save Settings to continue."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Если эти настройки вас устраивают, нажмите Сохранить настройки, чтобы продолжить."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If these settings look good to you, tap Save Settings to continue."
           }
         },
         "sv" : {
@@ -10641,12 +14932,42 @@
             "state" : "translated",
             "value" : "Bu ayarlar size uygun görünüyorsa, devam etmek için Ayarları Kaydet'e dokunun."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If these settings look good to you, tap Save Settings to continue."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If these settings look good to you, tap Save Settings to continue."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If these settings look good to you, tap Save Settings to continue."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If these settings look good to you, tap Save Settings to continue."
+          }
         }
       }
     },
     "If you've used a CGM before, you're likely familiar with target range as a wide range of values you'd like for your glucose notification alerts, such as 70-180 mg/dL or 90-200 mg/dL." : {
       "comment" : "Information about target range",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If you've used a CGM before, you're likely familiar with target range as a wide range of values you'd like for your glucose notification alerts, such as 70-180 mg/dL or 90-200 mg/dL."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10683,13 +15004,19 @@
             "value" : "אם השתמשת בחיישן (מד סוכר רציף), אתה בטח מכיר טווח יעד עם רצועה רחבה שמשמשת אותך להתראות, כמו 70-180mg/dL או 90-200mg/dL."
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If you've used a CGM before, you're likely familiar with target range as a wide range of values you'd like for your glucose notification alerts, such as 70-180 mg/dL or 90-200 mg/dL."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Se hai già utilizzato un CGM, probabilmente conosci l'intervallo target come un'ampia gamma di valori che desideri per gli avvisi di notifica della glicemia, ad esempio 70-180 mg/dL o 90-200 mg/dL."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hvis du har brukt en CGM før, er du sannsynligvis kjent med målområdet som et bredt spekter av verdier du vil ha for blodsukkervarslene dine, for eksempel 70-180 mg/dL eller 90-200 mg/dL."
@@ -10707,16 +15034,28 @@
             "value" : "Jeśli korzystałeś już z CGM, prawdopodobnie znasz zakres docelowy jako szeroki zakres wartości, które chcesz wyświetlać w alertach powiadomień o poziomie glukozy, na przykład 70-180 mg/dl lub 90-200 mg/dl."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dacă ați folosit anterior un CGM, probabil sunteți familiarizat cu intervalul țintă ca o gamă largă de valori pe care le-ați dori pentru alertele de notificare, cum sunt 70-180 mg/dl sau 90-200 mg/dl."
+            "state" : "new",
+            "value" : "If you've used a CGM before, you're likely familiar with target range as a wide range of values you'd like for your glucose notification alerts, such as 70-180 mg/dL or 90-200 mg/dL."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If you've used a CGM before, you're likely familiar with target range as a wide range of values you'd like for your glucose notification alerts, such as 70-180 mg/dL or 90-200 mg/dL."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Если вы уже пользовались CGM, вы, скорее всего, знакомы с целевым диапазоном как широким диапазоном значений, которые вы хотели бы видеть в уведомлениях о глюкозе, например, 3,9 ммоль/л - 10 ммоль/л или 5 - 11,1 ммоль/л."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If you've used a CGM before, you're likely familiar with target range as a wide range of values you'd like for your glucose notification alerts, such as 70-180 mg/dL or 90-200 mg/dL."
           }
         },
         "sv" : {
@@ -10731,6 +15070,24 @@
             "value" : "Daha önce bir CGM kullandıysanız, KŞ bildirim uyarılarınız için 70-180 mg/dL veya 90-200 mg/dL gibi geniş bir hedef aralığına aşinasınızdır."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If you've used a CGM before, you're likely familiar with target range as a wide range of values you'd like for your glucose notification alerts, such as 70-180 mg/dL or 90-200 mg/dL."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If you've used a CGM before, you're likely familiar with target range as a wide range of values you'd like for your glucose notification alerts, such as 70-180 mg/dL or 90-200 mg/dL."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If you've used a CGM before, you're likely familiar with target range as a wide range of values you'd like for your glucose notification alerts, such as 70-180 mg/dL or 90-200 mg/dL."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10741,9 +15098,15 @@
     },
     "info" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "info"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "info"
           }
         },
@@ -10753,21 +15116,45 @@
             "value" : "Info"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "info"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "info"
+          }
+        },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "info"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "info"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "info"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "info"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "info"
           }
         },
@@ -10779,13 +15166,19 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "info"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "info"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "info"
           }
         },
@@ -10795,10 +15188,46 @@
             "value" : "инфо"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "info"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "info"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "bilgi"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "info"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "info"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "info"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "info"
           }
         }
       }
@@ -10844,7 +15273,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Insulin Model"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Insulin Model"
           }
         },
@@ -10854,13 +15289,7 @@
             "value" : "Modello di azione dell'Insulina"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インスリンモデル"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Insulin modell"
@@ -10878,16 +15307,16 @@
             "value" : "Model insuliny"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Model"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Modelo de Insulina"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelul de insulină"
           }
         },
         "ru" : {
@@ -10914,10 +15343,22 @@
             "value" : "İnsülin Modeli"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Model"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chủng loại Insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Model"
           }
         },
         "zh-Hans" : {
@@ -10940,7 +15381,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulinfølsomheder"
+            "value" : "Insulin Sensitivitet"
           }
         },
         "de" : {
@@ -10952,25 +15393,31 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sensibilidad a la insulina"
+            "value" : "Factor de sensibilidad"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insuliiniherkkyydet"
+            "value" : "Insuliinin herkkyys"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Facteurs de sensibilité à l'insuline"
+            "value" : "Sensibilité à l'Insuline"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Insulin Sensitivities"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inzulin érzékenység"
           }
         },
         "it" : {
@@ -10979,46 +15426,46 @@
             "value" : "Sensibilità insulinica"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "インスリン効果値"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insulinsensitivitet"
+            "value" : "Insulinfølsomhet"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulinegevoeligheden"
+            "value" : "Insuline gevoeligheden"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wrażliwość na insulinę (ISF)"
+            "value" : "Wrażliwość na insulinę"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sensibilidade a Insulina"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sensibilidades a Insulina"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Factor de sensibilitate la insulină"
+            "value" : "Sensibilidade a Insulina"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Факторы чувствительности инсулина"
+            "value" : "Чувствительность к инсулину"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inzulínová citlivosť"
           }
         },
         "sv" : {
@@ -11033,10 +15480,22 @@
             "value" : "İnsülin Duyarlılığı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чутливість до інсуліну"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Độ nhạy của Insulin"
+            "value" : "Độ nhạy Insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Sensitivities"
           }
         },
         "zh-Hans" : {
@@ -11050,6 +15509,12 @@
     "Insulin sensitivity describes how your blood glucose should respond to a 1 Unit dose of insulin. Smaller values mean more insulin will be given when above target. Values that are too small can cause dangerously low blood glucose." : {
       "comment" : "The description shown on the insulin sensitivity schedule interface.",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin sensitivity describes how your blood glucose should respond to a 1 Unit dose of insulin. Smaller values mean more insulin will be given when above target. Values that are too small can cause dangerously low blood glucose."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11082,7 +15547,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Insulin sensitivity describes how your blood glucose should respond to a 1 Unit dose of insulin. Smaller values mean more insulin will be given when above target. Values that are too small can cause dangerously low blood glucose."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Insulin sensitivity describes how your blood glucose should respond to a 1 Unit dose of insulin. Smaller values mean more insulin will be given when above target. Values that are too small can cause dangerously low blood glucose."
           }
         },
@@ -11092,13 +15563,7 @@
             "value" : "La sensibilità insulinica descrive il modo in cui la tua glicemia dovrebbe rispondere a una dose d'insulina pari a 1 Unità. In caso di valori inferiori, al superamento del target verrà erogata più insulina. Valori troppo bassi possono causare livelli di glicemia pericolosamente bassi."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インスリン効果値は、1単位のインスリンによって血糖値がどれだけ反応するかを表します。この値が小さいほど、測定値がターゲットを超えたときに注入されるインスリンの量が多くなります。値を小さく設定しすぎると低血糖の原因となり危険です。"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Insulinfølsomhet beskriver hvordan blodsukkeret responderer på 1 enhet insulin. Mindre verdier betyr at mer insulin vil bli gitt når man er over målområdet. Verdier som er for små kan føre til farlig lavt blodsukker."
@@ -11116,22 +15581,28 @@
             "value" : "Insulinowrażliwość opisuje, w jaki sposób stężenie glukozy we krwi powinno reagować na 1 jednostkę insuliny. Mniejsze wartości oznaczają podanie większej ilości insuliny w przypadku wartości powyżej zakresu. Zbyt małe wartości mogą spowodować niebezpiecznie niskie stężenie glukozy we krwi."
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin sensitivity describes how your blood glucose should respond to a 1 Unit dose of insulin. Smaller values mean more insulin will be given when above target. Values that are too small can cause dangerously low blood glucose."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "A sensibilidade à insulina descreve como a glicose no sangue deve responder a uma dose unitária de insulina. Valores menores significam que mais insulina será administrada quando acima do objetivo. Valores muito pequenos podem causar hipoglicemia."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Factorul de sensibilitate la insulină descrie felul în care glicemia ar trebui să răspundă la 1 unitate de insulină. Valori mai mici determină administrarea unor doze mai mari de insulină pentru a scădea glicemia la intervalul țintă."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Чувствительность к инсулину показывает как ГК отреагирует на 1 ед. Инсулина. Меньшие величины означают подачу большего количества инсулина при ГК выше целевой. Слишком низкие величины могут привести к слишком низкой ГК."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin sensitivity describes how your blood glucose should respond to a 1 Unit dose of insulin. Smaller values mean more insulin will be given when above target. Values that are too small can cause dangerously low blood glucose."
           }
         },
         "sv" : {
@@ -11146,10 +15617,22 @@
             "value" : "İnsülin duyarlılığı, (İDF) kan şekerinizin 1 Ünite insülin dozuna nasıl tepki vermesi gerektiğini tanımlar. Daha küçük değerler, hedefin üzerindeyken daha fazla insülin verileceği anlamına gelir. Çok küçük değerler tehlikeli derecede düşük kan şekerine neden olabilir."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin sensitivity describes how your blood glucose should respond to a 1 Unit dose of insulin. Smaller values mean more insulin will be given when above target. Values that are too small can cause dangerously low blood glucose."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Độ nhạy của Insulin biểu thị đường huyết của bạn phản ứng với 1 unit insulin. Giá trị phản ứng nhỏ hơn nghĩa là bạn cần thêm insulin để đạt mục tiêu ở trên. Các giá trị quá nhỏ có thể dẫn đến tình trạng hạ đường huyết nghiêm trọng."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin sensitivity describes how your blood glucose should respond to a 1 Unit dose of insulin. Smaller values mean more insulin will be given when above target. Values that are too small can cause dangerously low blood glucose."
           }
         },
         "zh-Hans" : {
@@ -11163,6 +15646,12 @@
     "Interrupted %1$@: <b>%2$@</b> of %3$@ %4$@" : {
       "comment" : "Description of an interrupted bolus dose entry (1: title for dose type, 2: value (? if no value) in bold, 3: programmed value (? if no value), 4: unit)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Interrupted %1$@: <b>%2$@</b> of %3$@ %4$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11193,13 +15682,25 @@
             "value" : "Interrompu %1$@: <b>%2$@</b> de %3$@ %4$@"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Interrupted %1$@: <b>%2$@</b> of %3$@ %4$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Interrupted %1$@: <b>%2$@</b> of %3$@ %4$@"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Interrotto %1$@: <b>%2$@ </b> di %3$@ %4$@"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Avbrutt %1$@: <b>%2$@</b> av %3$@ %4$@"
@@ -11217,16 +15718,28 @@
             "value" : "Przerwane %1$@ : <b> %2$@ </b> z %3$@ %4$@"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Întrerupere %1$@: <b>%2$@</b> din %3$@ %4$@"
+            "state" : "new",
+            "value" : "Interrupted %1$@: <b>%2$@</b> of %3$@ %4$@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Interrupted %1$@: <b>%2$@</b> of %3$@ %4$@"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Прервано %1$@:<b>%2$@</b> из %3$@ %4$@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Interrupted %1$@: <b>%2$@</b> of %3$@ %4$@"
           }
         },
         "sv" : {
@@ -11240,12 +15753,42 @@
             "state" : "translated",
             "value" : "%1$@ kesintiye uğradı: %3$@ %4$@'nın <b>%2$@</b> 'si"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Interrupted %1$@: <b>%2$@</b> of %3$@ %4$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Interrupted %1$@: <b>%2$@</b> of %3$@ %4$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Interrupted %1$@: <b>%2$@</b> of %3$@ %4$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Interrupted %1$@: <b>%2$@</b> of %3$@ %4$@"
+          }
         }
       }
     },
     "It can be set as low as %1$@. It can be set as high as %2$@." : {
       "comment" : "Guardrail info text format",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It can be set as low as %1$@. It can be set as high as %2$@."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11276,13 +15819,25 @@
             "value" : "Il peut être défini aussi bas que %1$@. Il peut être défini aussi haut que %2$@ ."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It can be set as low as %1$@. It can be set as high as %2$@."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It can be set as low as %1$@. It can be set as high as %2$@."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Può essere impostato fino a %1$@. Può essere impostato fino a %2$@."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Den kan stilles inn så lavt som %1$@. Den kan settes så høyt som %2$@."
@@ -11300,16 +15855,28 @@
             "value" : "Można go ustawić w zakresie od %1$@ do %2$@."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poate fi setat la minim %1$@. Poate fi setat până la %2$@."
+            "state" : "new",
+            "value" : "It can be set as low as %1$@. It can be set as high as %2$@."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It can be set as low as %1$@. It can be set as high as %2$@."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Его можно установить на уровне %1$@. Он может быть установлен до %2$@."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It can be set as low as %1$@. It can be set as high as %2$@."
           }
         },
         "sv" : {
@@ -11324,6 +15891,24 @@
             "value" : "%1$@ kadar düşük bir değere ayarlanabilir. %2$@ kadar yükseğe ayarlanabilir."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It can be set as low as %1$@. It can be set as high as %2$@."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It can be set as low as %1$@. It can be set as high as %2$@."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "It can be set as low as %1$@. It can be set as high as %2$@."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11335,6 +15920,12 @@
     "Low Basal Rate" : {
       "comment" : "Title text for the low basal rate warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Basal Rate"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11365,13 +15956,25 @@
             "value" : "Valeur débit basal basse"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Basal Rate"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Basal Rate"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Velocità basale bassa"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lav basaldose"
@@ -11389,16 +15992,28 @@
             "value" : "Niska dawka podstawowa"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rată bazală scăzută"
+            "state" : "new",
+            "value" : "Low Basal Rate"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Basal Rate"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Слишком низкая база"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Basal Rate"
           }
         },
         "sv" : {
@@ -11412,12 +16027,42 @@
             "state" : "translated",
             "value" : "Düşük Bazal Oran"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Basal Rate"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Basal Rate"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Basal Rate"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Basal Rate"
+          }
         }
       }
     },
     "Low Carb Ratio" : {
       "comment" : "Title text for the low carb ratio warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Carb Ratio"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11448,13 +16093,25 @@
             "value" : "Ratios insuline-glucides bas"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Carb Ratio"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Carb Ratio"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rapporto carboidrati basso"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lavt karbohydratforhold"
@@ -11472,16 +16129,28 @@
             "value" : "Niski współczynnik węglowodanów"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Raport Carbohidrați/Insulina scăzut"
+            "state" : "new",
+            "value" : "Low Carb Ratio"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Carb Ratio"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Слишком низкое соотношение углеводов"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Carb Ratio"
           }
         },
         "sv" : {
@@ -11495,12 +16164,42 @@
             "state" : "translated",
             "value" : "Düşük Karb Oranı"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Carb Ratio"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Carb Ratio"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Carb Ratio"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Carb Ratio"
+          }
         }
       }
     },
     "Low Correction Value" : {
       "comment" : "Title text for the low correction value warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Correction Value"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11531,13 +16230,25 @@
             "value" : "Valeur correction basse"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Correction Value"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Correction Value"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Valore di correzione basso"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lav korreksjonsverdi"
@@ -11555,16 +16266,28 @@
             "value" : "Niska wartość korekty"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valoare de corecție scăzută"
+            "state" : "new",
+            "value" : "Low Correction Value"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Correction Value"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Слишком низкое значение для коррекции"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Correction Value"
           }
         },
         "sv" : {
@@ -11578,12 +16301,42 @@
             "state" : "translated",
             "value" : "Düşük Düzeltme Değeri"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Correction Value"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Correction Value"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Correction Value"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Correction Value"
+          }
         }
       }
     },
     "Low Glucose Safety Limit" : {
       "comment" : "Title text for the low glucose safety limit warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Glucose Safety Limit"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11620,13 +16373,19 @@
             "value" : "ערך הבטיחות נמוך"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Glucose Safety Limit"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Limite glicemico di sicurezza basso"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sikkerhetsgrense for lavt blodsukker"
@@ -11644,16 +16403,28 @@
             "value" : "Limit bezpieczeństwa niskiego poziomu glukozy"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limita inferioara de siguranță a glicemiei"
+            "state" : "new",
+            "value" : "Low Glucose Safety Limit"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Glucose Safety Limit"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Слишком низкий предел безопасности ГК"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Glucose Safety Limit"
           }
         },
         "sv" : {
@@ -11668,6 +16439,24 @@
             "value" : "Düşük KŞ Güvenlik Limiti"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Glucose Safety Limit"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Glucose Safety Limit"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Glucose Safety Limit"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11679,6 +16468,12 @@
     "Low Insulin Sensitivity" : {
       "comment" : "Title text for the low insulin sensitivity warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Insulin Sensitivity"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11709,13 +16504,25 @@
             "value" : "Sensibilité à l'insuline faible"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Insulin Sensitivity"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Insulin Sensitivity"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sensibilità insulinica bassa"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lav insulinfølsomhet"
@@ -11733,16 +16540,28 @@
             "value" : "Niski Współczynnik Wrażliwości"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Factor de sensibilitate la insulină scăzut"
+            "state" : "new",
+            "value" : "Low Insulin Sensitivity"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Insulin Sensitivity"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Низкая чувствительность к инсулину"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Insulin Sensitivity"
           }
         },
         "sv" : {
@@ -11756,12 +16575,42 @@
             "state" : "translated",
             "value" : "Düşük İnsülin Duyarlılığı"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Insulin Sensitivity"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Insulin Sensitivity"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Insulin Sensitivity"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Insulin Sensitivity"
+          }
         }
       }
     },
     "Low Maximum Basal Rate" : {
       "comment" : "Title text for low maximum basal rate warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Maximum Basal Rate"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11792,13 +16641,25 @@
             "value" : "Valeur Max débit basal basse"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Maximum Basal Rate"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Maximum Basal Rate"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Velocità basale massima bassa"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lav maksimal basaldose"
@@ -11816,16 +16677,28 @@
             "value" : "Niska maksymalna dawka podstawowa"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rată bazală maximă scăzută"
+            "state" : "new",
+            "value" : "Low Maximum Basal Rate"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Maximum Basal Rate"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Слишком низкая максимальная база"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Maximum Basal Rate"
           }
         },
         "sv" : {
@@ -11839,12 +16712,42 @@
             "state" : "translated",
             "value" : "Düşük Maksimum Bazal Oranı"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Maximum Basal Rate"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Maximum Basal Rate"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Maximum Basal Rate"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Maximum Basal Rate"
+          }
         }
       }
     },
     "Low Maximum Bolus" : {
       "comment" : "Title text for low maximum bolus warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Maximum Bolus"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11875,13 +16778,25 @@
             "value" : "Valeur Bolus basse"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Maximum Bolus"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Maximum Bolus"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bolo massimo basso"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lav maksimal bolus-dose"
@@ -11899,16 +16814,28 @@
             "value" : "Niski maksymalny bolus"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bolus maxim scăzut"
+            "state" : "new",
+            "value" : "Low Maximum Bolus"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Maximum Bolus"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Слишком маленький максимальный болюс"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Maximum Bolus"
           }
         },
         "sv" : {
@@ -11923,6 +16850,24 @@
             "value" : "Düşük Maksimum Bolus"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Maximum Bolus"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Maximum Bolus"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Maximum Bolus"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11934,6 +16879,12 @@
     "Low Pre-Meal Value" : {
       "comment" : "Title text for the low pre-meal value warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Pre-Meal Value"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11964,13 +16915,25 @@
             "value" : "Valeur de pré-repas basse"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Pre-Meal Value"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Pre-Meal Value"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Valore pre-pasto basso"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lav verdi før måltid"
@@ -11988,16 +16951,28 @@
             "value" : "Niska wartość przed posiłkiem"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valoare mica preprandiala"
+            "state" : "new",
+            "value" : "Low Pre-Meal Value"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Pre-Meal Value"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Слишком низкая настройка до еды"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Pre-Meal Value"
           }
         },
         "sv" : {
@@ -12011,12 +16986,42 @@
             "state" : "translated",
             "value" : "Düşük Yemek Öncesi Değer"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Pre-Meal Value"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Pre-Meal Value"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Pre-Meal Value"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Pre-Meal Value"
+          }
         }
       }
     },
     "Low Workout Value" : {
       "comment" : "Title text for the low workout value warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Workout Value"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12047,13 +17052,25 @@
             "value" : "Valeur basse exercice"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Workout Value"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Workout Value"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Valore allenamento basso"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lav treningsverdi"
@@ -12071,16 +17088,28 @@
             "value" : "Niska wartość treningu"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valoare mica antrenament"
+            "state" : "new",
+            "value" : "Low Workout Value"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Workout Value"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Слишком низкая настрйка для физнагрузки"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Workout Value"
           }
         },
         "sv" : {
@@ -12094,67 +17123,133 @@
             "state" : "translated",
             "value" : "Düşük Egzersiz Değeri"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Workout Value"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Workout Value"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Workout Value"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Workout Value"
+          }
         }
       }
     },
     "Lyumjev" : {
       "comment" : "Title of insulin model preset - lyumjev",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Lyumjev"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Lyumjev"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Lyumjev"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Lyumjev"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Lyumjev"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Lyumjev"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Lyumjev"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Lyumjev"
           }
         },
-        "ro" : {
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
+        "sk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lyumjev"
           }
         },
-        "ru" : {
+        "sv" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lyumjev"
@@ -12162,7 +17257,31 @@
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
             "state" : "translated",
+            "value" : "Lyumjev"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyumjev"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Lyumjev"
           }
         }
@@ -12171,21 +17290,27 @@
     "max" : {
       "comment" : "Placeholder for maximum value in glucose range\nPlaceholder for quantity range upper bound",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "max"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "max"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "max"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "max"
           }
         },
@@ -12197,37 +17322,37 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "max"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "max"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "max"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "max"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "max"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "max"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "max"
           }
         },
@@ -12237,15 +17362,15 @@
             "value" : "maks."
           }
         },
-        "pt-BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "max"
           }
         },
-        "ro" : {
+        "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "max"
           }
         },
@@ -12253,6 +17378,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "макс"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "max"
           }
         },
         "sv" : {
@@ -12267,10 +17398,22 @@
             "value" : "maks"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "max"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "tối đa"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "max"
           }
         },
         "zh-Hans" : {
@@ -12285,6 +17428,12 @@
       "comment" : "The title text for the maximum basal rate value",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12317,7 +17466,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Maximum Basal Rate"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Maximum Basal Rate"
           }
         },
@@ -12327,16 +17482,10 @@
             "value" : "Velocità basale massima"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最大基礎レート"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maks basalgrense"
+            "value" : "Maksimal basaldose"
           }
         },
         "nl" : {
@@ -12351,22 +17500,28 @@
             "value" : "Maksymalna dawka podstawowa"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Taxa Basal Máxima"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rată bazală maximă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Максимальная скорость базала"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximálna bazálna dávka"
           }
         },
         "sv" : {
@@ -12381,16 +17536,28 @@
             "value" : "Maksimum Bazal Oranı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lượng Basal tối đa"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "最大基础率限制"
+            "state" : "new",
+            "value" : "Maximum Basal Rate"
           }
         }
       }
@@ -12398,10 +17565,10 @@
     "Maximum Basal Rate is the maximum automatically adjusted basal rate that %1$@ is allowed to enact to help reach your correction range." : {
       "comment" : "Information about maximum basal rate (1: app name)",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maximální bazální dávka je maximální automaticky upravená bazální dávka, kterou může %1$@ podat, aby vás dostal do vašeho korekčního rozsahu."
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the maximum automatically adjusted basal rate that %1$@ is allowed to enact to help reach your correction range."
           }
         },
         "da" : {
@@ -12422,10 +17589,28 @@
             "value" : "La Tasa Basal Máxima es el máximo ajuste automático que %1$@ tiene permitido habilitar para ayudar a alcanzar tu rango de corrección."
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the maximum automatically adjusted basal rate that %1$@ is allowed to enact to help reach your correction range."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Le débit basal maximum est le débit de base temporaire le plus élevé que %1$@ est autorisé à utiliser pour atteindre votre plage de correction."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the maximum automatically adjusted basal rate that %1$@ is allowed to enact to help reach your correction range."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the maximum automatically adjusted basal rate that %1$@ is allowed to enact to help reach your correction range."
           }
         },
         "it" : {
@@ -12434,7 +17619,7 @@
             "value" : "La velocità basale massima è la velocità basale massima regolata automaticamente che %1$@ può applicare per raggiungere l'intervallo di correzione."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maksimal basaldose er den maksimale automatisk justerte basaldosen som %1$@ har lov til å aktivere for å hjelpe deg med å nå ditt korreksjonsområde."
@@ -12452,10 +17637,16 @@
             "value" : "Maksymalna dawka podstawowa to maksymalna automatycznie dostosowana baza, którą %1$@ może wprowadzić, aby pomóc osiągnąć zakres docelowy."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rata bazală maximă este rata bazală maximă ajustată automat pe care %1$@ are voie să o activeze pentru a vă ajuta să atingeți intervalul de corecție."
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the maximum automatically adjusted basal rate that %1$@ is allowed to enact to help reach your correction range."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the maximum automatically adjusted basal rate that %1$@ is allowed to enact to help reach your correction range."
           }
         },
         "ru" : {
@@ -12464,10 +17655,46 @@
             "value" : "Максимальная базальная скорость - это максимальная базальная скорость, которую %1$@ разрешено использовать для достижения диапазона коррекции в автоматическом режиме."
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the maximum automatically adjusted basal rate that %1$@ is allowed to enact to help reach your correction range."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximal basaldos är den automatisk inställda basaldos som %1$@ använder för att korrigera blodsockret till ditt angivna målvärde med."
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maksimum Bazal Oran, düzeltme aralığınıza ulaşmanıza yardımcı olmak için %1$@ tarafından yürürlüğe koymasına izin verilen otomatik olarak ayarlanan maksimum bazal orandır."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the maximum automatically adjusted basal rate that %1$@ is allowed to enact to help reach your correction range."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the maximum automatically adjusted basal rate that %1$@ is allowed to enact to help reach your correction range."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the maximum automatically adjusted basal rate that %1$@ is allowed to enact to help reach your correction range."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Basal Rate is the maximum automatically adjusted basal rate that %1$@ is allowed to enact to help reach your correction range."
           }
         }
       }
@@ -12476,6 +17703,12 @@
       "comment" : "The title text for the maximum bolus value",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12508,7 +17741,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Maximum Bolus"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Maximum Bolus"
           }
         },
@@ -12518,16 +17757,10 @@
             "value" : "Bolo massimo"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最大ボーラス"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maks bolus"
+            "value" : "Maksimal bolus"
           }
         },
         "nl" : {
@@ -12542,22 +17775,28 @@
             "value" : "Maksymalny bolus"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bolus Máximo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bolus maxim"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Максимальный Болюс"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximálny bolus"
           }
         },
         "sv" : {
@@ -12572,16 +17811,28 @@
             "value" : "Maksimum Bolus"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Liều Bolus tối đa"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "最大大剂量限制"
+            "state" : "new",
+            "value" : "Maximum Bolus"
           }
         }
       }
@@ -12589,10 +17840,10 @@
     "Maximum Bolus is the highest bolus amount that you will allow %1$@ to recommend at one time to cover carbs or bring down high glucose." : {
       "comment" : "Information about maximum bolus (1: app name)",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maximální bolus je nejvyšší hodnota bolusu, kterou umožníte %1$@ najednou doporučit na pokrytí sacharidů nebo snížení vysoké hladiny glukózy."
+            "state" : "new",
+            "value" : "Maximum Bolus is the highest bolus amount that you will allow %1$@ to recommend at one time to cover carbs or bring down high glucose."
           }
         },
         "da" : {
@@ -12613,10 +17864,28 @@
             "value" : "El Bolo Máximo es la cantidad de bolo más alta que permitirá que %1$@ recomiende de una sola vez para cubrir los carbohidratos o reducir los niveles altos de glucosa."
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus is the highest bolus amount that you will allow %1$@ to recommend at one time to cover carbs or bring down high glucose."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Le bolus maximum est la quantité de bolus la plus élevée que vous autoriserez %1$@ à recommander à un moment donné pour couvrir les glucides ou faire baisser une glycémie élevée."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus is the highest bolus amount that you will allow %1$@ to recommend at one time to cover carbs or bring down high glucose."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus is the highest bolus amount that you will allow %1$@ to recommend at one time to cover carbs or bring down high glucose."
           }
         },
         "it" : {
@@ -12625,7 +17894,7 @@
             "value" : "Il bolo massimo è la quantità di bolo più alta che %1$@ può consigliare in una volta per coprire i carboidrati o ridurre la glicemia alta."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maksimal bolus er den høyeste bolusmengden du vil tillate %1$@ å anbefale på en gang for å dekke karbohydrater eller redusere høyt blodsukker."
@@ -12643,10 +17912,16 @@
             "value" : "Maksymalny bolus to największa wartość bolusa, jaką %1$@ można podać w jednorazowo, aby zrekompensować węglowodany lub obniżyć wysoki poziom glukozy."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bolusul maxim este cea mai mare cantitate de insulină pe care o permiteți %1$@ să o recomande dintr-odată pentru a acoperi carbohidrați sau pentru a scădea o glicemie mare."
+            "state" : "new",
+            "value" : "Maximum Bolus is the highest bolus amount that you will allow %1$@ to recommend at one time to cover carbs or bring down high glucose."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus is the highest bolus amount that you will allow %1$@ to recommend at one time to cover carbs or bring down high glucose."
           }
         },
         "ru" : {
@@ -12655,10 +17930,40 @@
             "value" : "Максимальный болюс - это наибольший размер болюса, котороый вы позволите %1$@ рекомендовать за один раз для покрытия углеводов или снижения высокого уровня глюкозы."
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus is the highest bolus amount that you will allow %1$@ to recommend at one time to cover carbs or bring down high glucose."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximal bolus är den högsta bolusmängd som kan ges vid ett tillfälle av %1$@ för att behandla kolhydrater eller ett högt blodsocker."
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maksimum Bolus, karbonhidratları karşılamak veya yüksek kan şekerini düşürmek için %1$@ tarafından tek seferde önermesine izin vereceğiniz en yüksek bolus miktarıdır."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus is the highest bolus amount that you will allow %1$@ to recommend at one time to cover carbs or bring down high glucose."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus is the highest bolus amount that you will allow %1$@ to recommend at one time to cover carbs or bring down high glucose."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Bolus is the highest bolus amount that you will allow %1$@ to recommend at one time to cover carbs or bring down high glucose."
           }
         },
         "zh-Hans" : {
@@ -12672,16 +17977,22 @@
     "Medium" : {
       "comment" : "Section title for medium absorbing food",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Medium"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Medium"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mittlere"
+            "value" : "Medium"
           }
         },
         "es" : {
@@ -12692,8 +18003,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keskiverto"
+            "state" : "new",
+            "value" : "Medium"
           }
         },
         "fr" : {
@@ -12704,8 +18015,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Medium"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Közepes"
           }
         },
         "it" : {
@@ -12714,46 +18031,46 @@
             "value" : "Medio"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "中"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Medium"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Middel"
+            "value" : "Medium"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Średnia"
+            "state" : "new",
+            "value" : "Medium"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Medium"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Média"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Medie"
+            "state" : "new",
+            "value" : "Medium"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Средняя"
+            "value" : "Средний"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stredné"
           }
         },
         "sv" : {
@@ -12764,20 +18081,32 @@
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Medium"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "Orta"
+            "value" : "Середня"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Trung bình"
+            "value" : "Medium"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Medium"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "中等"
+            "state" : "new",
+            "value" : "Medium"
           }
         }
       }
@@ -12785,6 +18114,12 @@
     "min" : {
       "comment" : "Placeholder for minimum value in glucose range\nPlaceholder for quantity range lower bound",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "د"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12817,8 +18152,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "min"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "perc"
           }
         },
         "it" : {
@@ -12827,13 +18168,7 @@
             "value" : "min"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "min"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "min"
@@ -12851,15 +18186,15 @@
             "value" : "min."
           }
         },
-        "pt-BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "min"
           }
         },
-        "ro" : {
+        "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "min"
           }
         },
@@ -12867,6 +18202,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "мин"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "min"
           }
         },
         "sv" : {
@@ -12877,14 +18218,26 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "min"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "хв"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "tối thiểu"
+            "value" : "min"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "min"
           }
         },
         "zh-Hans" : {
@@ -12898,6 +18251,12 @@
     "More Info" : {
       "comment" : "Alert action title to open error help",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "More Info"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12930,7 +18289,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "More Info"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "More Info"
           }
         },
@@ -12940,13 +18305,7 @@
             "value" : "Piu info"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "詳細"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mer info"
@@ -12964,22 +18323,28 @@
             "value" : "Więcej informacji"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "More Info"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mais Info"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detalii"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Доп. инфо"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "More Info"
           }
         },
         "sv" : {
@@ -12994,10 +18359,22 @@
             "value" : "Daha fazla bilgi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "More Info"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thêm thông tin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "More Info"
           }
         },
         "zh-Hans" : {
@@ -13011,10 +18388,10 @@
     "Name" : {
       "comment" : "The text for the custom preset name setting",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Název"
+            "value" : "الاسم"
           }
         },
         "da" : {
@@ -13049,14 +18426,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Name"
           }
         },
-        "hi" : {
+        "hu" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "नाम"
+            "value" : "Megnevezés"
           }
         },
         "it" : {
@@ -13065,13 +18442,7 @@
             "value" : "Nome"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プリセット名"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Navn"
@@ -13085,8 +18456,14 @@
         },
         "pl" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Name"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "Nazwa"
+            "value" : "Nome"
           }
         },
         "pt-BR" : {
@@ -13095,16 +18472,10 @@
             "value" : "Nome"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nume"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Имя"
+            "value" : "Название"
           }
         },
         "sk" : {
@@ -13125,16 +18496,28 @@
             "value" : "İsim"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ім’я"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tên"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Name"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "名称"
+            "value" : "设备名称"
           }
         }
       }
@@ -13142,6 +18525,12 @@
     "New Entry" : {
       "comment" : "Title for mini-modal to add a new schedule entry",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Entry"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13172,13 +18561,25 @@
             "value" : "Ajout"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Entry"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Entry"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nuova voce"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ny oppføring"
@@ -13196,16 +18597,28 @@
             "value" : "Nowy wpis"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Înregistrare nouă"
+            "state" : "new",
+            "value" : "New Entry"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Entry"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Новая запись"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Entry"
           }
         },
         "sv" : {
@@ -13220,6 +18633,24 @@
             "value" : "Yeni giriş"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Entry"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Entry"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Entry"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13231,6 +18662,12 @@
     "New Preset" : {
       "comment" : "The title for the new custom preset entry screen",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Preset"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13263,7 +18700,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "New Preset"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "New Preset"
           }
         },
@@ -13273,13 +18716,7 @@
             "value" : "Nuovo Preset"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プリセットを設定する"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ny forhåndsinstilling"
@@ -13297,22 +18734,28 @@
             "value" : "Nowy Cel Tymczasowy"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Preset"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nova Predefinição"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Presetare nouă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Новый параметр"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Preset"
           }
         },
         "sv" : {
@@ -13327,10 +18770,22 @@
             "value" : "Yeni Ön Ayar"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Preset"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cài đặt mới"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Preset"
           }
         },
         "zh-Hans" : {
@@ -13344,6 +18799,12 @@
     "No Basal Insulin" : {
       "comment" : "Title text for the zero basal rate warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Basal Insulin"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13374,13 +18835,25 @@
             "value" : "Pas d'insuline Basal"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Basal Insulin"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Basal Insulin"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nessuna insulina basale"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ingen basal insulin"
@@ -13398,16 +18871,28 @@
             "value" : "Bez insuliny bazowej"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fără insulină bazală"
+            "state" : "new",
+            "value" : "No Basal Insulin"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Basal Insulin"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Без базального инсулина"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Basal Insulin"
           }
         },
         "sv" : {
@@ -13421,11 +18906,41 @@
             "state" : "translated",
             "value" : "Bazal İnsülin Yok"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Basal Insulin"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Basal Insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Basal Insulin"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Basal Insulin"
+          }
         }
       }
     },
     "Nothing to See Here!" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Nothing to See Here!"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13438,10 +18953,34 @@
             "value" : "Es gibt hier nichts zu sehen!"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Nothing to See Here!"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Nothing to See Here!"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il n’y a rien à voir ici !"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Nothing to See Here!"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Nothing to See Here!"
           }
         },
         "it" : {
@@ -13450,10 +18989,16 @@
             "value" : "Niente da vedere qui!"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ingenting å se her!"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Nothing to See Here!"
           }
         },
         "pl" : {
@@ -13462,10 +19007,64 @@
             "value" : "Nie ma tu nic do zobaczenia!"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Nothing to See Here!"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Nothing to See Here!"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Здесь нет ничего!"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Nothing to See Here!"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inget att se här!"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Nothing to See Here!"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Nothing to See Here!"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Nothing to See Here!"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Nothing to See Here!"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Nothing to See Here!"
           }
         }
       }
@@ -13473,16 +19072,22 @@
     "Other" : {
       "comment" : "Section title for no-carb food\nThe title for custom preset emoji miscellaneous section",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أخرى"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Anden"
+            "value" : "Andet"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Andere"
+            "value" : "Sonstiges"
           }
         },
         "es" : {
@@ -13493,8 +19098,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Muu"
+            "state" : "new",
+            "value" : "Other"
           }
         },
         "fr" : {
@@ -13505,8 +19110,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Other"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Egyéb"
           }
         },
         "it" : {
@@ -13515,13 +19126,7 @@
             "value" : "Altro"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "その他"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Annet"
@@ -13535,26 +19140,32 @@
         },
         "pl" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Other"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "Inne"
+            "value" : "Outro"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Outra"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Altele"
+            "value" : "Outros"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Другая"
+            "value" : "Прочее"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iné"
           }
         },
         "sv" : {
@@ -13569,10 +19180,22 @@
             "value" : "Diğer"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Інше"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Khác"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Other"
           }
         },
         "zh-Hans" : {
@@ -13586,6 +19209,12 @@
     "Overall Insulin Needs" : {
       "comment" : "The title text for the insulin sensitivity scaling setting",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Overall Insulin Needs"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13618,7 +19247,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Overall Insulin Needs"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Overall Insulin Needs"
           }
         },
@@ -13628,13 +19263,7 @@
             "value" : "Fabbisogno complessivo d'insulina"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "総インスリン必要量"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Insulinbehov totalt sett"
@@ -13652,22 +19281,28 @@
             "value" : "Ogólne zapotrzebowanie na insulinę"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Overall Insulin Needs"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Necessidades Gerais de Insulina"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Necesar de insulină total"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Общая потребность в инсулине"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Overall Insulin Needs"
           }
         },
         "sv" : {
@@ -13682,10 +19317,22 @@
             "value" : "Genel İnsülin İhtiyaçları"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Overall Insulin Needs"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nhu cầu Insulin tổng thể"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Overall Insulin Needs"
           }
         },
         "zh-Hans" : {
@@ -13699,6 +19346,12 @@
     "Override History" : {
       "comment" : "Title for override history view",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Override History"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13729,13 +19382,25 @@
             "value" : "Remplacer l'historique"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Override History"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Override History"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cronologia Override"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Overstyr historikk"
@@ -13753,16 +19418,28 @@
             "value" : "Historia Celu Tymczasowego"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suprascrie istoricul"
+            "state" : "new",
+            "value" : "Override History"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Override History"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "История временных целей"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Override History"
           }
         },
         "sv" : {
@@ -13775,6 +19452,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geçmişi geçersiz kılma"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Override History"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Override History"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Override History"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Override History"
           }
         }
       }
@@ -13821,7 +19522,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Override Presets"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Override Presets"
           }
         },
@@ -13831,13 +19538,7 @@
             "value" : "Preset Override"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オーバーライドプリセット"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Egendefinerte overstyringer"
@@ -13851,7 +19552,13 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Override Presets"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Override Presets"
           }
         },
@@ -13861,16 +19568,16 @@
             "value" : "Sobreposições Predefinidas"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Presetări de înlocuire"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Редактировать параметры"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Override Presets"
           }
         },
         "sv" : {
@@ -13885,10 +19592,22 @@
             "value" : "Geçersiz Kılma Ön Ayarları"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Override Presets"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cài đặt chồng liều"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Override Presets"
           }
         },
         "zh-Hans" : {
@@ -13903,6 +19622,12 @@
       "comment" : "Text directing the user to configure override presets",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Override presets can be set up under the 'Configuration' section of the settings screen."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13935,7 +19660,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Override presets can be set up under the 'Configuration' section of the settings screen."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Override presets can be set up under the 'Configuration' section of the settings screen."
           }
         },
@@ -13945,13 +19676,7 @@
             "value" : "È possibile impostare i Preset Override nella sezione Configurazione della schermata delle impostazioni."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オーバーライドプリセットは、設定画面のコンフィグレーションで設定できます。"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Egendefinerte overstyringer kan settes opp under Konfigurasjons-delen av innstillingsskjermen"
@@ -13969,22 +19694,28 @@
             "value" : "Wstępne ustawienia pominięcia można skonfigurować w części „Konfiguracja” na ekranie ustawień."
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Override presets can be set up under the 'Configuration' section of the settings screen."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "As predefinições de sobreposição podem ser configuradas na seção 'Configuração' da tela de configurações."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Presetările de înlocuire pot fi setate în secțiunea 'Configurație' din ecranul de setări."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Редактирование параметров может задаваться в разделе “Конфигурация” экрана настройки."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Override presets can be set up under the 'Configuration' section of the settings screen."
           }
         },
         "sv" : {
@@ -13999,10 +19730,22 @@
             "value" : "Geçersiz kılma ön ayarları, ayarlar ekranının 'Konfigürsayon' bölümü altında ayarlanabilir."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Override presets can be set up under the 'Configuration' section of the settings screen."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cài đặt chồng liều có thể được khai báo dưới mục 'Configuration' của phần cấu hình."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Override presets can be set up under the 'Configuration' section of the settings screen."
           }
         },
         "zh-Hans" : {
@@ -14016,112 +19759,136 @@
     "Overrides" : {
       "comment" : "The section title of glucose overrides",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Overrides"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Overrides"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Overrides"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sobreescrituras"
+            "state" : "new",
+            "value" : "Overrides"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilapäisasetukset"
+            "state" : "new",
+            "value" : "Overrides"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajustements"
+            "state" : "new",
+            "value" : "Overrides"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Overrides"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Overrides"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Override"
+            "value" : "Overrides"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "オーバーライド"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Overstyringer"
+            "state" : "new",
+            "value" : "Overrides"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Override's"
+            "value" : "Tijdelijke programma’s"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pominięcia"
+            "state" : "new",
+            "value" : "Overrides"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Overrides"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sobreposições"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Înlocuiri"
+            "state" : "new",
+            "value" : "Overrides"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Изменить"
+            "value" : "Переопределения"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Profily"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Overrides"
+            "value" : "Undantag"
           }
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Overrides"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "Geçersiz kılmalar"
+            "value" : "Перевизначити"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Chồng liều"
+            "value" : "Ghi đè"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Overrides"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "覆盖"
+            "state" : "new",
+            "value" : "Overrides"
           }
         }
       }
@@ -14131,7 +19898,7 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Pre-Meal"
           }
         },
@@ -14167,7 +19934,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pre-Meal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pre-Meal"
           }
         },
@@ -14177,13 +19950,7 @@
             "value" : "Pre-pasto"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "食前"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pre-måltid"
@@ -14191,7 +19958,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Pre-Meal"
           }
         },
@@ -14201,22 +19968,28 @@
             "value" : "Przed posiłkiem"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pre-Meal"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pré-Refeição"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preprandial"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "До еды"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pre-Meal"
           }
         },
         "sv" : {
@@ -14231,16 +20004,28 @@
             "value" : "Yemek öncesi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pre-Meal"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trước bữa ăn"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pre-Meal"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "餐前模式"
+            "state" : "new",
+            "value" : "Pre-Meal"
           }
         }
       }
@@ -14248,6 +20033,12 @@
     "Pre-Meal Values" : {
       "comment" : "Title text for multi-value pre-meal value warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pre-Meal Values"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14278,13 +20069,25 @@
             "value" : "Objectif de Pré-Repas"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pre-Meal Values"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pre-Meal Values"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Valori pre-pasto"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pre-måltids verdier"
@@ -14302,16 +20105,28 @@
             "value" : "Wartości przed posiłkiem"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valori preprandiale"
+            "state" : "new",
+            "value" : "Pre-Meal Values"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pre-Meal Values"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Значения до еды"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pre-Meal Values"
           }
         },
         "sv" : {
@@ -14325,12 +20140,42 @@
             "state" : "translated",
             "value" : "Yemek Öncesi Değerler"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pre-Meal Values"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pre-Meal Values"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pre-Meal Values"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pre-Meal Values"
+          }
         }
       }
     },
     "Prescription" : {
       "comment" : "title for prescription section",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prescription"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14357,7 +20202,19 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Prescription"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prescription"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Prescription"
           }
         },
@@ -14367,7 +20224,7 @@
             "value" : "Prescrizione"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Resept"
@@ -14385,16 +20242,28 @@
             "value" : "Recepta"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prescripție"
+            "state" : "new",
+            "value" : "Prescription"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prescription"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Рецепт"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prescription"
           }
         },
         "sv" : {
@@ -14408,12 +20277,42 @@
             "state" : "translated",
             "value" : "Reçete"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prescription"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prescription"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prescription"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prescription"
+          }
         }
       }
     },
     "PRESETS" : {
       "comment" : "The section header text for custom presets",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "PRESETS"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14446,7 +20345,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "PRESETS"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "PRESETS"
           }
         },
@@ -14456,13 +20361,7 @@
             "value" : "PRESET"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プリセット"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "FORHÅNDSINSTILLINGER"
@@ -14480,22 +20379,28 @@
             "value" : "USTAWIENIA WSTĘPNE"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "PRESETS"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "PREDEFINIDAS"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PRESETĂRI"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "НАСТРОЙКИ"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "PRESETS"
           }
         },
         "sv" : {
@@ -14510,10 +20415,22 @@
             "value" : "ÖN AYARLAR"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "PRESETS"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "CÀI ĐẶT SĂN"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "PRESETS"
           }
         },
         "zh-Hans" : {
@@ -14527,6 +20444,12 @@
     "Progressing." : {
       "comment" : "Accessibility label for ProgressIndicatorView when showIndeterminantProgress",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Progressing."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14557,13 +20480,25 @@
             "value" : "En cours de traitement."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Progressing."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Progressing."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Avanzamento in corso."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fremdrift."
@@ -14581,16 +20516,28 @@
             "value" : "Postęp."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Progresează."
+            "state" : "new",
+            "value" : "Progressing."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Progressing."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Прогресс."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Progressing."
           }
         },
         "sv" : {
@@ -14604,12 +20551,42 @@
             "state" : "translated",
             "value" : "İlerliyor."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Progressing."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Progressing."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Progressing."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Progressing."
+          }
         }
       }
     },
     "Pump Event" : {
       "comment" : "The title of the screen displaying a pump event",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Event"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14642,7 +20619,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pump Event"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump Event"
           }
         },
@@ -14652,13 +20635,7 @@
             "value" : "Evento pompa"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプイベント"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pumpehendelse"
@@ -14676,22 +20653,28 @@
             "value" : "Zdarzenie pompy"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Event"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Eventos da Bomba"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eveniment de pompă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Событие помпы"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Event"
           }
         },
         "sv" : {
@@ -14706,9 +20689,21 @@
             "value" : "Pompa Etkinliği"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Event"
+          }
+        },
         "vi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pump Event"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump Event"
           }
         },
@@ -14723,6 +20718,12 @@
     "Pump Inoperable" : {
       "comment" : "Title text for suspend resume button when the basal delivery state is not set",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Inoperable"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14753,13 +20754,25 @@
             "value" : "Pompe inutilisable"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Inoperable"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Inoperable"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pompa non funzionante"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pumpe er ute av drift"
@@ -14777,16 +20790,28 @@
             "value" : "Pompa nie działa"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pompă inoperabilă"
+            "state" : "new",
+            "value" : "Pump Inoperable"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Inoperable"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Неисправность помпы"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Inoperable"
           }
         },
         "sv" : {
@@ -14799,6 +20824,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pompa Çalışmıyor"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Inoperable"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Inoperable"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Inoperable"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Inoperable"
           }
         }
       }
@@ -14844,7 +20893,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Rapid-Acting – Adults"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Rapid-Acting – Adults"
           }
         },
@@ -14854,13 +20909,7 @@
             "value" : "Insulina ultrarapida – Adulti"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "超速攻型 - 大人"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hurtigvirkende - Voksen"
@@ -14878,22 +20927,28 @@
             "value" : "Szybko działające – dorośli"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rapid-Acting – Adults"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ação-Rápida – Adultos"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acțiune rapidă – Adulți"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Быстродействующий - взрослые"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rapid-Acting – Adults"
           }
         },
         "sv" : {
@@ -14908,10 +20963,22 @@
             "value" : "Hızlı Etkili – Yetişkinler"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rapid-Acting – Adults"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thuốc tác động nhanh cho người lớn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rapid-Acting – Adults"
           }
         },
         "zh-Hans" : {
@@ -14963,7 +21030,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Rapid-Acting – Children"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Rapid-Acting – Children"
           }
         },
@@ -14973,13 +21046,7 @@
             "value" : "Insulina ultrarapida – Bambini"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "超速攻型 - 子供"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hurtigvirkende - Barn"
@@ -14997,22 +21064,28 @@
             "value" : "Szybko działająca – dzieci"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rapid-Acting – Children"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ação-Rapida – Crianças"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acțiune rapidă - Copii"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Быстродействующий - дети"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rapid-Acting – Children"
           }
         },
         "sv" : {
@@ -15027,10 +21100,22 @@
             "value" : "Hızlı Etkili – Çocuklar"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rapid-Acting – Children"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thuốc tác động nhanh cho trẻ em"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rapid-Acting – Children"
           }
         },
         "zh-Hans" : {
@@ -15044,10 +21129,10 @@
     "Required" : {
       "comment" : "The default placeholder string for a credential",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Povinné"
+            "state" : "new",
+            "value" : "Required"
           }
         },
         "da" : {
@@ -15082,7 +21167,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Required"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Required"
           }
         },
@@ -15092,13 +21183,7 @@
             "value" : "Necessario"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "必須"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Påkrevd"
@@ -15116,16 +21201,16 @@
             "value" : "Wymagane"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Required"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Obrigatório"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Necesar"
           }
         },
         "ru" : {
@@ -15152,10 +21237,22 @@
             "value" : "Gerekli"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Required"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bắt buộc"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Required"
           }
         },
         "zh-Hans" : {
@@ -15207,7 +21304,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Reservoir"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Reservoir"
           }
         },
@@ -15217,13 +21320,7 @@
             "value" : "Serbatoio"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reservoir"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reservoar"
@@ -15241,16 +21338,16 @@
             "value" : "Zbiorniczek"
           }
         },
-        "pt-BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Reservoir"
           }
         },
-        "ro" : {
+        "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rezervor"
+            "state" : "new",
+            "value" : "Reservoir"
           }
         },
         "ru" : {
@@ -15277,9 +21374,21 @@
             "value" : "Rezervuar"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Резервуар"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Ngăn chứa insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Reservoir"
           }
         },
@@ -15294,6 +21403,12 @@
     "Resume Delivery" : {
       "comment" : "Title text for button to resume insulin delivery",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "استئناف الضخ"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15326,7 +21441,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Resume Delivery"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Resume Delivery"
           }
         },
@@ -15336,13 +21457,7 @@
             "value" : "Riprendi erogazione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "注入を再開"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gjenoppta leveranse"
@@ -15351,7 +21466,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hervat Toediening"
+            "value" : "Hervat toediening"
           }
         },
         "pl" : {
@@ -15360,22 +21475,28 @@
             "value" : "Wznów podawanie"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resume Delivery"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Retomar Entrega"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reia administrarea"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Возобновить подачу"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obnoviť podávanie inzulínu"
           }
         },
         "sv" : {
@@ -15390,16 +21511,28 @@
             "value" : "İletimi Devam Ettir"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відновити подачу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tiếp tục lại việc tiêm insulin"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resume Delivery"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "恢复输注"
+            "state" : "new",
+            "value" : "Resume Delivery"
           }
         }
       }
@@ -15407,6 +21540,12 @@
     "Resuming" : {
       "comment" : "Title text for button when insulin delivery is in the process of being resumed",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "استئناف"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15439,7 +21578,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Resuming"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Resuming"
           }
         },
@@ -15449,13 +21594,7 @@
             "value" : "Ripresa in corso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再開中"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gjenopptar"
@@ -15473,22 +21612,28 @@
             "value" : "Wznawianie"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resuming"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Retomando"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se reia"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Возобновляется"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obnovuje sa"
           }
         },
         "sv" : {
@@ -15503,16 +21648,28 @@
             "value" : "Devam ediyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відновлюється"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang tiếp tục lại"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resuming"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "恢复中"
+            "state" : "new",
+            "value" : "Resuming"
           }
         }
       }
@@ -15520,6 +21677,12 @@
     "Review and Save Settings" : {
       "comment" : "title for summary description section",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Review and Save Settings"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15550,13 +21713,25 @@
             "value" : "Vérifier et enregistrer les paramètres"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Review and Save Settings"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Review and Save Settings"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rivedi e salva le impostazioni"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Se gjennom og lagre innstillinger"
@@ -15574,16 +21749,28 @@
             "value" : "Przejrzyj i zapisz ustawienia"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Revizuiește și Salvează Setările"
+            "state" : "new",
+            "value" : "Review and Save Settings"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Review and Save Settings"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Просмотр и сохранение настроек"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Review and Save Settings"
           }
         },
         "sv" : {
@@ -15597,12 +21784,42 @@
             "state" : "translated",
             "value" : "Ayarları Gözden Geçir ve Kaydet"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Review and Save Settings"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Review and Save Settings"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Review and Save Settings"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Review and Save Settings"
+          }
         }
       }
     },
     "Review your therapy settings below. If you’d like to edit any of these settings, tap Back to go back to that screen." : {
       "comment" : "Description of how to interact with summary screen",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Review your therapy settings below. If you’d like to edit any of these settings, tap Back to go back to that screen."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15633,13 +21850,25 @@
             "value" : "Vérifiez vos réglages de thérapie ci-dessous. Si vous souhaitez modifier l'un de ces paramètres, appuyez sur Retour pour revenir à cet écran."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Review your therapy settings below. If you’d like to edit any of these settings, tap Back to go back to that screen."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Review your therapy settings below. If you’d like to edit any of these settings, tap Back to go back to that screen."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Controlla le impostazioni della terapia. Se desideri modificare una di queste impostazioni, tocca \"Indietro\" per tornare a quella schermata."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Se gjennom innstillingene dine nedenfor. Om du vil endre noen av disse, trykk \"Tilbake\" for å gå til det skjermbildet."
@@ -15657,16 +21886,28 @@
             "value" : "Przejrzyj ustawienia terapii. Jeśli chcesz edytować dowolne z tych ustawień, kliknij Wróć, aby przejść do poprzedniego ekranu."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Revizuiți setările de terapie de mai jos. Dacă doriți să editați oricare dintre aceste setări, apăsați Înapoi pentru a reveni la acel ecran."
+            "state" : "new",
+            "value" : "Review your therapy settings below. If you’d like to edit any of these settings, tap Back to go back to that screen."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Review your therapy settings below. If you’d like to edit any of these settings, tap Back to go back to that screen."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Просмотрите настройки терапии ниже. Если вы хотите изменить какие-либо из этих настроек, нажмите Назад"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Review your therapy settings below. If you’d like to edit any of these settings, tap Back to go back to that screen."
           }
         },
         "sv" : {
@@ -15680,6 +21921,30 @@
             "state" : "translated",
             "value" : "Aşağıdaki tedavi ayarlarınızı gözden geçirin. Bu ayarlardan herhangi birini düzenlemek isterseniz, o ekrana geri dönmek için Geri'ye dokunun."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Review your therapy settings below. If you’d like to edit any of these settings, tap Back to go back to that screen."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Review your therapy settings below. If you’d like to edit any of these settings, tap Back to go back to that screen."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Review your therapy settings below. If you’d like to edit any of these settings, tap Back to go back to that screen."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Review your therapy settings below. If you’d like to edit any of these settings, tap Back to go back to that screen."
+          }
         }
       }
     },
@@ -15688,7 +21953,7 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Running"
           }
         },
@@ -15724,7 +21989,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Running"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Running"
           }
         },
@@ -15734,13 +22005,7 @@
             "value" : "Esecuzione in corso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "動作中"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kjører"
@@ -15758,22 +22023,28 @@
             "value" : "Pracuje"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Running"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Executando"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se rulează"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Выполнение"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Running"
           }
         },
         "sv" : {
@@ -15788,10 +22059,22 @@
             "value" : "Çalışıyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Running"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang chạy"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Running"
           }
         },
         "zh-Hans" : {
@@ -15805,10 +22088,10 @@
     "Save" : {
       "comment" : "Button text for saving glucose correction range schedule\nButton text for saving insulin sensitivity schedule\nThe button text for saving on a configuration page",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Uložit"
+            "value" : "إحفظ"
           }
         },
         "da" : {
@@ -15826,7 +22109,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Agregar"
+            "value" : "Guardar"
           }
         },
         "fi" : {
@@ -15843,8 +22126,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Save"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elment"
           }
         },
         "it" : {
@@ -15853,13 +22142,7 @@
             "value" : "Salva"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lagre"
@@ -15877,16 +22160,16 @@
             "value" : "Zapisz"
           }
         },
-        "pt-BR" : {
+        "pt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Salvar"
           }
         },
-        "ro" : {
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Salvează"
+            "value" : "Salvar"
           }
         },
         "ru" : {
@@ -15913,16 +22196,28 @@
             "value" : "Kaydet"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зберегти"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lưu"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "保存"
+            "value" : "保存​​"
           }
         }
       }
@@ -15930,6 +22225,12 @@
     "Save Basal Rates?" : {
       "comment" : "Alert title for confirming basal rates outside the recommended range",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Basal Rates?"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15960,13 +22261,25 @@
             "value" : "Enregistrer les débits basaux?"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Basal Rates?"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Basal Rates?"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Salvare velocità basali?"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lagre basaldose?"
@@ -15984,16 +22297,28 @@
             "value" : "Zapisać Dawkę Podstawową?"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salvați ratele bazale?"
+            "state" : "new",
+            "value" : "Save Basal Rates?"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Basal Rates?"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Сохранить базальные дозы?"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Basal Rates?"
           }
         },
         "sv" : {
@@ -16007,12 +22332,42 @@
             "state" : "translated",
             "value" : "Bazal Oranlar Kaydedilsin mi?"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Basal Rates?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Basal Rates?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Basal Rates?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Basal Rates?"
+          }
         }
       }
     },
     "Save Carb Ratios?" : {
       "comment" : "Alert title for confirming carb ratios outside the recommended range",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Carb Ratios?"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16043,13 +22398,25 @@
             "value" : "Enregistrer les Ratios?"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Carb Ratios?"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Carb Ratios?"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Salvare rapporti carboidrati?"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lagre Karbo forhold?"
@@ -16067,16 +22434,28 @@
             "value" : "Zapisać współczynniki węglowodanowe?"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salvați rațiile insulina carbohidrați?"
+            "state" : "new",
+            "value" : "Save Carb Ratios?"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Carb Ratios?"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Сохранить соотношение углеводов?"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Carb Ratios?"
           }
         },
         "sv" : {
@@ -16090,12 +22469,42 @@
             "state" : "translated",
             "value" : "Karb Oranlarını Kaydet?"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Carb Ratios?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Carb Ratios?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Carb Ratios?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Carb Ratios?"
+          }
         }
       }
     },
     "Save Correction Range(s)?" : {
       "comment" : "Alert title for confirming correction ranges outside the recommended range",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Correction Range(s)?"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16126,13 +22535,25 @@
             "value" : "Enregistrer les plages de correction?"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Correction Range(s)?"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Correction Range(s)?"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Salvare intervallo di correzione?"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lagre korrigeringsområde(er)?"
@@ -16150,16 +22571,28 @@
             "value" : "Zapisz Zakres Docelowy?"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salvați intervalul (intervalele) de corecție?"
+            "state" : "new",
+            "value" : "Save Correction Range(s)?"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Correction Range(s)?"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Сохранить диапазон(ы) коррекции?"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Correction Range(s)?"
           }
         },
         "sv" : {
@@ -16173,12 +22606,42 @@
             "state" : "translated",
             "value" : "Düzeltme Aralığı/Aralıkları Kaydedilsin mi?"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Correction Range(s)?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Correction Range(s)?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Correction Range(s)?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Correction Range(s)?"
+          }
         }
       }
     },
     "Save Delivery Limits?" : {
       "comment" : "Alert title for confirming delivery limits outside the recommended range",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Delivery Limits?"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16209,13 +22672,25 @@
             "value" : "Enregistrer les limites d'injection?"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Delivery Limits?"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Delivery Limits?"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Salvare limiti di erogazione?"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lagre leveringsgrenser?"
@@ -16233,16 +22708,28 @@
             "value" : "Zapisać limity podaży?"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salvați limitele de administrare?"
+            "state" : "new",
+            "value" : "Save Delivery Limits?"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Delivery Limits?"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Сохранить пределы подачи?"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Delivery Limits?"
           }
         },
         "sv" : {
@@ -16256,12 +22743,42 @@
             "state" : "translated",
             "value" : "İletim Limitleri Kaydedilsin mi?"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Delivery Limits?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Delivery Limits?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Delivery Limits?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Delivery Limits?"
+          }
         }
       }
     },
     "Save Glucose Safety Limit?" : {
       "comment" : "Alert title for confirming a glucose safety limit outside the recommended range",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Glucose Safety Limit?"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16298,13 +22815,19 @@
             "value" : "האם לשמור את הגדרת הבטיחות?"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Glucose Safety Limit?"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Salvare limite di sicurezza della glicemia?"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lagre sikkerhetsbegrensning for blodsukker?"
@@ -16322,16 +22845,28 @@
             "value" : "Zapisać bezpieczny limit glukozy?"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salvați limita de siguranță pentru glicemie?"
+            "state" : "new",
+            "value" : "Save Glucose Safety Limit?"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Glucose Safety Limit?"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Сохранить безопасный предел глюкозы?"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Glucose Safety Limit?"
           }
         },
         "sv" : {
@@ -16345,12 +22880,42 @@
             "state" : "translated",
             "value" : "KŞ Güvenlik Limiti Kaydedilsin mi?"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Glucose Safety Limit?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Glucose Safety Limit?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Glucose Safety Limit?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Glucose Safety Limit?"
+          }
         }
       }
     },
     "Save Insulin Sensitivities?" : {
       "comment" : "Alert title for confirming insulin sensitivities outside the recommended range",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Insulin Sensitivities?"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16381,13 +22946,25 @@
             "value" : "Enregistrer les paramètres de sensibilité à l'insuline?"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Insulin Sensitivities?"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Insulin Sensitivities?"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Salvare sensibilità insulinica?"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lagre Insulinsensitivitet?"
@@ -16405,16 +22982,28 @@
             "value" : "Zapisać Współczynnik Wrażliwości na insulinę?"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salvați sensibilitatea la insulină?"
+            "state" : "new",
+            "value" : "Save Insulin Sensitivities?"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Insulin Sensitivities?"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Сохранить чувствительность к инсулину?"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Insulin Sensitivities?"
           }
         },
         "sv" : {
@@ -16428,12 +23017,42 @@
             "state" : "translated",
             "value" : "İnsülin Hassasiyeti Kaydedilsin mi?"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Insulin Sensitivities?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Insulin Sensitivities?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Insulin Sensitivities?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Insulin Sensitivities?"
+          }
         }
       }
     },
     "Save Pre-Meal Range?" : {
       "comment" : "Alert title for confirming pre-meal range overrides outside the recommended range",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Pre-Meal Range?"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16464,13 +23083,25 @@
             "value" : "Enregistrer la zone de pré-repas?"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Pre-Meal Range?"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Pre-Meal Range?"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Salvare intervallo pre-pasto?"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lagre forhåndsmåltid?"
@@ -16488,16 +23119,28 @@
             "value" : "Zapisać zakres przed posiłkiem?"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salvează Interval preprandial?"
+            "state" : "new",
+            "value" : "Save Pre-Meal Range?"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Pre-Meal Range?"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Сохранить диапазон до еды?"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Pre-Meal Range?"
           }
         },
         "sv" : {
@@ -16511,12 +23154,42 @@
             "state" : "translated",
             "value" : "Yemek Öncesi Aralığı Kaydedilsin mi?"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Pre-Meal Range?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Pre-Meal Range?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Pre-Meal Range?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Pre-Meal Range?"
+          }
         }
       }
     },
     "Save Workout Range?" : {
       "comment" : "Alert title for confirming workout range overrides outside the recommended range",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Workout Range?"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16547,13 +23220,25 @@
             "value" : "Enregistrer la fourchette exercice?"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Workout Range?"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Workout Range?"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Salvare intervallo di allenamento?"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lagre treningsområde?"
@@ -16571,16 +23256,28 @@
             "value" : "Zapisać zakres treningu?"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salvați intervalul țintă pentru antrenament?"
+            "state" : "new",
+            "value" : "Save Workout Range?"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Workout Range?"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Сохранить диапазон для физнагрузки?"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Workout Range?"
           }
         },
         "sv" : {
@@ -16594,16 +23291,40 @@
             "state" : "translated",
             "value" : "Egzersiz Aralığını Kaydet?"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Workout Range?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Workout Range?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Workout Range?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save Workout Range?"
+          }
         }
       }
     },
     "Saving..." : {
       "comment" : "The button text during saving on a configuration page",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ukládám..."
+            "state" : "new",
+            "value" : "Saving..."
           }
         },
         "da" : {
@@ -16615,7 +23336,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Speichere…"
+            "value" : "Speichern..."
           }
         },
         "es" : {
@@ -16624,19 +23345,37 @@
             "value" : "Guardando..."
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Saving..."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sauvegarde en cours..."
+            "value" : "Sauvegarde..."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Saving..."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mentés..."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Salvataggio in corso..."
+            "value" : "Sto salvando..."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lagrer..."
@@ -16654,10 +23393,16 @@
             "value" : "Zapisywanie..."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Salvare..."
+            "value" : "Salvando..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salvando..."
           }
         },
         "ru" : {
@@ -16669,13 +23414,43 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ukladá sa..."
+            "value" : "Ukladanie..."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sparar..."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kaydediliyor..."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Збереження..."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang lưu..."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Saving..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在保存..."
           }
         }
       }
@@ -16684,6 +23459,12 @@
       "comment" : "The section header text for a scheduled override",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "SCHEDULED OVERRIDE"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16716,7 +23497,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "SCHEDULED OVERRIDE"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "SCHEDULED OVERRIDE"
           }
         },
@@ -16726,13 +23513,7 @@
             "value" : "OVERRIDE PIANIFICATO"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SCHEDULED OVERRIDE"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "PLANLAGT OVERSTYRING"
@@ -16750,22 +23531,28 @@
             "value" : "ZAPLANOWANE CELU TYMCZASOWEGO"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "SCHEDULED OVERRIDE"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "SOBREPOSIÇÃO AGENDADA"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ÎNLOCUIRE PLANIFICATĂ"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ЗАПЛАНИРОВАННОЕ ВЫПОЛНЕНИЕ ИЗМЕНЕНИЙ"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "SCHEDULED OVERRIDE"
           }
         },
         "sv" : {
@@ -16780,9 +23567,21 @@
             "value" : "PLANLANMIŞ GEÇERSİZ KILMA"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "SCHEDULED OVERRIDE"
+          }
+        },
         "vi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "SCHEDULED OVERRIDE"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "SCHEDULED OVERRIDE"
           }
         },
@@ -16797,6 +23596,12 @@
     "SCHEDULED PRESET" : {
       "comment" : "The section header text for a scheduled custom preset",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "SCHEDULED PRESET"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16827,13 +23632,25 @@
             "value" : "PRÉRÉGLAGE PROGRAMMÉ"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "SCHEDULED PRESET"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "SCHEDULED PRESET"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "PRESET PROGRAMMATO"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "PLANLAGT OVERRIDE"
@@ -16851,16 +23668,28 @@
             "value" : "Lista Celów"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "PRESETARE PROGRAMATĂ"
+            "state" : "new",
+            "value" : "SCHEDULED PRESET"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "SCHEDULED PRESET"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ПРЕДУСТАНОВКА ПО РАСПИСАНИЮ"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "SCHEDULED PRESET"
           }
         },
         "sv" : {
@@ -16874,11 +23703,41 @@
             "state" : "translated",
             "value" : "PLANLANMIŞ ÖN AYAR"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "SCHEDULED PRESET"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "SCHEDULED PRESET"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "SCHEDULED PRESET"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "SCHEDULED PRESET"
+          }
         }
       }
     },
     "Selected" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selected"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16891,10 +23750,34 @@
             "value" : "Ausgewählt"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selected"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selected"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sélectionné"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selected"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selected"
           }
         },
         "it" : {
@@ -16903,7 +23786,7 @@
             "value" : "Selezionato"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Valgt"
@@ -16921,10 +23804,16 @@
             "value" : "Wybrany"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selectat"
+            "state" : "new",
+            "value" : "Selected"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selected"
           }
         },
         "ru" : {
@@ -16933,10 +23822,46 @@
             "value" : "Выбрано"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selected"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vald"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Seçilmiş"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selected"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selected"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selected"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selected"
           }
         }
       }
@@ -16944,6 +23869,12 @@
     "Slow" : {
       "comment" : "Section title for slow absorbing food",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Slow"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16976,7 +23907,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Slow"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Slow"
           }
         },
@@ -16986,13 +23923,7 @@
             "value" : "Lento"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "遅め"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Langsom"
@@ -17010,22 +23941,28 @@
             "value" : "Wolna"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Slow"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lenta"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lentă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Медленная"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Slow"
           }
         },
         "sv" : {
@@ -17040,10 +23977,22 @@
             "value" : "Yavaş"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Slow"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "chậm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Slow"
           }
         },
         "zh-Hans" : {
@@ -17057,6 +24006,12 @@
     "Some users choose a value 2, 3, or 4 times their highest scheduled basal rate." : {
       "comment" : "Information about typical maximum basal rates",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Some users choose a value 2, 3, or 4 times their highest scheduled basal rate."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17087,13 +24042,25 @@
             "value" : "Certains utilisateurs choisissent une valeur 2, 3 ou 4 fois supérieure à leur débit basal programmé le plus élevé."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Some users choose a value 2, 3, or 4 times their highest scheduled basal rate."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Some users choose a value 2, 3, or 4 times their highest scheduled basal rate."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alcuni utenti scelgono un valore pari a 2, 3 o 4 volte la velocità basale pianificata massima."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Noen brukere velger en verdi 2, 3 eller 4 ganger den høyeste planlagte basaldosen."
@@ -17111,16 +24078,28 @@
             "value" : "Niektórzy użytkownicy wybierają wartość 2, 3 lub 4 razy większą niż ich najwyższa zaplanowana dawka podstawowa."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unii utilizatori aleg o valoare de 2, 3 sau 4 ori cea mai mare rată bazală programată."
+            "state" : "new",
+            "value" : "Some users choose a value 2, 3, or 4 times their highest scheduled basal rate."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Some users choose a value 2, 3, or 4 times their highest scheduled basal rate."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Некоторые пользователи выбирают значение, в 2, 3 или 4 раза превышающее их самую высокую запланированную базальную скорость."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Some users choose a value 2, 3, or 4 times their highest scheduled basal rate."
           }
         },
         "sv" : {
@@ -17134,12 +24113,42 @@
             "state" : "translated",
             "value" : "Bazı kullanıcılar, programlanan en yüksek bazal oranının 2, 3 veya 4 katı bir değer seçer."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Some users choose a value 2, 3, or 4 times their highest scheduled basal rate."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Some users choose a value 2, 3, or 4 times their highest scheduled basal rate."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Some users choose a value 2, 3, or 4 times their highest scheduled basal rate."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Some users choose a value 2, 3, or 4 times their highest scheduled basal rate."
+          }
         }
       }
     },
     "Start Time" : {
       "comment" : "The text for the custom preset start time",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Start Time"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17172,7 +24181,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Start Time"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Start Time"
           }
         },
@@ -17182,13 +24197,7 @@
             "value" : "Orario di inizio"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開始時間"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Starttidspunkt"
@@ -17206,22 +24215,28 @@
             "value" : "Czas rozpoczęcia"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Start Time"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hora de Início"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oră începere"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Время начала"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Start Time"
           }
         },
         "sv" : {
@@ -17236,10 +24251,22 @@
             "value" : "Başlangıç zamanı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Start Time"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Giờ bắt đầu"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Start Time"
           }
         },
         "zh-Hans" : {
@@ -17253,6 +24280,12 @@
     "Starting Temp Basal" : {
       "comment" : "Title text for suspend resume button when temp basal starting",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بدء الجرعة الأساسية المؤقتة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17285,7 +24318,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Starting Temp Basal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Starting Temp Basal"
           }
         },
@@ -17295,13 +24334,7 @@
             "value" : "Attivazione velocità basale temporanea in corso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時基礎を開始"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Starter temp-basal"
@@ -17310,7 +24343,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tijdelijk Basaal Starten"
+            "value" : "Tijdelijk basaal starten"
           }
         },
         "pl" : {
@@ -17319,22 +24352,28 @@
             "value" : "Rozpoczynanie tymczasowej dawki podstawowej"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Starting Temp Basal"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Iniciando Temp Basal"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pornire bazală temporară"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Время начала временного базала"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spustiť dočasný bazál"
           }
         },
         "sv" : {
@@ -17349,16 +24388,28 @@
             "value" : "Geçici Bazal başlatılıyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Час початку тимчасового базала"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang bắt đầu liều Basal tạm thời"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Starting Temp Basal"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "启动临时寄出"
+            "state" : "new",
+            "value" : "Starting Temp Basal"
           }
         }
       }
@@ -17366,6 +24417,12 @@
     "Submitted by %1$@, %2$@" : {
       "comment" : "Format for prescription descriptive text (1: providerName, 2: datePrescribed)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Submitted by %1$@, %2$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17396,13 +24453,25 @@
             "value" : "Soumis par %1$@, %2$@"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Submitted by %1$@, %2$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Submitted by %1$@, %2$@"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Inviato da %1$@, %2$@"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Innsendt av %1$@, %2$@"
@@ -17420,16 +24489,28 @@
             "value" : "Wprowadzone przez %1$@, %2$@"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trimis de %1$@, %2$@"
+            "state" : "new",
+            "value" : "Submitted by %1$@, %2$@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Submitted by %1$@, %2$@"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Представлено %1$@, %2$@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Submitted by %1$@, %2$@"
           }
         },
         "sv" : {
@@ -17443,15 +24524,45 @@
             "state" : "translated",
             "value" : "%2$@, %1$@ tarafından gönderildi"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Submitted by %1$@, %2$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Submitted by %1$@, %2$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Submitted by %1$@, %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Submitted by %1$@, %2$@"
+          }
         }
       }
     },
     "Support" : {
       "comment" : "Title for support section",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Support"
           }
         },
@@ -17475,7 +24586,7 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Support"
           }
         },
@@ -17485,15 +24596,21 @@
             "value" : "תמיכה"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Supporto"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Support"
           }
         },
@@ -17509,16 +24626,28 @@
             "value" : "Wsparcie"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asistenţă"
+            "state" : "new",
+            "value" : "Support"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Поддержка"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support"
           }
         },
         "sv" : {
@@ -17532,16 +24661,46 @@
             "state" : "translated",
             "value" : "Destek"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support"
+          }
         }
       }
     },
     "Suspend Delivery" : {
       "comment" : "Title text for button to suspend insulin delivery",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إيقاف التوصيل مؤقتًا"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Afbryd insulintilførsel"
+            "value" : "Pause Indgivelse"
           }
         },
         "de" : {
@@ -17565,12 +24724,18 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Suspendre l'administration"
+            "value" : "Suspendre la distribution"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Suspend Delivery"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Suspend Delivery"
           }
         },
@@ -17580,13 +24745,7 @@
             "value" : "Sospendi erogazione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "注入を一時停止"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pause leveranse"
@@ -17595,7 +24754,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Onderbreek Toediening"
+            "value" : "Onderbreek toediening"
           }
         },
         "pl" : {
@@ -17604,16 +24763,16 @@
             "value" : "Wstrzymaj podawanie"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspend Delivery"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Suspender Entrega"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suspendă administrarea"
           }
         },
         "ru" : {
@@ -17622,10 +24781,16 @@
             "value" : "Остановить подачу"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pozastaviť dávkovanie"
+          }
+        },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pausa insulintillförsel"
+            "value" : "Pausa pump"
           }
         },
         "tr" : {
@@ -17634,10 +24799,22 @@
             "value" : "İletimi Askıya Al"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Призупинити Подачу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tạm ngưng liều insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspend Delivery"
           }
         },
         "zh-Hans" : {
@@ -17651,6 +24828,12 @@
     "Suspending" : {
       "comment" : "Title text for button when insulin delivery is in the process of being stopped",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعليق"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17683,7 +24866,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Suspending"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Suspending"
           }
         },
@@ -17693,13 +24882,7 @@
             "value" : "Sospensione in corso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時停止中"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pauser"
@@ -17717,22 +24900,28 @@
             "value" : "Wstrzymywanie"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspending"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Suspendendo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se suspendă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Выполняется остановка"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pozastavovanie"
           }
         },
         "sv" : {
@@ -17747,22 +24936,40 @@
             "value" : "Askıya alınıyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виконується зупинка"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang tạm ngưng"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspending"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在暂停"
+            "state" : "new",
+            "value" : "Suspending"
           }
         }
       }
     },
     "Switch Preview State" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Switch Preview State"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17793,13 +25000,25 @@
             "value" : "Changer l'état d'aperçu"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Switch Preview State"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Switch Preview State"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cambia stato di anteprima"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bytt forhåndsvisningsstatus"
@@ -17817,16 +25036,28 @@
             "value" : "Przełącz podgląd"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schimbă către Stare Previzualizare"
+            "state" : "new",
+            "value" : "Switch Preview State"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Switch Preview State"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Состояние переключателя просмотра"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Switch Preview State"
           }
         },
         "sv" : {
@@ -17840,21 +25071,51 @@
             "state" : "translated",
             "value" : "Önizleme Durumunu Değiştir"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Switch Preview State"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Switch Preview State"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Switch Preview State"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Switch Preview State"
+          }
         }
       }
     },
     "Symbol" : {
       "comment" : "The text for the custom preset symbol setting",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Symbol"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Symbol"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Symbol"
           }
         },
@@ -17878,7 +25139,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Symbol"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Symbol"
           }
         },
@@ -17888,15 +25155,9 @@
             "value" : "Simbolo"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "シンボル"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Symbol"
           }
         },
@@ -17908,7 +25169,13 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Symbol"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Symbol"
           }
         },
@@ -17918,16 +25185,16 @@
             "value" : "Símbolo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Simbol"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Значок"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Symbol"
           }
         },
         "sv" : {
@@ -17942,9 +25209,21 @@
             "value" : "Sembol"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Symbol"
+          }
+        },
         "vi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Symbol"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Symbol"
           }
         },
@@ -17959,6 +25238,12 @@
     "Tap '+' to create a new custom preset." : {
       "comment" : "Text directing the user to configure their first custom preset",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap '+' to create a new custom preset."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17989,13 +25274,25 @@
             "value" : "Appuyez sur '+' pour créer un nouveau préréglage personnalisé."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap '+' to create a new custom preset."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap '+' to create a new custom preset."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tocca \"+\" per creare una nuova programmazione."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trykk på '+' for å opprette en ny 'Override'."
@@ -18013,16 +25310,28 @@
             "value" : "Stuknij „+”, aby utworzyć nowy Cel Tymczasowy"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apasă '+' pentru a crea o nouă presetare personalizată."
+            "state" : "new",
+            "value" : "Tap '+' to create a new custom preset."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap '+' to create a new custom preset."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Нажмите «+», чтобы создать новый пользовательский пресет."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap '+' to create a new custom preset."
           }
         },
         "sv" : {
@@ -18036,15 +25345,81 @@
             "state" : "translated",
             "value" : "Yeni bir özel ön ayar oluşturmak için '+' düğmesine dokunun."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap '+' to create a new custom preset."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap '+' to create a new custom preset."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap '+' to create a new custom preset."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap '+' to create a new custom preset."
+          }
         }
       }
     },
     "Tap back to continue exploring the rest of the %@ interface." : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap back to continue exploring the rest of the %@ interface."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tryk på tilbage for at fortsætte med at udforske resten af %@-grænsefladen."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap back to continue exploring the rest of the %@ interface."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap back to continue exploring the rest of the %@ interface."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap back to continue exploring the rest of the %@ interface."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap back to continue exploring the rest of the %@ interface."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap back to continue exploring the rest of the %@ interface."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap back to continue exploring the rest of the %@ interface."
           }
         },
         "it" : {
@@ -18053,10 +25428,16 @@
             "value" : "Tocca \"Indietro\" per continuare a esplorare il resto dell'interfaccia %@ ."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trykk på tilbake for å fortsette å utforske resten av %@-grensesnittet."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap back to continue exploring the rest of the %@ interface."
           }
         },
         "pl" : {
@@ -18065,10 +25446,64 @@
             "value" : "Stuknij przycisk Wstecz, aby kontynuować przeglądanie pozostałej części interfejsu %@."
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap back to continue exploring the rest of the %@ interface."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap back to continue exploring the rest of the %@ interface."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Нажмите «Назад», чтобы продолжить изучение остальной части %@ интерфейса ."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap back to continue exploring the rest of the %@ interface."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tryck tillbaka för att fortsätta utforska resten av %@ gränssnittet."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap back to continue exploring the rest of the %@ interface."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap back to continue exploring the rest of the %@ interface."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap back to continue exploring the rest of the %@ interface."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap back to continue exploring the rest of the %@ interface."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap back to continue exploring the rest of the %@ interface."
           }
         }
       }
@@ -18076,10 +25511,10 @@
     "Tap to set" : {
       "comment" : "The empty-state text for a configuration value",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Klepnutím nastavit"
+            "state" : "new",
+            "value" : "Tap to set"
           }
         },
         "da" : {
@@ -18114,7 +25549,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Tap to set"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Tap to set"
           }
         },
@@ -18124,13 +25565,7 @@
             "value" : "Tocca per impostare"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "タップして確定"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trykk for å angi"
@@ -18148,16 +25583,16 @@
             "value" : "Kliknij, aby ustawić"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap to set"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toque para Definir"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apăsați pentru setare"
           }
         },
         "ru" : {
@@ -18184,10 +25619,22 @@
             "value" : "Ayarlamak için dokunun"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap to set"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chạm để cài đặt"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap to set"
           }
         },
         "zh-Hans" : {
@@ -18201,6 +25648,12 @@
     "Target Range" : {
       "comment" : "The text for the custom preset target range setting",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Target Range"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18233,7 +25686,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Target Range"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Target Range"
           }
         },
@@ -18243,13 +25702,7 @@
             "value" : "Intervallo target"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ターゲット範囲"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Målområde"
@@ -18267,22 +25720,28 @@
             "value" : "Zakres docelowy"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Target Range"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Intervalo Meta"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Interval țintă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Целевой диапазон"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Target Range"
           }
         },
         "sv" : {
@@ -18297,10 +25756,22 @@
             "value" : "Hedef Aralığı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Target Range"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Phạm vi Mục tiêu"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Target Range"
           }
         },
         "zh-Hans" : {
@@ -18314,6 +25785,12 @@
     "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes." : {
       "comment" : "Description of pre-meal mode",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18323,7 +25800,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Senke Dein Blutzuckerziel vor einer Mahlzeit vorübergehend ab, um Blutzuckerspitzen nach der Mahlzeit auszugleichen."
+            "value" : "Senke Deinen Blutzuckerziel vor einer Mahlzeit vorübergehend ab, um Blutzuckerspitzen nach der Mahlzeit auszugleichen."
           }
         },
         "es" : {
@@ -18344,16 +25821,28 @@
             "value" : "Diminue temporairement votre cible de glycémie avant un repas pour influer sur les pics d'hyperglycémie post-repas."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Abbassa temporaneamente il tuo target glicemico prima di un pasto per influenzare i picchi glicemici postprandiali."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reduser blodsukkermålet ditt midlertidig før et måltid for å påvirke blodsukkertoppene etter måltidet."
+            "value" : "Reduser glukosemålet ditt midlertidig før et måltid for å påvirke glukosetoppene etter måltidet."
           }
         },
         "nl" : {
@@ -18368,16 +25857,28 @@
             "value" : "Tymczasowo obniż docelowy poziom glukozy przed posiłkiem, aby ograniczyć gwałtowny wzrost glukozy po posiłku."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reduceți temporar glicemia țintă înainte de masă pentru a avea un impact asupra vârfurilor postprandiale."
+            "state" : "new",
+            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Временно понизьте целевое значение уровня глюкозы перед едой, чтобы уменьшить пики глюкозы после еды."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
           }
         },
         "sv" : {
@@ -18391,12 +25892,42 @@
             "state" : "translated",
             "value" : "Yemek sonrası KŞ artışlarını engellemek için yemekten önce KŞ hedefinizi geçici olarak düşürün."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tạm thời hạ mục tiêu đường huyết trước bữa ăn để giảm mức tăng đường huyết sau ăn."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily lower your glucose target before a meal to impact post-meal glucose spikes."
+          }
         }
       }
     },
     "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events." : {
       "comment" : "Description of workout mode",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18427,13 +25958,25 @@
             "value" : "Augmente temporairement votre cible de glycémie avant, pendant ou après l'activité physique pour réduire le risque d'hypoglycémie."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aumenta temporaneamente il target glicemico prima, durante o dopo l'attività fisica per ridurre il rischio di eventi ipoglicemici."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Øk blodsukkermålet ditt midlertidig før, under eller etter fysisk aktivitet for å redusere risikoen for hendelser med lavt blodsukker."
@@ -18442,7 +25985,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Verhoog tijdelijk je glucosedoel voor, gedurende, of na fysieke activiteit om het risico op lage glucosegebeurtenissen te verminderen."
+            "value" : "Verhoog tijdelijk je glucosedoel voor, gedurende of na fysieke activiteit om het risico van lage glucosewaarden te verminderen."
           }
         },
         "pl" : {
@@ -18451,16 +25994,28 @@
             "value" : "Tymczasowo zwiększ docelowy poziom glukozy przed, w trakcie lub po aktywności fizycznej, aby zmniejszyć ryzyko wystąpienia niskiego poziomu glukozy (Hipoglikemia)."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creșteți temporar valoarea ținta a glicemiei înainte, în timpul sau după activitatea fizică pentru a reduce riscul de apariție a hipoglicemiei."
+            "state" : "new",
+            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Временно повышайте целевой уровень глюкозы до, во время или после физической активности, чтобы снизить риск развития событий, связанных с низким уровнем глюкозы."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
           }
         },
         "sv" : {
@@ -18474,6 +26029,30 @@
             "state" : "translated",
             "value" : "Düşük KŞ riskini azaltmak için fiziksel aktivite öncesinde, sırasında veya sonrasında KŞ hedefinizi geçici olarak yükseltin."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tạm thời nâng mục tiêu đường huyết trước, trong hoặc sau khi hoạt động thể chất để giảm nguy cơ hạ đường huyết."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events."
+          }
         }
       }
     },
@@ -18481,6 +26060,12 @@
       "comment" : "The title for the override selection screen",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporary Override"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18513,7 +26098,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Temporary Override"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Temporary Override"
           }
         },
@@ -18523,13 +26114,7 @@
             "value" : "Override temporaneo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時的オーバーライト"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Midlertidig overstyring"
@@ -18547,22 +26132,28 @@
             "value" : "Zdalny Cel Tymczasowy"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporary Override"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sobreposição Temporária"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Înlocuire temporară"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Временный"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporary Override"
           }
         },
         "sv" : {
@@ -18577,10 +26168,22 @@
             "value" : "Geçici Geçersiz Kılma"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporary Override"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chồng liều tạm thời"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporary Override"
           }
         },
         "zh-Hans" : {
@@ -18593,51 +26196,87 @@
     },
     "Test" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Test"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Test"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Test"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Test"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Test"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Test"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Test"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Test"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Test"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Test"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Test"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Test"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Test"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Test"
           }
         },
@@ -18647,9 +26286,45 @@
             "value" : "Тест"
           }
         },
-        "tr" : {
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Test"
+          }
+        },
+        "sv" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Test"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Test"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Test"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Test"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Test"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Test"
           }
         }
@@ -18658,6 +26333,12 @@
     "than your Correction Range." : {
       "comment" : "Information about pre-meal range relative to correction range\nInformation about workout range relative to correction range",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "than your Correction Range."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18688,13 +26369,25 @@
             "value" : "que votre plage de correction."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "than your Correction Range."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "than your Correction Range."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "rispetto al tuo intervallo di correzione."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "enn ditt korreksjonsområde."
@@ -18712,16 +26405,28 @@
             "value" : "niż twój zakres docelowy."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "față de intervalul de corecții."
+            "state" : "new",
+            "value" : "than your Correction Range."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "than your Correction Range."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "чем ваш диапазон коррекции."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "than your Correction Range."
           }
         },
         "sv" : {
@@ -18735,76 +26440,166 @@
             "state" : "translated",
             "value" : "düzeltme Aralığınızdan daha fazla."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "than your Correction Range."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "than your Correction Range."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "than your Correction Range."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "than your Correction Range."
+          }
         }
       }
     },
     "The currently selected fast acting insulin model will be used as a default." : {
       "comment" : "Description for selection when no insulin type is selected.",
       "localizations" : {
-        "da" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Den aktuelt valgte hurtigtvirkende insulinmodel anvendes som standard."
+            "value" : "سيتم استخدام نموذج الأنسولين سريع المفعول المحدد حالياً كافتراضي."
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The currently selected fast acting insulin model will be used as a default."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das aktuell ausgewählte schnell wirkende Insulinmodell wird als Standard verwendet."
+            "state" : "new",
+            "value" : "The currently selected fast acting insulin model will be used as a default."
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se utilizará por defecto el modelo de insulina de acción rápida actualmente seleccionado."
+            "state" : "new",
+            "value" : "The currently selected fast acting insulin model will be used as a default."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The currently selected fast acting insulin model will be used as a default."
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le modèle d'insuline à action rapide actuellement sélectionné sera utilisé par défaut."
+            "state" : "new",
+            "value" : "The currently selected fast acting insulin model will be used as a default."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The currently selected fast acting insulin model will be used as a default."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The currently selected fast acting insulin model will be used as a default."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Il modello d'insulina ad azione rapida attualmente selezionato verrà utilizzato come predefinito."
+            "value" : "Il modello di insulina ad azione rapida attualmente selezionato sarà usato come predefinito."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Den for øyeblikket valgte hurtigvirkende insulinmodellen vil bli brukt som standard."
+            "state" : "new",
+            "value" : "The currently selected fast acting insulin model will be used as a default."
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Het momenteel geselecteerde snelwerkende insulinemodel wordt als standaard gebruikt."
+            "value" : "Het momenteel gekozen model voor snelle insuline zal worden gebruikt als standaard."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktualnie wybrany model insuliny szybko działającej zostanie użyty jako domyślny."
+            "state" : "new",
+            "value" : "The currently selected fast acting insulin model will be used as a default."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelul de insulină cu acțiune rapidă selectat în prezent va fi utilizat ca implicit."
+            "state" : "new",
+            "value" : "The currently selected fast acting insulin model will be used as a default."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The currently selected fast acting insulin model will be used as a default."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Выбранная в данный момент модель быстродействующего инсулина будет использоваться по умолчанию."
+            "value" : "Выбранная модель быстродействующего инсулина будет использоваться по умолчанию."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Použije sa aktuálne vybraný model rýchlopôsobiaceho inzulínu."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Den nuvarande snabbverkande insulinmodellen kommer att användas som standard."
           }
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "The currently selected fast acting insulin model will be used as a default."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "Şu anda seçili olan hızlı etkili insülin modeli varsayılan olarak kullanılacaktır."
+            "value" : "Вибрана на даний момент модель інсуліну швидкої дії використовуватиметься як стандартна."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mô hình insulin tác dụng nhanh hiện đang được chọn sẽ được sử dụng làm mặc định."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The currently selected fast acting insulin model will be used as a default."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The currently selected fast acting insulin model will be used as a default."
           }
         }
       }
@@ -18850,7 +26645,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "The legacy model used by Loop, allowing customization of action duration."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "The legacy model used by Loop, allowing customization of action duration."
           }
         },
@@ -18860,13 +26661,7 @@
             "value" : "Il modello legacy utilizzato da Loop, che consente la personalizzazione della durata dell'azione."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ループのレガシーモデルで、作用期間をカスタマイズできます。"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Den eldre modellen som brukes av Loop, tillater tilpasning av handlingsvarighet."
@@ -18884,22 +26679,28 @@
             "value" : "Model umożliwiający dostosowanie czasu działania insuliny."
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The legacy model used by Loop, allowing customization of action duration."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "O modelo antigo utilizado pelo Loop permitindo personalização da duração da ação."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelul vechi utilizat de Loop, permite personalizarea duratei de acțiune."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Устаревшая модель, используемая Loop, позволяющая настраивать продолжительность действия."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The legacy model used by Loop, allowing customization of action duration."
           }
         },
         "sv" : {
@@ -18914,10 +26715,22 @@
             "value" : "Loop tarafından kullanılan ve eylem süresinin özelleştirilmesine izin veren eski model."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The legacy model used by Loop, allowing customization of action duration."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mô hình cũ được Loop sử dụng, cho phép tùy chỉnh thời lượng hành động."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The legacy model used by Loop, allowing customization of action duration."
           }
         },
         "zh-Hans" : {
@@ -18932,6 +26745,12 @@
       "comment" : "Alert body displayed absorption time greater than max (1: maximum absorption time)",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The maximum absorption time is %@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18964,7 +26783,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "The maximum absorption time is %@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "The maximum absorption time is %@"
           }
         },
@@ -18974,13 +26799,7 @@
             "value" : "Il periodo di assorbimento massimo è %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最大吸収時間: %@"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maks absorbsjonstid er %@"
@@ -18998,22 +26817,28 @@
             "value" : "Maksymalny czas absorpcji wynosi %@"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The maximum absorption time is %@"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "O tempo máximo de absorção é %@"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Durata maximă de absorbție este de %@"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Максимальная длительность усвоения %@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The maximum absorption time is %@"
           }
         },
         "sv" : {
@@ -19028,10 +26853,22 @@
             "value" : "Maksimum emilim süresi %@"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The maximum absorption time is %@"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thời gian tiêu hóa tối đa là  %@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The maximum absorption time is %@"
           }
         },
         "zh-Hans" : {
@@ -19046,6 +26883,12 @@
       "comment" : "Alert body displayed for quantity greater than max (1: maximum quantity in grams)",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The maximum allowed amount is %@ grams"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19078,7 +26921,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "The maximum allowed amount is %@ grams"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "The maximum allowed amount is %@ grams"
           }
         },
@@ -19088,13 +26937,7 @@
             "value" : "La quantità massima permessa è %@ grammi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最大量: %@ g"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maks tillatt mengde er %@ gram"
@@ -19112,22 +26955,28 @@
             "value" : "Maksymalna dozwolona ilość wynosi %@ gramów"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The maximum allowed amount is %@ grams"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "A quantidade máxima permitida é %@ gramas"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cantitatea maximă admisă este de %@ grame"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Максимальное допустимое количество %@ грамм"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The maximum allowed amount is %@ grams"
           }
         },
         "sv" : {
@@ -19142,10 +26991,22 @@
             "value" : "İzin verilen maksimum miktar %@ gramdır"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The maximum allowed amount is %@ grams"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Khối lượng cho phép tối đa là %@ grams"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The maximum allowed amount is %@ grams"
           }
         },
         "zh-Hans" : {
@@ -19159,6 +27020,12 @@
     "The rapid-acting adult model assumes peak activity at 75 minutes." : {
       "comment" : "Information about adult insulin model",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The rapid-acting adult model assumes peak activity at 75 minutes."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19189,13 +27056,25 @@
             "value" : "Ce modèle \"Action rapide-Adulte\" est basé sur une activité maximale de l’insuline vers 75 minutes."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The rapid-acting adult model assumes peak activity at 75 minutes."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The rapid-acting adult model assumes peak activity at 75 minutes."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il modello adulto ad azione rapida assume il picco di attività a 75 minuti."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Den hurtigvirkende modellen for voksne antar maksimal insulinaktivitet etter 75 minutter."
@@ -19213,16 +27092,28 @@
             "value" : "Szybko działający model dla dorosłych zakłada szczytową aktywność po 75 minutach."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelul pentru adulți de acțiune rapidă presupune vârful de acțiune la 75 de minute."
+            "state" : "new",
+            "value" : "The rapid-acting adult model assumes peak activity at 75 minutes."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The rapid-acting adult model assumes peak activity at 75 minutes."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Быстродействующая взрослая модель предполагает пик активности через 75 минут."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The rapid-acting adult model assumes peak activity at 75 minutes."
           }
         },
         "sv" : {
@@ -19236,12 +27127,42 @@
             "state" : "translated",
             "value" : "Hızlı etkili yetişkin modeli, 75 dakikada en yüksek etkiyi varsayar."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The rapid-acting adult model assumes peak activity at 75 minutes."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The rapid-acting adult model assumes peak activity at 75 minutes."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The rapid-acting adult model assumes peak activity at 75 minutes."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The rapid-acting adult model assumes peak activity at 75 minutes."
+          }
         }
       }
     },
     "The rapid-acting child model assumes peak activity at 65 minutes." : {
       "comment" : "Information about child insulin model",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The rapid-acting child model assumes peak activity at 65 minutes."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19272,13 +27193,25 @@
             "value" : "Ce modèle \"Action rapide-Enfant\" est basé sur une activité maximale de l’insuline vers 65 minutes."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The rapid-acting child model assumes peak activity at 65 minutes."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The rapid-acting child model assumes peak activity at 65 minutes."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il modello del bambino ad azione rapida assume il picco di attività a 65 minuti."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Den hurtigvirkende modellen for barn antar maksimal insulinaktivitet etter 65 minutter."
@@ -19296,16 +27229,28 @@
             "value" : "Szybko działający model dziecka zakłada szczytową aktywność po 65 minutach."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelul pentru copii de acțiune rapidă presupune vârful de acțiune la 65 de minute."
+            "state" : "new",
+            "value" : "The rapid-acting child model assumes peak activity at 65 minutes."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The rapid-acting child model assumes peak activity at 65 minutes."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Быстродействующая детская модель предполагает пиковую активность через 65 минут."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The rapid-acting child model assumes peak activity at 65 minutes."
           }
         },
         "sv" : {
@@ -19319,12 +27264,42 @@
             "state" : "translated",
             "value" : "Hızlı etkili çocuk modeli, 65 dakikada en yüksek etkiyi varsayar."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The rapid-acting child model assumes peak activity at 65 minutes."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The rapid-acting child model assumes peak activity at 65 minutes."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The rapid-acting child model assumes peak activity at 65 minutes."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The rapid-acting child model assumes peak activity at 65 minutes."
+          }
         }
       }
     },
     "The schedule starts at midnight and cannot contain a rate of 0 U/hr." : {
       "comment" : "Information about basal rate scheduling",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The schedule starts at midnight and cannot contain a rate of 0 U/hr."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19355,13 +27330,25 @@
             "value" : "La définition de l'horaire commence à minuit et ne peut pas contenir un taux de 0 U/hr."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The schedule starts at midnight and cannot contain a rate of 0 U/hr."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The schedule starts at midnight and cannot contain a rate of 0 U/hr."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il programma inizia a mezzanotte e non può contenere una velocità di 0 U/ora."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tidsplanen starter ved midnatt, og kan ikke inneholde en basaldose på 0 E/time."
@@ -19379,16 +27366,28 @@
             "value" : "Harmonogram rozpoczyna się o północy i nie może zawierać dawki 0 J/h."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programul începe la miezul nopții și nu poate conține o rată bazala de 0 U/oră."
+            "state" : "new",
+            "value" : "The schedule starts at midnight and cannot contain a rate of 0 U/hr."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The schedule starts at midnight and cannot contain a rate of 0 U/hr."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Расписание начинается в полночь и не может содержать скорость 0 Ед/ч."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The schedule starts at midnight and cannot contain a rate of 0 U/hr."
           }
         },
         "sv" : {
@@ -19402,12 +27401,42 @@
             "state" : "translated",
             "value" : "Program gece yarısı başlar ve 0 Ü/sa bir oran içeremez."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The schedule starts at midnight and cannot contain a rate of 0 U/hr."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The schedule starts at midnight and cannot contain a rate of 0 U/hr."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The schedule starts at midnight and cannot contain a rate of 0 U/hr."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The schedule starts at midnight and cannot contain a rate of 0 U/hr."
+          }
         }
       }
     },
     "Therapy Settings" : {
       "comment" : "Therapy Settings screen title",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Therapy Settings"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19444,13 +27473,19 @@
             "value" : "תכנית טיפול"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Therapy Settings"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Impostazioni terapia"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Behandlingsinnstillinger"
@@ -19468,16 +27503,28 @@
             "value" : "Ustawienia terapii"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Setări Terapie"
+            "state" : "new",
+            "value" : "Therapy Settings"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Therapy Settings"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Настройки терапии"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Therapy Settings"
           }
         },
         "sv" : {
@@ -19491,12 +27538,42 @@
             "state" : "translated",
             "value" : "Tedavi Ayarları"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Therapy Settings"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Therapy Settings"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Therapy Settings"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Therapy Settings"
+          }
         }
       }
     },
     "This model assumes peak insulin activity at 19 minutes." : {
       "comment" : "Subtitle of afrezza preset",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 19 minutes."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19515,10 +27592,28 @@
             "value" : "Este modelo asume la actividad máxima de la insulina a los 19 minutos."
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 19 minutes."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ce modèle est basé sur un pic d'activité de l’insuline à 19 minutes."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 19 minutes."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 19 minutes."
           }
         },
         "it" : {
@@ -19527,7 +27622,7 @@
             "value" : "Questo modello presuppone il picco di attività insulinica a 19 minuti."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Denne modellen antar topp insulinaktivitet etter 19 minutter."
@@ -19545,10 +27640,16 @@
             "value" : "Model ten zakłada szczytową aktywność insuliny po 19 minutach."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acest model presupune vârful de acțiune al insulinei la 19 minute."
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 19 minutes."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 19 minutes."
           }
         },
         "ru" : {
@@ -19557,10 +27658,46 @@
             "value" : "Эта модель предполагает пик активности инсулина на 19 минуте."
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 19 minutes."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Denna modell antar en maximal aktivitet vid 19 minuter."
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bu model, 19. dakikada en yüksek insülin aktivitesini varsayar."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 19 minutes."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 19 minutes."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 19 minutes."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 19 minutes."
           }
         }
       }
@@ -19568,6 +27705,12 @@
     "This model assumes peak insulin activity at 55 minutes." : {
       "comment" : "Subtitle of Fiasp preset\nSubtitle of Lyumjev preset",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 55 minutes."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19598,13 +27741,25 @@
             "value" : "Ce modèle est basé sur un pic d'activité de l’insuline à 55 minutes."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 55 minutes."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 55 minutes."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Questo modello presuppone il picco di attività insulinica a 55 minuti."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Denne modellen antar maksimal insulinaktivitet etter 55 minutter."
@@ -19622,16 +27777,28 @@
             "value" : "Model ten zakłada szczytową aktywność insuliny po 55 minutach."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acest model presupune activitatea maximă a insulinei la 55 minute."
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 55 minutes."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 55 minutes."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Эта модель предполагает пик активности инсулина на 55 минуте."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 55 minutes."
           }
         },
         "sv" : {
@@ -19645,12 +27812,42 @@
             "state" : "translated",
             "value" : "Bu model, 55. dakikada en yüksek insülin aktivitesini varsayar."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 55 minutes."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 55 minutes."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 55 minutes."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 55 minutes."
+          }
         }
       }
     },
     "This model assumes peak insulin activity at 65 minutes." : {
       "comment" : "Subtitle of Rapid-Acting – Children preset",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 65 minutes."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19681,13 +27878,25 @@
             "value" : "Ce modèle est basé sur un pic d'activité de l’insuline à 65 minutes."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 65 minutes."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 65 minutes."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Questo modello presuppone il picco di attività insulinica a 65 minuti."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Denne modellen antar maksimal insulinaktivitet etter 65 minutter."
@@ -19705,16 +27914,28 @@
             "value" : "Model ten zakłada szczytową aktywność insuliny po 65 minutach."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acest model presupune activitatea maximă a insulinei la 65 minute."
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 65 minutes."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 65 minutes."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Эта модель предполагает пик активности инсулина на 65 минуте."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 65 minutes."
           }
         },
         "sv" : {
@@ -19728,12 +27949,42 @@
             "state" : "translated",
             "value" : "Bu model, 65 dakikada en yüksek insülin aktivitesini varsayar."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 65 minutes."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 65 minutes."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 65 minutes."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 65 minutes."
+          }
         }
       }
     },
     "This model assumes peak insulin activity at 75 minutes." : {
       "comment" : "Subtitle of Rapid-Acting – Adult preset",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 75 minutes."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19764,13 +28015,25 @@
             "value" : "Ce modèle est basé sur un pic d'activité de l’insuline à 75 minutes."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 75 minutes."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 75 minutes."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Questo modello presuppone il picco di attività insulinica a 75 minuti."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Denne modellen antar maksimal insulinaktivitet etter 75 minutter."
@@ -19788,16 +28051,28 @@
             "value" : "Model ten zakłada szczytową aktywność insuliny po 75 minutach."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acest model presupune activitatea maximă a insulinei la 75 minute."
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 75 minutes."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 75 minutes."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Эта модель предполагает пик активности инсулина на 75 минуте."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 75 minutes."
           }
         },
         "sv" : {
@@ -19811,15 +28086,81 @@
             "state" : "translated",
             "value" : "Bu model, 75 dakikada en yüksek insülin aktivitesini varsayar."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 75 minutes."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 75 minutes."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 75 minutes."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This model assumes peak insulin activity at 75 minutes."
+          }
         }
       }
     },
     "This section of the %@ app is unavailable in this simulator." : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This section of the %@ app is unavailable in this simulator."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Denne del af %@-appen er ikke tilgængelig i denne simulator."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This section of the %@ app is unavailable in this simulator."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This section of the %@ app is unavailable in this simulator."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This section of the %@ app is unavailable in this simulator."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This section of the %@ app is unavailable in this simulator."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This section of the %@ app is unavailable in this simulator."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This section of the %@ app is unavailable in this simulator."
           }
         },
         "it" : {
@@ -19828,10 +28169,16 @@
             "value" : "Questa sezione dell'app %@ non è disponibile in questo simulatore."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Denne delen av %@-appen er ikke tilgjengelig i denne simulatoren."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This section of the %@ app is unavailable in this simulator."
           }
         },
         "pl" : {
@@ -19840,10 +28187,64 @@
             "value" : "Ta sekcja aplikacji %@ jest niedostępna w tym symulatorze."
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This section of the %@ app is unavailable in this simulator."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This section of the %@ app is unavailable in this simulator."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Этот раздел %@ приложения  недоступен в этом симуляторе."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This section of the %@ app is unavailable in this simulator."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Denna del av %@ appen är inte tillgänglig i den här simulatorn."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This section of the %@ app is unavailable in this simulator."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This section of the %@ app is unavailable in this simulator."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This section of the %@ app is unavailable in this simulator."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This section of the %@ app is unavailable in this simulator."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This section of the %@ app is unavailable in this simulator."
           }
         }
       }
@@ -19851,6 +28252,12 @@
     "This setting will also determine a safety limit for automatic dosing. %1$@ will limit automatic delivery to keep the amount of active insulin below twice your maximum bolus." : {
       "comment" : "Information about maximum automated insulin on board (1: app name)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This setting will also determine a safety limit for automatic dosing. %1$@ will limit automatic delivery to keep the amount of active insulin below twice your maximum bolus."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19863,10 +28270,34 @@
             "value" : "Diese Einstellung bestimmt auch eine Sicherheitsgrenze für die automatische Dosierung. %1$@ begrenzt die automatische Abgabe, um die Menge an aktivem Insulin unter dem Doppelten Deines maximalen Bolus zu halten."
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This setting will also determine a safety limit for automatic dosing. %1$@ will limit automatic delivery to keep the amount of active insulin below twice your maximum bolus."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This setting will also determine a safety limit for automatic dosing. %1$@ will limit automatic delivery to keep the amount of active insulin below twice your maximum bolus."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ce réglage déterminera également une limite de sécurité pour le dosage automatique. %1$@ limitera l’administration automatique pour maintenir la quantité d’insuline active en dessous de deux fois votre bolus maximal."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This setting will also determine a safety limit for automatic dosing. %1$@ will limit automatic delivery to keep the amount of active insulin below twice your maximum bolus."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This setting will also determine a safety limit for automatic dosing. %1$@ will limit automatic delivery to keep the amount of active insulin below twice your maximum bolus."
           }
         },
         "it" : {
@@ -19875,7 +28306,7 @@
             "value" : "Questa impostazione determinerà anche un limite di sicurezza per il dosaggio automatico. %1$@ limiterà l'erogazione automatica per mantenere la quantità d'insulina attiva al di sotto del doppio del bolo massimo."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Denne innstillingen vil også bestemme en sikkerhetsgrense for automatisk dosering. %1$@ vil begrense automatisk tilførsel for å holde mengden aktivt insulin under det dobbelte av maksimal bolus."
@@ -19893,10 +28324,16 @@
             "value" : "Te ustawienia będą dodatkowo określać bezpieczny limit automatycznych dawek. %1$@ ograniczy automatyczne podawanie, do dwukrotności Twojego maksymalnego bolusa."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Această setare va determina, de asemenea, o limită de siguranță pentru administrarea automată. %1$@ va limita administrarea automată pentru a menține cantitatea de insulină activă sub dublul bolusului maxim."
+            "state" : "new",
+            "value" : "This setting will also determine a safety limit for automatic dosing. %1$@ will limit automatic delivery to keep the amount of active insulin below twice your maximum bolus."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This setting will also determine a safety limit for automatic dosing. %1$@ will limit automatic delivery to keep the amount of active insulin below twice your maximum bolus."
           }
         },
         "ru" : {
@@ -19905,10 +28342,40 @@
             "value" : "Эта настройка также определяет предел безопасности для автоматического введения инсулина. %1$@ ограничит автоматический ввод инсулина, чтобы количество активного инсулина не превышало удвоенного максимального болюса."
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This setting will also determine a safety limit for automatic dosing. %1$@ will limit automatic delivery to keep the amount of active insulin below twice your maximum bolus."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Denna inställning kommer också att fastställa en säkerhetsgräns för automatisk dosering. %1$@ kommer att begränsa automatisk tillförsel för att hålla mängden aktivt insulin under två gånger din maximala bolus."
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bu ayar aynı zamanda otomatik dozlama için bir güvenlik limiti belirleyecektir. %1$@ aktif insülin miktarını maksimum bolusunuzun iki katının altında tutmak için otomatik iletimi sınırlayacaktır."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This setting will also determine a safety limit for automatic dosing. %1$@ will limit automatic delivery to keep the amount of active insulin below twice your maximum bolus."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This setting will also determine a safety limit for automatic dosing. %1$@ will limit automatic delivery to keep the amount of active insulin below twice your maximum bolus."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This setting will also determine a safety limit for automatic dosing. %1$@ will limit automatic delivery to keep the amount of active insulin below twice your maximum bolus."
           }
         },
         "zh-Hans" : {
@@ -19922,6 +28389,12 @@
     "This will typically be" : {
       "comment" : "Information about pre-meal range relative to correction range\nInformation about workout range relative to correction range",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This will typically be"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19952,13 +28425,25 @@
             "value" : "Il s'agit généralement"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This will typically be"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This will typically be"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Questo in genere sarà"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dette vil typisk være"
@@ -19976,16 +28461,28 @@
             "value" : "Zazwyczaj będzie to "
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acesta va fi de obicei"
+            "state" : "new",
+            "value" : "This will typically be"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This will typically be"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Как правило, это "
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This will typically be"
           }
         },
         "sv" : {
@@ -19999,12 +28496,42 @@
             "state" : "translated",
             "value" : "Bu genellikle şu şekilde olacaktır"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This will typically be"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This will typically be"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This will typically be"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This will typically be"
+          }
         }
       }
     },
     "Time" : {
       "comment" : "Label for offset from midnight picker",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الوقت"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20014,13 +28541,13 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zeit"
+            "value" : "Uhrzeit"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hora"
+            "value" : "Tiempo"
           }
         },
         "fi" : {
@@ -20037,26 +28564,26 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "שעה"
+            "state" : "new",
+            "value" : "Time"
           }
         },
-        "hi" : {
+        "hu" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "समय"
+            "value" : "Idő"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Orario"
+            "value" : "Tempo"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tid"
+            "value" : "Tidspunkt"
           }
         },
         "nl" : {
@@ -20071,10 +28598,16 @@
             "value" : "Czas"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Timp"
+            "value" : "Hora"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hora"
           }
         },
         "ru" : {
@@ -20098,7 +28631,25 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zaman"
+            "value" : "Saat"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Час"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thời gian"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Time"
           }
         },
         "zh-Hans" : {
@@ -20112,6 +28663,12 @@
     "Times in %1$@%2$@%3$@" : {
       "comment" : "The schedule table view header describing the configured time zone difference from the default time zone. The substitution parameters are: (1: time zone name)(2: +/-)(3: time interval)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Times in %1$@%2$@%3$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20144,7 +28701,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Times in %1$@%2$@%3$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Times in %1$@%2$@%3$@"
           }
         },
@@ -20154,13 +28717,7 @@
             "value" : "Orari in %1$@%2$@%3$@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "時間帯 %1$@%2$@%3$@"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tider i %1$@%2$@%3$@"
@@ -20178,22 +28735,28 @@
             "value" : "Czas w %1$@%2$@%3$@"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Times in %1$@%2$@%3$@"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hora em %1$@%2$@%3$@"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Orele în %1$@%2$@%3$@"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Хронометраж %1$@%2$@%3$@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Times in %1$@%2$@%3$@"
           }
         },
         "sv" : {
@@ -20208,10 +28771,22 @@
             "value" : "Saat dilimi %1$@%2$@%3$@"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Times in %1$@%2$@%3$@"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thời gian trong %1$@%2$@%3$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Times in %1$@%2$@%3$@"
           }
         },
         "zh-Hans" : {
@@ -20224,6 +28799,12 @@
     },
     "To be implemented" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "To be implemented"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20254,13 +28835,25 @@
             "value" : "Pas encore implémenté"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "To be implemented"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "To be implemented"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Da implementare"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Skal implementeres"
@@ -20278,16 +28871,28 @@
             "value" : "Być realizowane"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Va fi implementat"
+            "state" : "new",
+            "value" : "To be implemented"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "To be implemented"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Будет применено"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "To be implemented"
           }
         },
         "sv" : {
@@ -20301,12 +28906,42 @@
             "state" : "translated",
             "value" : "Uygulanacak"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "To be implemented"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "To be implemented"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "To be implemented"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "To be implemented"
+          }
         }
       }
     },
     "Total" : {
       "comment" : "The text indicating Total for Daily Schedule Basal",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Total"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20325,9 +28960,27 @@
             "value" : "Total"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Total"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Total"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Total"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Total"
           }
         },
@@ -20337,10 +28990,10 @@
             "value" : "Totale"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Total"
+            "value" : "Sum"
           }
         },
         "nl" : {
@@ -20351,13 +29004,19 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Łącznie"
+            "state" : "new",
+            "value" : "Total"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Total"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Total"
           }
         },
@@ -20367,10 +29026,46 @@
             "value" : "Всего"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spolu"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Totalt"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toplam"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Всього"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Total"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Total"
           }
         }
       }
@@ -20378,28 +29073,52 @@
     "U/day" : {
       "comment" : "The text indicating U/day for Daily Schedule Basal",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U/day"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "E/dag"
+            "state" : "new",
+            "value" : "U/day"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "IE/Tag"
+            "value" : "iE/Tag"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "U/día"
+            "state" : "new",
+            "value" : "U/day"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U/day"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "U/jour"
+            "state" : "new",
+            "value" : "U/day"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U/day"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U/day"
           }
         },
         "it" : {
@@ -20408,10 +29127,10 @@
             "value" : "U/giorno"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "E/dag"
+            "state" : "new",
+            "value" : "U/day"
           }
         },
         "nl" : {
@@ -20422,26 +29141,68 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "J/dzień"
+            "state" : "new",
+            "value" : "U/day"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "U/zi"
+            "state" : "new",
+            "value" : "U/day"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U/day"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ед/сутки"
+            "value" : "Ед/день"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "J/deň"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IE/dag"
           }
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "U/day"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "Ü/gün"
+            "value" : "U/день"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "U/day"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U/day"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U/day"
           }
         }
       }
@@ -20450,6 +29211,12 @@
       "comment" : "The unit string for units per hour",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U/hour"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20482,7 +29249,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "U/hour"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "U/hour"
           }
         },
@@ -20492,13 +29265,7 @@
             "value" : "U/ora"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "U/時"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "E/timen"
@@ -20516,22 +29283,28 @@
             "value" : "J/godzinę"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U/hour"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "U/houra"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "U/oră"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ед/ч"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U/hour"
           }
         },
         "sv" : {
@@ -20546,10 +29319,22 @@
             "value" : "Ü/saat"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U/hour"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "U/giờ"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U/hour"
           }
         },
         "zh-Hans" : {
@@ -20563,6 +29348,12 @@
     "Unable to Save" : {
       "comment" : "Alert title when error occurs while saving a schedule",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to Save"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20593,13 +29384,25 @@
             "value" : "Impossible d'enregistrer"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to Save"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to Save"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Impossibile salvare"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kunne ikke lagre"
@@ -20617,16 +29420,28 @@
             "value" : "Nie można zapisać"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu se poate salva"
+            "state" : "new",
+            "value" : "Unable to Save"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to Save"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Невозможно сохранить"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to Save"
           }
         },
         "sv" : {
@@ -20640,6 +29455,30 @@
             "state" : "translated",
             "value" : "Kaydedilemiyor"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to Save"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to Save"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to Save"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to Save"
+          }
         }
       }
     },
@@ -20647,6 +29486,12 @@
       "comment" : "The unit string for units",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Units"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20679,7 +29524,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Units"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Units"
           }
         },
@@ -20689,13 +29540,7 @@
             "value" : "Unità"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "単位"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enheter"
@@ -20713,16 +29558,16 @@
             "value" : "Jednostki"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Units"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Unidades"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unități"
           }
         },
         "ru" : {
@@ -20749,9 +29594,21 @@
             "value" : "Ünite"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Units"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đơn vị"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Units"
           }
         },
@@ -20768,7 +29625,7 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Unknown"
           }
         },
@@ -20804,8 +29661,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Unknown"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ismeretlen"
           }
         },
         "it" : {
@@ -20814,13 +29677,7 @@
             "value" : "Sconosciuto"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不明"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ukjent"
@@ -20835,19 +29692,19 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nieznany"
+            "value" : "Nieznana"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Desconhecido"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Necunoscut"
           }
         },
         "ru" : {
@@ -20871,13 +29728,25 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bilinmeyen"
+            "value" : "Bilinmiyor"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Невідомий"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Không nhận ra"
+            "value" : "Không xác định"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown"
           }
         },
         "zh-Hans" : {
@@ -20890,6 +29759,12 @@
     },
     "Unselected" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unselected"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20902,10 +29777,34 @@
             "value" : "Nicht ausgewählt"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unselected"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unselected"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Non sélectionné"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unselected"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unselected"
           }
         },
         "it" : {
@@ -20914,7 +29813,7 @@
             "value" : "Non selezionato"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ikke valgt"
@@ -20932,10 +29831,16 @@
             "value" : "Niezaznaczone"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neselectat"
+            "state" : "new",
+            "value" : "Unselected"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unselected"
           }
         },
         "ru" : {
@@ -20944,10 +29849,46 @@
             "value" : "Не выбрано"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unselected"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ej vald"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Seçilmemiş"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unselected"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unselected"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unselected"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unselected"
           }
         }
       }
@@ -20955,28 +29896,52 @@
     "Unset" : {
       "comment" : "Title for selection when no insulin type is selected.",
       "localizations" : {
-        "da" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ikke-indstillet"
+            "value" : "غير معيَّن"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unset"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicht gesetzt"
+            "state" : "new",
+            "value" : "Unset"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sin configurar"
+            "state" : "new",
+            "value" : "Unset"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unset"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non sélectionné"
+            "state" : "new",
+            "value" : "Unset"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unset"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unset"
           }
         },
         "it" : {
@@ -20985,46 +29950,94 @@
             "value" : "Non impostato"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fjern"
+            "state" : "new",
+            "value" : "Unset"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Niet Ingesteld"
+            "value" : "Instelling verwijderen"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Niewybrano"
+            "state" : "new",
+            "value" : "Unset"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nealeasă"
+            "state" : "new",
+            "value" : "Unset"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unset"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Не выбрано"
+            "value" : "Не указан"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenastavený"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obestämt"
           }
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Unset"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "Ayarlanmamış"
+            "value" : "Не встановлено"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chưa được đặt"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unset"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unset"
           }
         }
       }
     },
     "Unsupported %@" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unsupported %@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21037,16 +30050,52 @@
             "value" : "Nicht unterstützt %@"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unsupported %@"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unsupported %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unsupported %@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unsupported %@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unsupported %@"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Non supportato %@"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ikke-støttet %@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unsupported %@"
           }
         },
         "pl" : {
@@ -21055,10 +30104,64 @@
             "value" : "Nieobsługiwany %@"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unsupported %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unsupported %@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не поддерживается %@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unsupported %@"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ stöds inte"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unsupported %@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unsupported %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unsupported %@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unsupported %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unsupported %@"
           }
         }
       }
@@ -21066,6 +30169,12 @@
     "Value" : {
       "comment" : "Placeholder text until value is entered",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "القيمة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21086,8 +30195,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arvo"
+            "state" : "new",
+            "value" : "Value"
           }
         },
         "fr" : {
@@ -21096,13 +30205,25 @@
             "value" : "Valeur"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Value"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Érték"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Valore"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verdi"
@@ -21116,20 +30237,32 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wartość"
+            "state" : "new",
+            "value" : "Value"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valoare"
+            "state" : "new",
+            "value" : "Value"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Value"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Значение"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hodnota"
           }
         },
         "sv" : {
@@ -21143,12 +30276,42 @@
             "state" : "translated",
             "value" : "Değer"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Значення"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giá trị"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Value"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "值"
+          }
         }
       }
     },
     "Verifying" : {
       "comment" : "Label indicating validation is occurring",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Verifying"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21181,7 +30344,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Verifying"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Verifying"
           }
         },
@@ -21191,13 +30360,7 @@
             "value" : "Verifica in corso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "確認中"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bekrefter"
@@ -21215,22 +30378,28 @@
             "value" : "Weryfikuję"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Verifying"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verificando"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se verifică"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Верифицируется"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Verifying"
           }
         },
         "sv" : {
@@ -21245,10 +30414,22 @@
             "value" : "Doğrulanıyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Verifying"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang kiểm tra"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Verifying"
           }
         },
         "zh-Hans" : {
@@ -21262,6 +30443,12 @@
     "View Override" : {
       "comment" : "The title for the override editing screen",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "View Override"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21292,13 +30479,25 @@
             "value" : "Voir les ajustements"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "View Override"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "View Override"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Visualizza Override"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vis overstyring"
@@ -21316,16 +30515,28 @@
             "value" : "Podgląd Celu Tymczasowego"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vizualizare suprascriere"
+            "state" : "new",
+            "value" : "View Override"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "View Override"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Просмотреть оверрайд"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "View Override"
           }
         },
         "sv" : {
@@ -21339,6 +30550,30 @@
             "state" : "translated",
             "value" : "Geçersiz Kılmayı Görüntüle"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "View Override"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "View Override"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "View Override"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "View Override"
+          }
         }
       }
     },
@@ -21347,91 +30582,97 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Walsh"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Walsh"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Walsh"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Walsh"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Walsh"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Walsh"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Walsh"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Walsh"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Walsh"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Walsh"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Walsh"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Walsh"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Walsh"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Walsh"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Walsh"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Walsh"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Walsh"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Walsh"
           }
         },
@@ -21443,19 +30684,31 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Walsh"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Walsh"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Walsh"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Walsh"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Walsh"
           }
         }
@@ -21465,6 +30718,12 @@
       "comment" : "Title of an alert containing a validation warning",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Warning"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21497,7 +30756,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Warning"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Warning"
           }
         },
@@ -21507,13 +30772,7 @@
             "value" : "Avvertimento"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "警告"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Advarsel"
@@ -21531,22 +30790,28 @@
             "value" : "Ostrzeżenie"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Warning"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aviso"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avertizare"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Предостережение"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Upozornenie"
           }
         },
         "sv" : {
@@ -21561,10 +30826,22 @@
             "value" : "Uyarı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Попередження"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cảnh báo"
+            "value" : "Cảnh báo"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Warning"
           }
         },
         "zh-Hans" : {
@@ -21578,6 +30855,12 @@
     "Work with your healthcare provider to choose a value that is higher than your highest scheduled basal rate, but as conservative or aggressive as you feel comfortable." : {
       "comment" : "Disclaimer",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Work with your healthcare provider to choose a value that is higher than your highest scheduled basal rate, but as conservative or aggressive as you feel comfortable."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21608,13 +30891,25 @@
             "value" : "Travaillez avec votre prestataire de soins pour choisir une valeur supérieure à votre débit basal le plus élevé prévu, mais aussi conservatrice ou agressive que vous le souhaitez."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Work with your healthcare provider to choose a value that is higher than your highest scheduled basal rate, but as conservative or aggressive as you feel comfortable."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Work with your healthcare provider to choose a value that is higher than your highest scheduled basal rate, but as conservative or aggressive as you feel comfortable."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Collabora con il tuo medico per scegliere un valore più alto della tua massima velocità basale programmata, ma il più conservativo o aggressivo possibile, a seconda di come ti senti a tuo agio."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Samarbeid med helsepersonell for å velge en verdi som er høyere enn din høyeste planlagte basaldose, men så konservativ eller aggressiv som du føler deg komfortabel."
@@ -21632,16 +30927,28 @@
             "value" : "Współpracuj z lekarzem przy ustalaniu limitu podaży. Limit powinien ustawiony być tak, abyś czuł się bezpiecznie."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consultați-va cu medicul pentru a alege o valoare mai mare decât cea mai mare rată bazală programată, dar suficient de prudenta sau agresiva pe cât vă simțiți confortabil."
+            "state" : "new",
+            "value" : "Work with your healthcare provider to choose a value that is higher than your highest scheduled basal rate, but as conservative or aggressive as you feel comfortable."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Work with your healthcare provider to choose a value that is higher than your highest scheduled basal rate, but as conservative or aggressive as you feel comfortable."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вместе с вашим лечащим врачом выберите значение, которое будет выше, чем ваша самая высокая запланированная база, но на столько, на сколько вам удобно."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Work with your healthcare provider to choose a value that is higher than your highest scheduled basal rate, but as conservative or aggressive as you feel comfortable."
           }
         },
         "sv" : {
@@ -21654,6 +30961,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Programlanan en yüksek bazal oranınızdan daha yüksek, ancak kendinizi rahat hissettiğiniz ölçüde tutucu veya agresif bir değer seçmek için sağlık uzmanınızla birlikte çalışın."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Work with your healthcare provider to choose a value that is higher than your highest scheduled basal rate, but as conservative or aggressive as you feel comfortable."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Work with your healthcare provider to choose a value that is higher than your highest scheduled basal rate, but as conservative or aggressive as you feel comfortable."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Work with your healthcare provider to choose a value that is higher than your highest scheduled basal rate, but as conservative or aggressive as you feel comfortable."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Work with your healthcare provider to choose a value that is higher than your highest scheduled basal rate, but as conservative or aggressive as you feel comfortable."
           }
         }
       }
@@ -21699,7 +31030,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Workout"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Workout"
           }
         },
@@ -21709,16 +31046,10 @@
             "value" : "Allenamento"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "運動"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trening"
+            "value" : "Treningsøkt"
           }
         },
         "nl" : {
@@ -21733,22 +31064,28 @@
             "value" : "Wysiłek fizyczny"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Exercício"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activitate sportivă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Физическая нагрузка"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tréning"
           }
         },
         "sv" : {
@@ -21763,16 +31100,28 @@
             "value" : "Egzersiz"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Tập luyện"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Workout"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "锻炼/运动模式"
+            "value" : "运动"
           }
         }
       }
@@ -21780,6 +31129,12 @@
     "Workout Range is the glucose value or range of values you want %1$@ to target during activity. This range will be in effect when you activate the Workout Preset button." : {
       "comment" : "Information about workout range format (1: app name)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout Range is the glucose value or range of values you want %1$@ to target during activity. This range will be in effect when you activate the Workout Preset button."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21810,13 +31165,25 @@
             "value" : "La plage exercice est la valeur de glycémie ou la fourchette de valeurs que vous souhaitez que %1$@ cible pendant l'activité. Cette plage sera effective lorsque vous activez le préréglage exercice."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout Range is the glucose value or range of values you want %1$@ to target during activity. This range will be in effect when you activate the Workout Preset button."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout Range is the glucose value or range of values you want %1$@ to target during activity. This range will be in effect when you activate the Workout Preset button."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "L'intervallo di allenamento è il valore o l'intervallo di valori di glicemia che desideri che %1$@ raggiunga durante l'attività. Questo intervallo sarà attivo quando attivi Preset allenamento."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Treningsområde er blodsukkerverdien eller verdiområdet du vil at %1$@ skal målrettes mot under aktivitet. Dette området trer i kraft når du aktiverer knappen Forhåndsinnstilling for treningsøkt."
@@ -21834,16 +31201,28 @@
             "value" : "Zakres treningu to wartość glukozy lub zakres wartości, do których chcesz dążyć %1$@ podczas aktywności. Ten zakres będzie obowiązywać po aktywowaniu przycisku ustawienia wstępnego treningu."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intervalul ținta pentru antrenament este valoarea glicemiei sau intervalul de valori pe care vrei să le țintești %1$@ în timpul activității. Acest interval va fi în vigoare atunci când activați butonul de presetare a antrenamentului."
+            "state" : "new",
+            "value" : "Workout Range is the glucose value or range of values you want %1$@ to target during activity. This range will be in effect when you activate the Workout Preset button."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout Range is the glucose value or range of values you want %1$@ to target during activity. This range will be in effect when you activate the Workout Preset button."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Диапазон физнагрузки - это значение глюкозы или диапазон значений, на которые вы хотите ориентировать %1$@ во время активности. Этот диапазон будет действовать, когда вы активируете кнопку Workout Preset"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout Range is the glucose value or range of values you want %1$@ to target during activity. This range will be in effect when you activate the Workout Preset button."
           }
         },
         "sv" : {
@@ -21857,12 +31236,42 @@
             "state" : "translated",
             "value" : "Egzersiz Aralığı, aktivite sırasında %1$@ değerinin hedeflenmesini istediğiniz KŞ değeri veya değer aralığıdır. Bu aralık, Egzersiz Ön Ayarı butonunu etkinleştirdiğinizde geçerli olacaktır."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout Range is the glucose value or range of values you want %1$@ to target during activity. This range will be in effect when you activate the Workout Preset button."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout Range is the glucose value or range of values you want %1$@ to target during activity. This range will be in effect when you activate the Workout Preset button."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout Range is the glucose value or range of values you want %1$@ to target during activity. This range will be in effect when you activate the Workout Preset button."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout Range is the glucose value or range of values you want %1$@ to target during activity. This range will be in effect when you activate the Workout Preset button."
+          }
         }
       }
     },
     "Workout Values" : {
       "comment" : "Title text for multi-value workout value warning",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout Values"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21893,13 +31302,25 @@
             "value" : "Valeurs exercice"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout Values"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout Values"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Valori allenamento"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verdier for treningsøkt"
@@ -21917,16 +31338,28 @@
             "value" : "Wartości treningu"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valori activitate sportivă"
+            "state" : "new",
+            "value" : "Workout Values"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout Values"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Настройки физнагрузок"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout Values"
           }
         },
         "sv" : {
@@ -21940,12 +31373,42 @@
             "state" : "translated",
             "value" : "Egzersiz Değerleri"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout Values"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout Values"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout Values"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Workout Values"
+          }
         }
       }
     },
     "You can add different carb ratios for different times of day by using the ➕." : {
       "comment" : "Description of how to add a ratio",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different carb ratios for different times of day by using the ➕."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21976,13 +31439,25 @@
             "value" : "Vous pouvez ajouter différents ratios insuline-glucides pour différentes périodes de la journée en utilisant le ➕."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different carb ratios for different times of day by using the ➕."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different carb ratios for different times of day by using the ➕."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "È possibile aggiungere diversi rapporti di carboidrati per i diversi momenti della giornata utilizzando il tasto ➕."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Du kan legge til forskjellige karbohydratforhold for forskjellige tider på dagen ved å bruke ➕."
@@ -22000,16 +31475,28 @@
             "value" : "Możesz dodać różne współczynniki węglowodanowe dla różnych pór dnia, używając ➕."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poți adăuga diferite rații carbohidrați/insulina pentru diferite momente ale zilei folosind ➕."
+            "state" : "new",
+            "value" : "You can add different carb ratios for different times of day by using the ➕."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different carb ratios for different times of day by using the ➕."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вы можете добавлять различные соотношения углеводов для разного времени суток с помощью ➕."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different carb ratios for different times of day by using the ➕."
           }
         },
         "sv" : {
@@ -22024,6 +31511,24 @@
             "value" : "➕ butonunu kullanarak günün farklı saatleri için farklı karbonhidrat oranları ekleyebilirsiniz."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different carb ratios for different times of day by using the ➕."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different carb ratios for different times of day by using the ➕."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different carb ratios for different times of day by using the ➕."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22035,6 +31540,12 @@
     "You can add different insulin sensitivities for different times of day by using the ➕." : {
       "comment" : "Description of how to add a ratio",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different insulin sensitivities for different times of day by using the ➕."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22065,13 +31576,25 @@
             "value" : "Vous pouvez ajouter différentes sensibilités à l'insuline pour différents moments de la journée en utilisant ➕."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different insulin sensitivities for different times of day by using the ➕."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different insulin sensitivities for different times of day by using the ➕."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "È possibile aggiungere diverse sensibilità insuliniche per i diversi momenti della giornata utilizzando ➕."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Du kan legge til forskjellige insulinfølsomheter for forskjellige tider på dagen ved å bruke ➕."
@@ -22089,16 +31612,28 @@
             "value" : "Możesz dodać różne wrażliwości na insulinę dla różnych pór dnia za pomocą ➕."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Puteți adăuga valori pentru sensibilitatea la insulină pentru diferite momente ale zilei utilizând ➕."
+            "state" : "new",
+            "value" : "You can add different insulin sensitivities for different times of day by using the ➕."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different insulin sensitivities for different times of day by using the ➕."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вы можете добавить различные показатели чувствительности к инсулину для разного времени суток с помощью кнопки ➕."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different insulin sensitivities for different times of day by using the ➕."
           }
         },
         "sv" : {
@@ -22113,6 +31648,24 @@
             "value" : "➕ butonunu kullanarak günün farklı saatleri için farklı insülin duyarlılıkları ekleyebilirsiniz."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different insulin sensitivities for different times of day by using the ➕."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different insulin sensitivities for different times of day by using the ➕."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different insulin sensitivities for different times of day by using the ➕."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22124,6 +31677,12 @@
     "You can add different ranges for different times of day by using the ➕." : {
       "comment" : "Description of how to add a configuration range",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different ranges for different times of day by using the ➕."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22154,13 +31713,25 @@
             "value" : "Vous pouvez ajouter différentes plages pour différentes périodes de la journée en utilisant le ➕."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different ranges for different times of day by using the ➕."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different ranges for different times of day by using the ➕."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "È possibile aggiungere diversi intervalli per i diversi momenti della giornata utilizzando ➕."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Du kan legge til forskjellige områder for forskjellige tider på dagen ved å bruke ➕."
@@ -22178,16 +31749,28 @@
             "value" : "Możesz dodać różne zakresy dla różnych pór dnia, używając ➕."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poți adăuga diferite intervale pentru diferite momente ale zilei folosind ➕."
+            "state" : "new",
+            "value" : "You can add different ranges for different times of day by using the ➕."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different ranges for different times of day by using the ➕."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вы можете добавить различные диапазоны для разного времени суток с помощью кнопки ➕."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different ranges for different times of day by using the ➕."
           }
         },
         "sv" : {
@@ -22202,6 +31785,24 @@
             "value" : "➕ butonunu kullanarak günün farklı saatleri için farklı aralıklar ekleyebilirsiniz."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different ranges for different times of day by using the ➕."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different ranges for different times of day by using the ➕."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add different ranges for different times of day by using the ➕."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22213,6 +31814,12 @@
     "You can add entries for different times of day by using the ➕." : {
       "comment" : "Description of how to add a range",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add entries for different times of day by using the ➕."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22243,13 +31850,25 @@
             "value" : "Vous pouvez ajouter différentes entrées pour différentes périodes de la journée en utilisant le ➕."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add entries for different times of day by using the ➕."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add entries for different times of day by using the ➕."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "È possibile aggiungere diversi valori per i diversi momenti della giornata utilizzando ➕."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Du kan legge til oppføringer for forskjellige tider på dagen ved å bruke ➕."
@@ -22267,16 +31886,28 @@
             "value" : "Możesz dodać różne współczynniki węglowodanowe dla różnych pór dnia, używając ➕."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poți adăuga intrări pentru diferite momente ale zilei folosind ➕."
+            "state" : "new",
+            "value" : "You can add entries for different times of day by using the ➕."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add entries for different times of day by using the ➕."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Можно добавлять записи для разного времени суток с помощью кнопки ➕."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add entries for different times of day by using the ➕."
           }
         },
         "sv" : {
@@ -22290,16 +31921,40 @@
             "state" : "translated",
             "value" : "➕ butonunu kullanarak günün farklı saatleri için girişler ekleyebilirsiniz."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add entries for different times of day by using the ➕."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add entries for different times of day by using the ➕."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add entries for different times of day by using the ➕."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can add entries for different times of day by using the ➕."
+          }
         }
       }
     },
     "You can choose how %1$@ measures rapid acting insulin's peak activity according to one of these two insulin models." : {
       "comment" : "Information about insulin model (1: app name)",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Můžete si vybrat, jak %1$@ měří nejvyšší aktivitu rychle působícího inzulínu podle jednoho z těchto dvou inzulínových modelů."
+            "state" : "new",
+            "value" : "You can choose how %1$@ measures rapid acting insulin's peak activity according to one of these two insulin models."
           }
         },
         "da" : {
@@ -22320,10 +31975,28 @@
             "value" : "Puedes elegir cómo %1$@ mide el pico del efecto de la insulina de acción rápida en función de uno de estos dos modelos de insulina."
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can choose how %1$@ measures rapid acting insulin's peak activity according to one of these two insulin models."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vous pouvez choisir comment %1$@ mesure l'activité maximale de l'insuline à action rapide selon l'un de ces deux modèles d'insuline."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can choose how %1$@ measures rapid acting insulin's peak activity according to one of these two insulin models."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can choose how %1$@ measures rapid acting insulin's peak activity according to one of these two insulin models."
           }
         },
         "it" : {
@@ -22332,7 +32005,7 @@
             "value" : "È possibile scegliere come %1$@ misura l'attività di picco dell'insulina ad azione rapida in base a uno di questi due modelli d'insulina."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Du kan velge hvordan %1$@ måler hurtigvirkende insulins toppaktivitet i henhold til en av disse to insulinmodellene."
@@ -22350,10 +32023,16 @@
             "value" : "Możesz wybrać jak %1$@ prognozuje szczyt działania insuliny szybko działającej spośród dwóch dostępnych modeli insulinowych."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Puteți alege modul în care %1$@ măsoară momentul de vârf al insulinei cu acțiune rapidă în funcție de unul dintre aceste două modele de insulină."
+            "state" : "new",
+            "value" : "You can choose how %1$@ measures rapid acting insulin's peak activity according to one of these two insulin models."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can choose how %1$@ measures rapid acting insulin's peak activity according to one of these two insulin models."
           }
         },
         "ru" : {
@@ -22362,10 +32041,46 @@
             "value" : "Вы можете выбрать, как %1$@ измеряет пиковую активность быстродействующего инсулина в соответствии с одной из этих двух моделей инсулина."
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can choose how %1$@ measures rapid acting insulin's peak activity according to one of these two insulin models."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Du kan välja hur %1$@ mäter insulinets maximala effekt enligt en av dessa två insulinmodeller."
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bu iki insülin modelinden birine göre %1$@ hızlı etkili insülinin tepe aktivitesini nasıl ölçeceğini seçebilirsiniz."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can choose how %1$@ measures rapid acting insulin's peak activity according to one of these two insulin models."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can choose how %1$@ measures rapid acting insulin's peak activity according to one of these two insulin models."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can choose how %1$@ measures rapid acting insulin's peak activity according to one of these two insulin models."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can choose how %1$@ measures rapid acting insulin's peak activity according to one of these two insulin models."
           }
         }
       }
@@ -22373,6 +32088,12 @@
     "You can edit a setting by tapping into any line item." : {
       "comment" : "Description of how to edit setting",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can edit a setting by tapping into any line item."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22403,13 +32124,25 @@
             "value" : "Vous pouvez modifier une paramètre de l'élément en appuyant n'importe ou sur sa ligne."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can edit a setting by tapping into any line item."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can edit a setting by tapping into any line item."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "È possibile modificare un'impostazione toccando un qualsiasi elemento riga."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Du kan redigere en innstilling ved å trykke på et hvilket som helst linjeelement."
@@ -22427,16 +32160,28 @@
             "value" : "Możesz edytować ustawienie, stukając w pozycję mg/dL"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Puteți edita o setare apăsând pe orice linie."
+            "state" : "new",
+            "value" : "You can edit a setting by tapping into any line item."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can edit a setting by tapping into any line item."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вы можете изменить настройку, коснувшись самой строки."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can edit a setting by tapping into any line item."
           }
         },
         "sv" : {
@@ -22451,6 +32196,24 @@
             "value" : "Herhangi bir satır öğesine dokunarak bir ayarı düzenleyebilirsiniz."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can edit a setting by tapping into any line item."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can edit a setting by tapping into any line item."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can edit a setting by tapping into any line item."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22462,6 +32225,12 @@
     "You can edit the setting by tapping into the line item." : {
       "comment" : "Description of how to edit setting",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can edit the setting by tapping into the line item."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22492,13 +32261,25 @@
             "value" : "Vous pouvez modifier la valeur de l'élément en appuyant n'importe ou sur sa ligne."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can edit the setting by tapping into the line item."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can edit the setting by tapping into the line item."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "È possibile modificare l'impostazione toccando l'elemento riga."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Du kan redigere innstillingen ved å trykke på linjeelementet."
@@ -22516,16 +32297,28 @@
             "value" : "Możesz edytować ustawienie, stukając w pozycję mg/dL"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Puteți edita setarea apăsând pe linie."
+            "state" : "new",
+            "value" : "You can edit the setting by tapping into the line item."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can edit the setting by tapping into the line item."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вы можете изменить настройку, коснувшись самой строки."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can edit the setting by tapping into the line item."
           }
         },
         "sv" : {
@@ -22540,6 +32333,24 @@
             "value" : "Satır öğesine dokunarak ayarı düzenleyebilirsiniz."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can edit the setting by tapping into the line item."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can edit the setting by tapping into the line item."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You can edit the setting by tapping into the line item."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22551,6 +32362,12 @@
     "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs." : {
       "comment" : "Information about basal rates",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22581,13 +32398,25 @@
             "value" : "Votre débit basal d'insuline est le nombre d'unités par heure que vous souhaitez utiliser pour couvrir vos besoins vitaux d'insuline."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "La velocità basale d'insulina è il numero di unità all'ora che si desidera utilizzare per coprire il tuo fabbisogno d'insulina basale."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Din basaldose av insulin er antall enheter pr. time du vil bruke for å dekke ditt bakgrunnsinsulinbehov."
@@ -22605,16 +32434,28 @@
             "value" : "Dawka podstawowa insuliny to liczba jednostek na godzinę, którą chcesz wykorzystać do pokrycia podstawowego zapotrzebowania na insulinę."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rata bazală de insulină este numărul de unități pe oră pe care doriți să le utilizați pentru a acoperi necesarul bazal de insulina al organismului."
+            "state" : "new",
+            "value" : "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ваш базальный инсулин - это количество единиц в час, которое вы хотите использовать для покрытия своих фоновых потребностей в инсулине."
+            "value" : "Ваша базальная норма инсулина - это количество единиц в час, которое вы хотите использовать для покрытия своих фоновых потребностей в инсулине."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tvoja bazálna dávka inzulínu je počet jednotiek za hodinu, ktoré chceš použiť na pokrytie svojich základných potrieb inzulínu."
           }
         },
         "sv" : {
@@ -22628,12 +32469,42 @@
             "state" : "translated",
             "value" : "Bazal İnsülin Oranınız, arka plan insülin ihtiyaçlarınızı karşılamak için kullanmak istediğiniz  saat başına ünite miktarıdır."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tốc độ insulin nền của bạn là số đơn vị mỗi giờ được dùng để đáp ứng nhu cầu insulin nền của cơ thể."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Basal Rate of insulin is the number of units per hour that you want to use to cover your background insulin needs."
+          }
         }
       }
     },
     "your Glucose Safety Limit" : {
       "comment" : "Lower bound pre-meal information text",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "your Glucose Safety Limit"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22664,13 +32535,25 @@
             "value" : "votre seuil de suspension glycémique"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "your Glucose Safety Limit"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "your Glucose Safety Limit"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "il tuo limite glicemico di sicurezza"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "din sikkerhetsgrense for blodsukker"
@@ -22688,16 +32571,28 @@
             "value" : "Bezpieczny Limit Glukozy"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "limita de siguranță a glicemiei"
+            "state" : "new",
+            "value" : "your Glucose Safety Limit"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "your Glucose Safety Limit"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ваш безопасный предел ГК"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "your Glucose Safety Limit"
           }
         },
         "sv" : {
@@ -22711,12 +32606,42 @@
             "state" : "translated",
             "value" : "KŞ Güvenlik Limitiniz"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "your Glucose Safety Limit"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "your Glucose Safety Limit"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "your Glucose Safety Limit"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "your Glucose Safety Limit"
+          }
         }
       }
     },
     "Your healthcare provider can help you choose a Correction Range that's right for you." : {
       "comment" : "Disclaimer",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your healthcare provider can help you choose a Correction Range that's right for you."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22747,13 +32672,25 @@
             "value" : "Votre professionnel de soins de santé peut vous aider à choisir une plage de correction qui vous convient."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your healthcare provider can help you choose a Correction Range that's right for you."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your healthcare provider can help you choose a Correction Range that's right for you."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il tuo medico curante può aiutarti a scegliere l'intervallo di correzione più adatto a te."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Helsepersonellet kan hjelpe deg med å velge et korrigeringsområde som er riktig for deg."
@@ -22771,16 +32708,28 @@
             "value" : "Twój lekarz może pomóc Ci wybrać zakres docelowy odpowiedni dla Ciebie."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Medicul dvs. vă poate ajuta să alegeți un interval de corecție potrivit pentru dvs."
+            "state" : "new",
+            "value" : "Your healthcare provider can help you choose a Correction Range that's right for you."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your healthcare provider can help you choose a Correction Range that's right for you."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ваш лечащий врач поможет вам выбрать подходящий для Вас диапазон коррекции."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your healthcare provider can help you choose a Correction Range that's right for you."
           }
         },
         "sv" : {
@@ -22795,6 +32744,24 @@
             "value" : "Sağlık uzmanınız sizin için doğru olan Düzeltme Aralığını seçmenize yardımcı olabilir."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your healthcare provider can help you choose a Correction Range that's right for you."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your healthcare provider can help you choose a Correction Range that's right for you."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your healthcare provider can help you choose a Correction Range that's right for you."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22806,6 +32773,12 @@
     "Your Insulin Sensitivity Factor (ISF) is the drop in glucose expected from one unit of insulin." : {
       "comment" : "Description of insulin sensitivity factor",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Insulin Sensitivity Factor (ISF) is the drop in glucose expected from one unit of insulin."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22836,13 +32809,25 @@
             "value" : "Votre facteur de sensibilité à l’insuline (ISF) est la baisse de glycémie attendue avec une unité d’insuline."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Insulin Sensitivity Factor (ISF) is the drop in glucose expected from one unit of insulin."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Insulin Sensitivity Factor (ISF) is the drop in glucose expected from one unit of insulin."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il fattore di sensibilità insulinica (ISF) è il calo di glicemia previsto da un'unità d'insulina."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Din insulinsensitivitetsfaktor (ISF) er fallet i blodsukker som forventes fra én enhet insulin."
@@ -22860,16 +32845,28 @@
             "value" : "Twój współczynnik wrażliwości na insulinę (ISF) to oczekiwany spadek glukozy po podaniu jednej jednostki insuliny."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Factorul de sensibilitate la insulină (ISF) este scăderea glicemiei determinata de o unitate de insulină."
+            "state" : "new",
+            "value" : "Your Insulin Sensitivity Factor (ISF) is the drop in glucose expected from one unit of insulin."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Insulin Sensitivity Factor (ISF) is the drop in glucose expected from one unit of insulin."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ваш фактор чувствительности к инсулину (ISF) - это снижение уровня глюкозы, ожидаемое от ввода одной единицы инсулина."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Insulin Sensitivity Factor (ISF) is the drop in glucose expected from one unit of insulin."
           }
         },
         "sv" : {
@@ -22883,12 +32880,42 @@
             "state" : "translated",
             "value" : "İnsülin Duyarlılık faktörünüz (İDF), bir ünite insülinden beklenen KŞ düşüşünü ifade eder."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Insulin Sensitivity Factor (ISF) is the drop in glucose expected from one unit of insulin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Insulin Sensitivity Factor (ISF) is the drop in glucose expected from one unit of insulin."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Insulin Sensitivity Factor (ISF) is the drop in glucose expected from one unit of insulin."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Insulin Sensitivity Factor (ISF) is the drop in glucose expected from one unit of insulin."
+          }
         }
       }
     },
     "Your Pre-Meal Range should be the glucose value (or range of values) you want %1$@ to target by the time you take your first bite of your meal. This range will be in effect when you activate the Pre-Meal Preset button." : {
       "comment" : "Information about pre-meal range format (1: app name)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Pre-Meal Range should be the glucose value (or range of values) you want %1$@ to target by the time you take your first bite of your meal. This range will be in effect when you activate the Pre-Meal Preset button."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22919,13 +32946,25 @@
             "value" : "Votre plage pré-repas doit correspondre à la valeur (ou fourchette de valeurs) de glycémie que vous souhaitez que %1$@ cible au moment où vous commencez. Cette plage sera en vigueur lorsque vous activerez le préréglage pré-repas."
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Pre-Meal Range should be the glucose value (or range of values) you want %1$@ to target by the time you take your first bite of your meal. This range will be in effect when you activate the Pre-Meal Preset button."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Pre-Meal Range should be the glucose value (or range of values) you want %1$@ to target by the time you take your first bite of your meal. This range will be in effect when you activate the Pre-Meal Preset button."
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il tuo Intervallo pre-prasto dovrebbe essere il valore glicemico (o l'intervallo di valori) che vuoi che %1$@ abbia come target prima che tu assuma il primo boccone del tuo pasto. Questo intervallo sarà effettivo quando attivi Preset pre-pasto."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pre-Meal Range bør være blodsukkerverdien (eller verdiområdet) du vil at %1$@ skal målrettes mot når du tar din første bit av måltidet. Dette området vil være i kraft når du aktiverer forhåndsinnstillingsknappen før måltid."
@@ -22943,16 +32982,28 @@
             "value" : "Twój zakres przed posiłkiem powinien być wartością glukozy (lub zakresem wartości), do którego chcesz dążyć %1$@, zanim zaczniesz spożywać posiłek. Ten zakres będzie obowiązywał po aktywowaniu przycisku Przed Posiłkiem."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intervalul ținta preparandial trebuie să fie valoarea glicemiei (sau intervalul de valori) pe care doriți %1$@ să o vizați până la prima mușcătură a mesei. Acest interval va fi în vigoare atunci când activați butonul Presetare înainte de masă."
+            "state" : "new",
+            "value" : "Your Pre-Meal Range should be the glucose value (or range of values) you want %1$@ to target by the time you take your first bite of your meal. This range will be in effect when you activate the Pre-Meal Preset button."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Pre-Meal Range should be the glucose value (or range of values) you want %1$@ to target by the time you take your first bite of your meal. This range will be in effect when you activate the Pre-Meal Preset button."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Диапазон до еды - это значение глюкозы (или диапазон значений), которое Вы хотите, чтобы %1$@ было целевым к моменту приема пищи. Этот диапазон будет действовать, только когда Вы активируете кнопку предварительной настройки до еды и будет выключен после ввода углеводов."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Pre-Meal Range should be the glucose value (or range of values) you want %1$@ to target by the time you take your first bite of your meal. This range will be in effect when you activate the Pre-Meal Preset button."
           }
         },
         "sv" : {
@@ -22965,6 +33016,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Yemek Öncesi Aralığınız, yemeğinizden ilk lokmanızı aldığınız zaman %1$@ 'un hedeflemesini istediğiniz KŞ değeri (veya değer aralığı) olmalıdır. Bu aralık, Yemek Öncesi Ön Ayar butonunu etkinleştirdiğinizde etkin olacaktır."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Pre-Meal Range should be the glucose value (or range of values) you want %1$@ to target by the time you take your first bite of your meal. This range will be in effect when you activate the Pre-Meal Preset button."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Pre-Meal Range should be the glucose value (or range of values) you want %1$@ to target by the time you take your first bite of your meal. This range will be in effect when you activate the Pre-Meal Preset button."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Pre-Meal Range should be the glucose value (or range of values) you want %1$@ to target by the time you take your first bite of your meal. This range will be in effect when you activate the Pre-Meal Preset button."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your Pre-Meal Range should be the glucose value (or range of values) you want %1$@ to target by the time you take your first bite of your meal. This range will be in effect when you activate the Pre-Meal Preset button."
           }
         }
       }

--- a/MockKit/Resources/Localizable.xcstrings
+++ b/MockKit/Resources/Localizable.xcstrings
@@ -662,8 +662,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump Battery Dead"
+            "state" : "translated",
+            "value" : "Розряджена батарея помпи"
           }
         },
         "vi" : {
@@ -936,8 +936,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump Occlusion"
+            "state" : "translated",
+            "value" : "Помпа забита"
           }
         },
         "vi" : {

--- a/MockKit/Resources/Localizable.xcstrings
+++ b/MockKit/Resources/Localizable.xcstrings
@@ -7,7 +7,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bolus"
+            "value" : "الجرعة"
           }
         },
         "da" : {
@@ -31,7 +31,7 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bolus"
+            "value" : "Lisäannos"
           }
         },
         "fr" : {
@@ -42,8 +42,14 @@
         },
         "he" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "בולוס"
+            "value" : "Bólus"
           }
         },
         "it" : {
@@ -52,13 +58,7 @@
             "value" : "Bolo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ボーラス"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bolus"
@@ -72,19 +72,19 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Bolus"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Bolus"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bolus"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Bolus"
           }
         },
@@ -108,14 +108,32 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Bolus"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Болюс"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bolus"
+            "value" : "Liều bolus"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bolus Value"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大剂量"
           }
         }
       }
@@ -123,6 +141,12 @@
     "Comms Issue" : {
       "comment" : "Status highlight that delivery is uncertain.",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مشكلة في الاتصالات"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -132,7 +156,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kommunikationsproblem"
+            "value" : "Kommunikationsfehler"
           }
         },
         "es" : {
@@ -143,56 +167,80 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yhteysongelma"
+            "state" : "new",
+            "value" : "Comms Issue"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Problème de communication"
+            "value" : "Problème de com."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Comms Issue"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Comms Issue"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Problema di comunicazione"
+            "value" : "Problema Comms"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kommunikasjonsutgave"
+            "value" : "Kommunikasjons-problem"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Communicatieprobleem"
+            "value" : "Opdrachtenprobleem"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Problem z komunikacją"
+            "state" : "new",
+            "value" : "Comms Issue"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Problemă de comunicații"
+            "state" : "new",
+            "value" : "Comms Issue"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Comms Issue"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Проблемы со связью"
+            "value" : "Проблемы с сообщением"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Problém s komunikáciou"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kommandoproblem"
+            "value" : "Kommunikationsproblem"
           }
         },
         "tr" : {
@@ -200,12 +248,42 @@
             "state" : "translated",
             "value" : "İletişim Sorunu"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Проблеми з повідомленням"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Câu lệnh có vấn đề"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Comms Issue"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Comms Issue"
+          }
         }
       }
     },
     "Insulin Suspended" : {
       "comment" : "Status highlight that insulin delivery was suspended.",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Suspended"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -215,19 +293,19 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulinabgabe unterbrochen"
+            "value" : "Insulin ausgesetzt"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulina Suspendida"
+            "value" : "Insulina suspendida"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insuliini pysäytetty"
+            "state" : "new",
+            "value" : "Insulin Suspended"
           }
         },
         "fr" : {
@@ -236,52 +314,100 @@
             "value" : "Insuline suspendue"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Suspended"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Suspended"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erogazione Insulina sospesa"
+            "value" : "Insulina Sospesa"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulin suspendert"
+            "value" : "Insulintilførsel pauset"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insuline Onderbroken"
+            "value" : "Insuline tijdelijk uitgeschakeld"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Podawanie Zawieszone"
+            "state" : "new",
+            "value" : "Insulin Suspended"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Administrarea insulinei suspendată"
+            "state" : "new",
+            "value" : "Insulin Suspended"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Suspended"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Подача инсулина приостановлена"
+            "value" : "Подача приостановлена"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inzulín Suspendovaný"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulintillförsel pausad"
+            "value" : "Pump pausad"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "İnsülin Askıya Alındı"
+            "value" : "İnsülin Durduldu"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подання Припинено"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã tạm dừng cấp liều Insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Suspended"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Suspended"
           }
         }
       }
@@ -289,10 +415,10 @@
     "No Insulin" : {
       "comment" : "Status highlight that a pump is out of insulin.",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Žádný inzulín"
+            "value" : "لا يوجد إنسولين"
           }
         },
         "da" : {
@@ -315,8 +441,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ei insuliinia"
+            "state" : "new",
+            "value" : "No Insulin"
           }
         },
         "fr" : {
@@ -325,34 +451,52 @@
             "value" : "Pas d'insuline"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Insulin"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Insulin"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulina esaurita"
+            "value" : "Nessuna Insulina"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ingen insulin"
+            "value" : "Tom for insulin"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Geen Insuline"
+            "value" : "Geen insuline"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Brak insuliny"
+            "state" : "new",
+            "value" : "No Insulin"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fără insulină"
+            "state" : "new",
+            "value" : "No Insulin"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Insulin"
           }
         },
         "ru" : {
@@ -376,7 +520,31 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "İnsülin yok"
+            "value" : "İnsülin Yok"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нема Інсуліну"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hết Insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Insulin"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Insulin"
           }
         }
       }
@@ -384,6 +552,12 @@
     "Pump Battery Dead" : {
       "comment" : "Status highlight that pump has a dead battery.",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Dead"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -414,13 +588,25 @@
             "value" : "Batterie de la pompe déchargée"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Dead"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Dead"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Batteria pompa esaurita"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pumpebatteri er dødt"
@@ -438,16 +624,28 @@
             "value" : "Rozładowana bateria pompy"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baterie epuizata pompa"
+            "state" : "new",
+            "value" : "Pump Battery Dead"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Dead"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Батарея помпы неисправна"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batéria pumpy je vybitá"
           }
         },
         "sv" : {
@@ -461,12 +659,42 @@
             "state" : "translated",
             "value" : "Pompa Pili Bitti"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Dead"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pin bơm đã cạn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Dead"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Dead"
+          }
         }
       }
     },
     "Pump Error" : {
       "comment" : "Status highlight that a pump error occurred.",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خطأ في المضخة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -494,28 +722,28 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erreur de la pompe"
+            "value" : "Erreur détectée"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pump Error"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump Error"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Errore della pompa"
+            "value" : "Errore microinfusore"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプエラー"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pumpefeil"
@@ -524,7 +752,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pomp Foutmelding"
+            "value" : "Pomp foutmelding"
           }
         },
         "pl" : {
@@ -533,22 +761,28 @@
             "value" : "Błąd pompy"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Error"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erro na Bomba"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eroare pompă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ошибка помпы"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chyba pumpy"
           }
         },
         "sv" : {
@@ -563,10 +797,22 @@
             "value" : "Pompa Hatası"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Помилка помпи"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bơm lỗi"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Error"
           }
         },
         "zh-Hans" : {
@@ -580,6 +826,12 @@
     "Pump Occlusion" : {
       "comment" : "Status highlight that an occlusion was detected.",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Occlusion"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -610,13 +862,25 @@
             "value" : "Occlusion de la pompe"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Occlusion"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Occlusion"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Occlusione pompa"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pumpeokklusjon"
@@ -634,16 +898,28 @@
             "value" : "Niedrożność pompy"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ocluzie pompă"
+            "state" : "new",
+            "value" : "Pump Occlusion"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Occlusion"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Закупорка помпы"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oklúzia pumpy"
           }
         },
         "sv" : {
@@ -657,12 +933,42 @@
             "state" : "translated",
             "value" : "Pompa Tıkanıklığı"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Occlusion"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bơm bị tắc nghẽn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Occlusion"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Occlusion"
+          }
         }
       }
     },
     "Resume" : {
       "comment" : "Pump Event title for UnfinalizedDose with doseType of .resume",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resume"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -681,10 +987,28 @@
             "value" : "Reanudar"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resume"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reprendre"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resume"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visszatérés"
           }
         },
         "it" : {
@@ -693,28 +1017,34 @@
             "value" : "Riprendi"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gjenoppta"
+            "value" : "Gjenoppta leveranse"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hervatten"
+            "value" : "Hervat"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wznowiono"
+            "state" : "new",
+            "value" : "Resume"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reluați"
+            "state" : "new",
+            "value" : "Resume"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resume"
           }
         },
         "ru" : {
@@ -723,10 +1053,46 @@
             "value" : "Возобновление"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pokračovať"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Återuppta"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Devam et"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відновити"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiếp tục"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resume"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢复"
           }
         }
       }
@@ -734,6 +1100,12 @@
     "Suspend" : {
       "comment" : "Pump Event title for UnfinalizedDose with doseType of .suspend",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspend"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -752,10 +1124,28 @@
             "value" : "Suspender"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspend"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Suspendre"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspend"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Felfüggesztés"
           }
         },
         "it" : {
@@ -764,10 +1154,10 @@
             "value" : "Sospendi"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Suspendere"
+            "value" : "Pause leveranse"
           }
         },
         "nl" : {
@@ -778,20 +1168,26 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wstrzymano"
+            "state" : "new",
+            "value" : "Suspend"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suspendați"
+            "state" : "new",
+            "value" : "Suspend"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspend"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Приостановка"
+            "value" : "Остановка"
           }
         },
         "sk" : {
@@ -800,10 +1196,40 @@
             "value" : "Pozastavenie"
           }
         },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pausa"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Askıya al"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Призупинити"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã tạm dừng"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspend"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂停"
           }
         }
       }
@@ -811,10 +1237,16 @@
     "Temp Basal" : {
       "comment" : "Pump Event title for UnfinalizedDose with doseType of .tempBasal",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temp Basal"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Midlertidig basal"
+            "value" : "Midlertidig Basal"
           }
         },
         "de" : {
@@ -831,14 +1263,26 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilapäinen basaali"
+            "state" : "new",
+            "value" : "Temp Basal"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Débit basal temporaire"
+            "value" : "Basal Temp."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temp Basal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temp Basal"
           }
         },
         "it" : {
@@ -847,7 +1291,7 @@
             "value" : "Basale temporanea"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Midlertidig basal"
@@ -856,25 +1300,31 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tijdelijk Basaal"
+            "value" : "Tijdelijk basaal"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tymczasowa dawka podst."
+            "state" : "new",
+            "value" : "Temp Basal"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bazală temporară"
+            "state" : "new",
+            "value" : "Temp Basal"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temp Basal"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ВБС"
+            "value" : "Врем. базал"
           }
         },
         "sk" : {
@@ -892,7 +1342,31 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Geçici Bazal"
+            "value" : "Geçici Bazal Oranı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тимчасовий  Базал"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temp Basal"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temp Basal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "临时基础率"
           }
         }
       }

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,10 @@
+files:
+  - source: /LoopKit/Resources/Localizable.xcstrings
+    translation: /LoopKit/Resources/Localizable.xcstrings
+    multilingual: 1
+  - source: /MockKit/Resources/Localizable.xcstrings
+    translation: /MockKit/Resources/Localizable.xcstrings
+    multilingual: 1
+  - source: /LoopKitUI/Resources/Localizable.xcstrings
+    translation: /LoopKitUI/Resources/Localizable.xcstrings
+    multilingual: 1


### PR DESCRIPTION
Swedish and Dutch 100% and other languages not fully completed.   Created with Crowdin (= no parsing errors). 

Unfortunately there is also be an added configuration file, crowdin.yml. This file is only used by Crowdin, meaning it will not mess anything up with lokalise or the Loop Workspace. You can ignore it, when merging, but it would be easier to keep it (for future PRs).