### PR TITLE
Pretty print pump events

### DIFF
--- a/LoopKit/InsulinKit/DoseEntry.swift
+++ b/LoopKit/InsulinKit/DoseEntry.swift
@@ -155,16 +155,16 @@ extension DoseEntry {
     public var formatted: String {
         return [
             "type: \(type)",
-            "isMutable: \(isMutable)",
             "automatic: \(optionalString(automatic))",
-            "startDate: \(startDate)",
-            "endDate: \(endDate)",
+            "isMutable: \(isMutable)",
             "deliveredUnits: \(deliveredUnits != nil ? deliveredUnits!.insulinFormatter : "nil")",
             "units: \(value.insulinFormatter)",
-            "description: \(optionalString(description))",
             "insulinType: \(optionalString(insulinType))",
+            "startDate: \(startDate)",
+            "endDate: \(endDate)",
             "manuallyEntered: \(manuallyEntered)",
             "wasProgrammedByPumpUI: \(wasProgrammedByPumpUI)",
+            "description: \(optionalString(description))",
             "scheduledBasalRate: \(optionalString(scheduledBasalRate))",
         ].joined(separator: "\n")
     }

--- a/LoopKit/InsulinKit/DoseEntry.swift
+++ b/LoopKit/InsulinKit/DoseEntry.swift
@@ -166,6 +166,7 @@ extension DoseEntry {
             "wasProgrammedByPumpUI: \(wasProgrammedByPumpUI)",
             "description: \(optionalString(description))",
             "scheduledBasalRate: \(optionalString(scheduledBasalRate))",
+            "syncIdentifier: \(optionalString(syncIdentifier))",
         ].joined(separator: "\n")
     }
 }

--- a/LoopKit/InsulinKit/DoseEntry.swift
+++ b/LoopKit/InsulinKit/DoseEntry.swift
@@ -303,9 +303,9 @@ fileprivate extension Double {
         formatter.maximumFractionDigits = 3
         formatter.locale = Locale.current
         if let formattedValue = formatter.string(from: self) {
-            return(formattedValue)
+            return formattedValue
         } else {
-            return("nil")
+            return "nil"
         }
     }
 }

--- a/LoopKit/InsulinKit/DoseEntry.swift
+++ b/LoopKit/InsulinKit/DoseEntry.swift
@@ -151,6 +151,23 @@ extension DoseEntry {
 
         return deliveredUnits ?? round(programmedUnits * DoseEntry.minimumMinimedIncrementPerUnit) / DoseEntry.minimumMinimedIncrementPerUnit
     }
+
+    public var formatted: String {
+        return [
+            "type: \(type)",
+            "isMutable: \(isMutable)",
+            "automatic: \(optionalString(automatic))",
+            "startDate: \(startDate)",
+            "endDate: \(endDate)",
+            "deliveredUnits: \(deliveredUnits != nil ? deliveredUnits!.insulinFormatter : "nil")",
+            "units: \(value.insulinFormatter)",
+            "description: \(optionalString(description))",
+            "insulinType: \(optionalString(insulinType))",
+            "manuallyEntered: \(manuallyEntered)",
+            "wasProgrammedByPumpUI: \(wasProgrammedByPumpUI)",
+            "scheduledBasalRate: \(optionalString(scheduledBasalRate))",
+        ].joined(separator: "\n")
+    }
 }
 
 extension DoseEntry: Codable {
@@ -275,4 +292,26 @@ extension DoseEntry: RawRepresentable {
 
         return rawValue
     }
+}
+
+fileprivate extension Double {
+    var insulinFormatter: String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 1
+        formatter.maximumFractionDigits = 3
+        formatter.locale = Locale.current
+        if let formattedValue = formatter.string(from: self) {
+            return(formattedValue)
+        } else {
+            return("nil")
+        }
+    }
+}
+
+fileprivate func optionalString(_ object : Any?) -> String {
+    if object == nil {
+        return "nil"
+    }
+    return String(describing: object!)
 }


### PR DESCRIPTION
## Purpose

This is in response to [Loop Issue 2383](https://github.com/LoopKit/Loop/issues/2383).

This PR along with [Loop PR 2403](https://github.com/LoopKit/Loop/pull/2403) modify the formatting for the pump event history so the detailed view is easier to read.