### PR TITLE
Fixes title gutter on OverrideSelectionViewController

### DIFF
--- a/LoopKitUI/View Controllers/OverrideSelectionViewController.swift
+++ b/LoopKitUI/View Controllers/OverrideSelectionViewController.swift
@@ -22,6 +22,7 @@ public protocol OverrideSelectionViewControllerDelegate: AnyObject {
 }
 
 public final class OverrideSelectionViewController: UICollectionViewController, IdentifiableClass {
+    private static let contentHorizontalInset: CGFloat = 20
 
     public var glucoseUnit: HKUnit!
 
@@ -49,6 +50,13 @@ public final class OverrideSelectionViewController: UICollectionViewController, 
         collectionView?.backgroundColor = .systemGroupedBackground
         navigationItem.rightBarButtonItems = [saveButton, editButton]
         navigationItem.leftBarButtonItem = cancelButton
+
+        navigationController?.navigationBar.directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: Self.contentHorizontalInset,
+            bottom: 0,
+            trailing: Self.contentHorizontalInset
+        )
     }
 
     @objc private func cancel() {
@@ -398,7 +406,8 @@ public final class OverrideSelectionViewController: UICollectionViewController, 
 
 extension OverrideSelectionViewController: UICollectionViewDelegateFlowLayout {
     private var sectionInsets: UIEdgeInsets {
-        return UIEdgeInsets(top: 0, left: 12, bottom: 12, right: 12)
+        let horizontalInset = Self.contentHorizontalInset
+        return UIEdgeInsets(top: 0, left: horizontalInset, bottom: 12, right: horizontalInset)
     }
 
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
@@ -411,8 +420,8 @@ extension OverrideSelectionViewController: UICollectionViewDelegateFlowLayout {
         layout collectionViewLayout: UICollectionViewLayout,
         sizeForItemAt indexPath: IndexPath
     ) -> CGSize {
-        let paddingSpace = sectionInsets.left * 2
-        let width = view.frame.width - paddingSpace
+        let paddingSpace = sectionInsets.left + sectionInsets.right
+        let width = collectionView.bounds.width - paddingSpace
         let height: CGFloat
         switch cellContent(for: indexPath) {
         case .scheduledOverride, .preset:


### PR DESCRIPTION
The OverrideSelectionViewController title ('Custom Preset') has no gutter in the latest dev and so is not aligned with the rest of the content on the page. Small PR to correct this as it keeps bugging me!

Before:
<img width="389" height="800" alt="image" src="https://github.com/user-attachments/assets/c766ee2a-e5b1-4b04-866b-879bd66e87e6" />

After: 
<img width="389" height="800" alt="image" src="https://github.com/user-attachments/assets/65cccdfc-656c-4c5c-a42d-180a275ce8bb" />
