### PR TITLE
Update lyumjev peak to 45 minutes

### DIFF
--- a/LoopKit/Insulin/ExponentialInsulinModelPreset.swift
+++ b/LoopKit/Insulin/ExponentialInsulinModelPreset.swift
@@ -42,7 +42,7 @@ extension ExponentialInsulinModelPreset {
         case .fiasp:
             return .minutes(55)
         case .lyumjev:
-            return .minutes(55)
+            return .minutes(45)
         case.afrezza:
             return .minutes(29)
         }


### PR DESCRIPTION
## Purpose

Modify the lyumjev peak from 55 minutes to 45 minutes.

The lyumjev exponential model parameters match those of the fiasp model (code before this PR)
* See my comment in [LoopKit Issue 531](https://github.com/LoopKit/LoopKit/issues/531#issuecomment-3348633407)
* This issue was primarily focused for Loop Users
* Now, these insulin models are also used for Trio which modifies the exponential model:
   * In Trio, the actionDuration for all insulins is modified to a default value of 10 hours
   * The longer actionDuration modifies the shape of the curve in the early hours following delivery
* The request from Trio developers is to change the peakActivity from 55 to 45 minutes
   * This simplifies the use of lyumjev for Trio users in that they no longer need to manually modify that parameter

## Consequence

If this is accepted, then it will be announced that anyone who currently uses the lyumjev model needs to be aware that the peak time is different. If they got better results with Loop before the change, they can select the fiasp model instead.

The [comment](https://github.com/LoopKit/LoopKit/issues/531#issuecomment-3348890351) from @damonbayer is that Loop users will not notice much difference.

Evidently Trio users are affected more by this change.