### PR TITLE
Fix cannot save first carb entry after adding a pump

### DIFF
--- a/LoopKit/InsulinKit/DoseStore.swift
+++ b/LoopKit/InsulinKit/DoseStore.swift
@@ -684,6 +684,12 @@ extension DoseStore {
             return
         }
 
+        for event in events {
+            if let dose = event.dose {
+                self.log.debug("Add %@, isMutable=%@", String(describing: dose), String(describing: event.dose?.isMutable))
+            }
+        }
+
         persistenceController.managedObjectContext.perform {
             var lastFinalDate: Date?
             var firstMutableDate: Date?


### PR DESCRIPTION
## Purpose:

Edited to say - treat this as an Issue - not a PR. I messed up the test and thought this fixed something - it did not.  See later comments.

After merging PR #574 into dev, we later found that the very first entry of carbs to Loop following the addition of a new pump manager had a failure saying `Unable to Save Carb Entry`. 

If you then look at the ICE screen following this error, the carbs show up, but cannot be deleted. When you try to delete the spurious carb entry, the message indicates a duration that is too short. By quitting and restarting the app, the spurious carb entry is removed and then carbs can be added normally so long as Loop is using that pump manager.

This was reproduced for OmniBLE, ~~OmniKit~~ and MinimedKit. It was also reported for someone testing with DanaKit.

Reverting that the change in that PR fixed the issue, but we do want the protection against future reconciliation date provided by that PR.

## Method:

After examining the PR, empirically decided to restore one section of the `DoseStore.swift` code to see if that fixed the `Unable to Save Carb Entry` error ~~and found that it did fix the error~~.

## Test

~~Built this version on several phones and added several pumps including OmniBLE, OmniKit and MinimedKit.~~
~~After each pump addition, enter a carb entry and it worked as expected.~~

I used the wrong test - this is not a fix.