### PR TITLE
Revert pumpevent fix attempt

### DIFF
--- a/LoopKit/InsulinKit/DoseStore.swift
+++ b/LoopKit/InsulinKit/DoseStore.swift
@@ -684,6 +684,12 @@ extension DoseStore {
             return
         }
 
+        for event in events {
+            if let dose = event.dose {
+                self.log.debug("Add %@, isMutable=%@", String(describing: dose), String(describing: event.dose?.isMutable))
+            }
+        }
+
         persistenceController.managedObjectContext.perform {
             var lastFinalDate: Date?
             var firstMutableDate: Date?
@@ -706,7 +712,8 @@ extension DoseStore {
             })
 
             // There is no guarantee of event ordering, so we must search the entire array to find key date boundaries.
-            for var event in events {
+
+            for event in events {
                 if case .prime? = event.type {
                     primeValueAdded = true
                 }
@@ -720,11 +727,6 @@ extension DoseStore {
                 }
 
                 let object = PumpEvent(context: self.persistenceController.managedObjectContext)
-
-                if let dose = event.dose, let lastPumpEventsReconciliation = self.lastPumpEventsReconciliation, !dose.isMutable && dose.endDate > lastPumpEventsReconciliation {
-                    self.log.error("FIXME! PumpManager submitted immutable dose with future end date: %{public}@", String(describing: dose))
-                    event.dose?.endDate = lastPumpEventsReconciliation
-                }
 
                 object.date = event.date
                 object.raw = event.raw

--- a/LoopKit/InsulinKit/DoseStore.swift
+++ b/LoopKit/InsulinKit/DoseStore.swift
@@ -684,9 +684,15 @@ extension DoseStore {
             return
         }
 
+
         for event in events {
             if let dose = event.dose {
-                self.log.debug("Add %@, isMutable=%@", String(describing: dose), String(describing: event.dose?.isMutable))
+                if let lastReconciliation, !dose.isMutable, dose.endDate > lastReconciliation {
+                    // Doses with an endDate after lastReconciliation should still be considered ongoing/mutable, as
+                    // a future history read could show that they were interrupted.
+                    fatalError("Pump event dose marked as not mutable, with endDate after lastReconciliation!")
+                }
+                self.log.debug("Add %@, isMutable=%@", String(describing: dose), String(describing: dose.isMutable))
             }
         }
 

--- a/LoopKit/InsulinKit/DoseStore.swift
+++ b/LoopKit/InsulinKit/DoseStore.swift
@@ -687,11 +687,11 @@ extension DoseStore {
 
         for event in events {
             if let dose = event.dose {
-                if let lastReconciliation, !dose.isMutable, dose.endDate > lastReconciliation {
-                    // Doses with an endDate after lastReconciliation should still be considered ongoing/mutable, as
-                    // a future history read could show that they were interrupted.
-                    fatalError("Pump event dose marked as not mutable, with endDate after lastReconciliation!")
-                }
+//                if let lastReconciliation, !dose.isMutable, dose.endDate > lastReconciliation {
+//                    // Doses with an endDate after lastReconciliation should still be considered ongoing/mutable, as
+//                    // a future history read could show that they were interrupted.
+//                    fatalError("Pump event dose marked as not mutable, with endDate after lastReconciliation!")
+//                }
                 self.log.debug("Add %@, isMutable=%@", String(describing: dose), String(describing: dose.isMutable))
             }
         }

--- a/LoopKit/InsulinKit/NewPumpEvent.swift
+++ b/LoopKit/InsulinKit/NewPumpEvent.swift
@@ -13,7 +13,7 @@ public struct NewPumpEvent: Equatable {
     /// The date of the event
     public let date: Date
     /// The insulin dose described by the event, if applicable
-    public var dose: DoseEntry?
+    public let dose: DoseEntry?
     /// The opaque raw data representing the event
     public let raw: Data
     /// The type of pump event

--- a/LoopKitTests/DoseStoreTests.swift
+++ b/LoopKitTests/DoseStoreTests.swift
@@ -113,64 +113,6 @@ class DoseStoreTests: PersistenceControllerTestCase {
         waitForExpectations(timeout: 3)
     }
 
-    func testFutureEndDateBolus() {
-        // This test simulates a pump submitting a non-mutable pump event with a future end time.
-        // Pumps should not do this (if the dose has not ended, it should still be mutable).
-        // As a fail-safe, Loop will hackishly update the end time to now if it gets a mutable
-        // dose with an end time in the future, but any PumpManagers that aren't currently
-        // following this rule should be fixed.
-
-        var now = testingDate("2023-01-08 17:00:00 +0000")
-        let doseStore = defaultStore(testingDate: now)
-
-        let bolusStart = now.addingTimeInterval(.minutes(-2))
-        let bolusEnd = now.addingTimeInterval(10) // ends 10s in future
-
-        let pumpEvents: [NewPumpEvent] = [
-            NewPumpEvent(
-                date: bolusStart,
-                dose: DoseEntry(
-                    type: .bolus,
-                    startDate: bolusStart,
-                    endDate: bolusEnd,
-                    value: 6.1,
-                    unit: .units
-                ),
-                raw: Data(String("TestBolus").utf8),
-                title: "TestBolus"
-            )]
-
-        var storageExpectations = expectation(description: "add new doses finished")
-
-        doseStore.addPumpEvents(pumpEvents, lastReconciliation: now.addingTimeInterval(-5)) { error in
-            storageExpectations.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
-
-        now.addTimeInterval(20) // 20 seconds later, we do another report, to update lastReconciliation
-
-        doseStore.insulinDeliveryStore.test_currentDate = now
-
-        storageExpectations = expectation(description: "add new doses finished")
-
-        doseStore.addPumpEvents(pumpEvents, lastReconciliation: now) { error in
-            storageExpectations.fulfill()
-        }
-
-        let queryFinishedExpectation = expectation(description: "query finished")
-        doseStore.insulinOnBoard(at: now) { (result) in
-            switch result {
-            case .failure(let error):
-                XCTFail("Unexpected error: \(error)")
-            case .success(let value):
-                XCTAssertEqual(6.1, value.value, accuracy: 0.01)
-            }
-            queryFinishedExpectation.fulfill()
-        }
-        waitForExpectations(timeout: 3)
-    }
-
     func testMutableDosesIncludedInIOB() {
         let now = testingDate("2023-01-08 17:11:14 +0000")
         let doseStore = defaultStore(testingDate: now)
@@ -195,7 +137,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
 
         let tempBasalStart = testingDate("2023-01-08 17:02:35 +0000")
         let tempBasalEnd = testingDate("2023-01-08 17:32:35 +0000")
-        let tempBasal = DoseEntry(type: .tempBasal, startDate: tempBasalStart, endDate: tempBasalEnd, value:0.575, unit: .unitsPerHour, isMutable: true)
+        let tempBasal = DoseEntry(type: .tempBasal, startDate: tempBasalStart, endDate: tempBasalEnd, value:0.575, unit: .unitsPerHour, isMutable: false)
 
         let pumpEvents: [NewPumpEvent] = [
             NewPumpEvent(date: bolus.startDate, dose: bolus, raw: Data(hexadecimalString: "0000")!, title: "Bolus 5.15U"),


### PR DESCRIPTION
Modifying the events pumpmanagers report was hack to try to deal with invalid events. Fixing the pumpmanagers is a better solution.  The pumpmanagers that were reporting the invalid events are removed from the main code now.

Adding a fatalError if invalid pump events are submitted, so pumpmanager developers will discover issues like this faster.