### PR TITLE
Add opaque bolusReference and a shared bolus origin store

### DIFF
--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -319,7 +319,7 @@
 		892155152245C57E009112BC /* SegmentedGaugeBarLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892155142245C57E009112BC /* SegmentedGaugeBarLayer.swift */; };
 		892155182245FBEF009112BC /* InsulinSensitivityScalingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892155162245FBEF009112BC /* InsulinSensitivityScalingTableViewCell.swift */; };
 		892155192245FBEF009112BC /* InsulinSensitivityScalingTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 892155172245FBEF009112BC /* InsulinSensitivityScalingTableViewCell.xib */; };
-		892A5D28222EF567008961AB /* (null) in Sources */ = {isa = PBXBuildFile; };
+		892A5D28222EF567008961AB /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		892A5D2E222EF69A008961AB /* MockHUDProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892A5D2D222EF69A008961AB /* MockHUDProvider.swift */; };
 		892A5D46222F03CB008961AB /* LoopTestingKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 892A5D36222F03CB008961AB /* LoopTestingKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		892A5D49222F03CC008961AB /* LoopTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 892A5D34222F03CB008961AB /* LoopTestingKit.framework */; };
@@ -462,6 +462,7 @@
 		9E784341236656770016C583 /* ice_35_min_partial_piecewiselinear_output.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E784340236656770016C583 /* ice_35_min_partial_piecewiselinear_output.json */; };
 		9E784343236659BD0016C583 /* ice_slow_absorption_piecewiselinear_output.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E784342236659BD0016C583 /* ice_slow_absorption_piecewiselinear_output.json */; };
 		9E78434523665B5A0016C583 /* ice_35_min_partial_piecewiselinear_adaptiverate_output.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E78434423665B5A0016C583 /* ice_35_min_partial_piecewiselinear_adaptiverate_output.json */; };
+		A3CCF575EF0E4E4E84F0D496 /* BolusOriginStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 448F0FEA2D41F0D00F177071 /* BolusOriginStore.swift */; };
 		A9012EB225BA3861000813AD /* SetupUIResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9012EB125BA3861000813AD /* SetupUIResult.swift */; };
 		A91263872790B45300C6C950 /* NewPumpEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91263862790B45300C6C950 /* NewPumpEventTests.swift */; };
 		A912BE29245B9CD500CBE199 /* SettingsObject+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912BE28245B9CD500CBE199 /* SettingsObject+CoreDataClass.swift */; };
@@ -1363,6 +1364,7 @@
 		43FB60E620DCBC55002B996B /* RadioSelectionTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioSelectionTableViewController.swift; sourceTree = "<group>"; };
 		43FB60E820DCBE64002B996B /* PumpManagerStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PumpManagerStatus.swift; sourceTree = "<group>"; };
 		43FB610620DDF19B002B996B /* PumpManagerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PumpManagerError.swift; sourceTree = "<group>"; };
+		448F0FEA2D41F0D00F177071 /* BolusOriginStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BolusOriginStore.swift; sourceTree = "<group>"; };
 		8907E35821A9D0EC00335852 /* GlucoseEntryTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlucoseEntryTableViewController.swift; sourceTree = "<group>"; };
 		8907E35A21A9D1B200335852 /* SineCurveParametersTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SineCurveParametersTableViewController.swift; sourceTree = "<group>"; };
 		89186C0424BEC9CA0003D0F3 /* SegmentedControlTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedControlTableViewCell.swift; sourceTree = "<group>"; };
@@ -2663,6 +2665,7 @@
 				4302F4E81D5066F400F0FCAF /* ReservoirValue.swift */,
 				A9498D6E23386C0B00DAA9B9 /* TempBasalRecommendation.swift */,
 				C1DB55B01F2E95FD00C483A2 /* WalshInsulinModel.swift */,
+				448F0FEA2D41F0D00F177071 /* BolusOriginStore.swift */,
 			);
 			path = InsulinKit;
 			sourceTree = "<group>";
@@ -4259,6 +4262,7 @@
 				89F6E30F244A1A5D00CB9E15 /* Guardrail.swift in Sources */,
 				A985464F251449FE0099C1A6 /* NotificationSettings.swift in Sources */,
 				C187337E29B9481500519CDF /* LocalizedString.swift in Sources */,
+				A3CCF575EF0E4E4E84F0D496 /* BolusOriginStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4408,7 +4412,7 @@
 				B42C950E24A3BD4B00857C73 /* MeasurementFrequencyTableViewController.swift in Sources */,
 				B45774352562CCC6004B9466 /* SupportedRangeTableViewController.swift in Sources */,
 				B45703C22A1808ED00F615B7 /* MockCGMManagerControlsView.swift in Sources */,
-				892A5D28222EF567008961AB /* (null) in Sources */,
+				892A5D28222EF567008961AB /* BuildFile in Sources */,
 				B45703C32A1808F600F615B7 /* MockCGMManagerSettingsViewModel.swift in Sources */,
 				B451D10D2A161A3E004878F1 /* MockPumpManagerSettingsView.swift in Sources */,
 				C1E0EEF624EB26D800086510 /* DeliveryUncertaintyRecoveryView.swift in Sources */,

--- a/LoopKit/DeviceManager/PumpManager.swift
+++ b/LoopKit/DeviceManager/PumpManager.swift
@@ -169,6 +169,24 @@ public protocol PumpManager: DeviceManager {
     ///   - error: An optional error describing why the command failed
     func enactBolus(units: Double, activationType: BolusActivationType, completion: @escaping (_ error: PumpManagerError?) -> Void)
 
+    /// Send a bolus command carrying an opaque, caller-supplied reference, and handle the result.
+    ///
+    /// The reference is meaningless to the pump manager: it is stored alongside the in-progress dose and
+    /// echoed back, unchanged, on the resulting `DoseEntry.bolusReference` so the caller can correlate the
+    /// reported dose with the request that produced it. Pump managers that persist their in-progress dose
+    /// should persist the reference too, so the correlation survives an app restart while delivery is ongoing.
+    ///
+    /// A default implementation drops the reference and forwards to
+    /// `enactBolus(units:activationType:completion:)`, so existing pump managers remain source compatible.
+    ///
+    /// - Parameters:
+    ///   - units: The number of units to deliver
+    ///   - activationType: Whether the dose was triggered automatically as opposed to commanded by user
+    ///   - bolusReference: An opaque caller-supplied reference echoed back on the reported `DoseEntry`, or nil
+    ///   - completion: A closure called after the command is complete
+    ///   - error: An optional error describing why the command failed
+    func enactBolus(units: Double, activationType: BolusActivationType, bolusReference: UUID?, completion: @escaping (_ error: PumpManagerError?) -> Void)
+
     /// Cancels the current, in progress, bolus.
     ///
     /// - Parameters:
@@ -228,6 +246,12 @@ public protocol PumpManager: DeviceManager {
 
 
 public extension PumpManager {
+    /// Default implementation for pump managers that have not adopted bolus references. The opaque reference
+    /// is dropped and the call is forwarded to `enactBolus(units:activationType:completion:)`.
+    func enactBolus(units: Double, activationType: BolusActivationType, bolusReference: UUID?, completion: @escaping (_ error: PumpManagerError?) -> Void) {
+        enactBolus(units: units, activationType: activationType, completion: completion)
+    }
+
     func roundToSupportedBasalRate(unitsPerHour: Double) -> Double {
         return supportedBasalRates.filter({$0 <= unitsPerHour}).max() ?? 0
     }

--- a/LoopKit/InsulinKit/BolusOriginStore.swift
+++ b/LoopKit/InsulinKit/BolusOriginStore.swift
@@ -1,0 +1,119 @@
+//
+//  BolusOriginStore.swift
+//  LoopKit
+//
+//  Correlates a bolus request with the dose the pump later reports, so a caller (the app) can record where a
+//  bolus came from and a consumer (e.g. a remote-data service) can read it back. Lives in LoopKit so both the
+//  app and in-process service plugins can share one instance; it is file-backed so the mapping survives an app
+//  restart while a bolus is in flight.
+//
+//  Copyright © 2025 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+/// Where a user-initiated bolus came from. Autobolus / SMB is intentionally absent — that is already conveyed
+/// by the dose's `automatic` flag (and, in Trio, the SMB event type). `rawValue` is the machine token uploaded
+/// to Nightscout; `displayName` is the human label. Not every app uses every case (e.g. Loop has no bolus
+/// shortcut), which is fine.
+public enum BolusOrigin: String, Codable {
+    case remote
+    case watch
+    case manual
+    case shortcut
+
+    public var displayName: String {
+        switch self {
+        case .remote: return "Remote"
+        case .watch: return "Watch"
+        case .manual: return "Manual"
+        case .shortcut: return "Shortcut"
+        }
+    }
+}
+
+public final class BolusOriginStore {
+    public static let shared = BolusOriginStore()
+
+    private struct Entry: Codable {
+        let origin: BolusOrigin
+        let createdAt: Date
+    }
+
+    private let lock = NSRecursiveLock()
+    private var entries: [String: Entry]
+
+    /// In-flight references are short-lived; drop anything older than this so the file stays bounded.
+    private static let maxAge: TimeInterval = 6 * 60 * 60
+
+    private let fileURL: URL?
+
+    init(fileURL: URL? = BolusOriginStore.defaultFileURL) {
+        self.fileURL = fileURL
+        let loaded = fileURL
+            .flatMap { try? Data(contentsOf: $0) }
+            .flatMap { try? JSONDecoder().decode([String: Entry].self, from: $0) } ?? [:]
+        let cutoff = Date().addingTimeInterval(-Self.maxAge)
+        entries = loaded.filter { $0.value.createdAt > cutoff }
+    }
+
+    private static var defaultFileURL: URL? {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?
+            .appendingPathComponent("bolus_origins.json")
+    }
+
+    /// Remember an origin under a freshly generated reference and return the reference to pass to the pump.
+    public func makeReference(for origin: BolusOrigin) -> UUID {
+        let reference = UUID()
+        sync {
+            entries[reference.uuidString] = Entry(origin: origin, createdAt: Date())
+            persist()
+        }
+        return reference
+    }
+
+    /// When the reported dose is known, re-key the origin from its request reference to the pump's stable
+    /// `syncIdentifier`, which is what persists in the dose store and is available at upload time.
+    public func promoteReference(_ reference: UUID, toSyncIdentifier syncIdentifier: String) {
+        sync {
+            guard let entry = entries.removeValue(forKey: reference.uuidString) else { return }
+            entries[syncIdentifier] = entry
+            persist()
+        }
+    }
+
+    /// Resolve the origin recorded for a reported dose's `syncIdentifier`, if any.
+    public func origin(forSyncIdentifier syncIdentifier: String) -> BolusOrigin? {
+        sync { entries[syncIdentifier]?.origin }
+    }
+
+    /// Resolve the origin directly by its request reference. Use this when the reference is still available on
+    /// the reported dose (no `syncIdentifier` promotion needed).
+    public func origin(forReference reference: UUID) -> BolusOrigin? {
+        sync { entries[reference.uuidString]?.origin }
+    }
+
+    /// Drop a mapping once it has been consumed, or clean up a request that failed.
+    public func remove(reference: UUID) {
+        sync { entries.removeValue(forKey: reference.uuidString); persist() }
+    }
+
+    public func remove(syncIdentifier: String) {
+        sync { entries.removeValue(forKey: syncIdentifier); persist() }
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult private func sync<T>(_ body: () -> T) -> T {
+        lock.lock(); defer { lock.unlock() }
+        return body()
+    }
+
+    /// Caller must hold `lock`.
+    private func persist() {
+        let cutoff = Date().addingTimeInterval(-Self.maxAge)
+        entries = entries.filter { $0.value.createdAt > cutoff }
+        guard let fileURL = fileURL, let data = try? JSONEncoder().encode(entries) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+}

--- a/LoopKit/InsulinKit/BolusOriginStore.swift
+++ b/LoopKit/InsulinKit/BolusOriginStore.swift
@@ -11,6 +11,7 @@
 //
 
 import Foundation
+import os.log
 
 /// Where a user-initiated bolus came from. Autobolus / SMB is intentionally absent — that is already conveyed
 /// by the dose's `automatic` flag (and, in Trio, the SMB event type). `rawValue` is the machine token uploaded
@@ -40,24 +41,38 @@ public final class BolusOriginStore {
         let createdAt: Date
     }
 
-    private let lock = NSRecursiveLock()
+    private let log = OSLog(category: "BolusOriginStore")
+    private let lock = NSLock()
+
+    /// Entries are keyed by either a request reference's `uuidString` or a reported dose's `syncIdentifier`
+    /// (after promotion). The two key kinds share one dictionary on purpose: a key is only ever written and
+    /// read as one kind, and a pump's syncIdentifier colliding with a caller-minted UUID string is not a
+    /// realistic concern.
     private var entries: [String: Entry]
 
     /// In-flight references are short-lived; drop anything older than this so the file stays bounded.
+    /// Expiry is applied when the store is loaded and whenever it is persisted — deliberately not on lookup,
+    /// so a dose that surfaces late (e.g. resolved after prolonged uncertain delivery) still gets its origin
+    /// if the entry happens to survive.
     private static let maxAge: TimeInterval = 6 * 60 * 60
 
     private let fileURL: URL?
 
-    init(fileURL: URL? = BolusOriginStore.defaultFileURL) {
+    public init(fileURL: URL? = BolusOriginStore.defaultFileURL) {
         self.fileURL = fileURL
-        let loaded = fileURL
-            .flatMap { try? Data(contentsOf: $0) }
-            .flatMap { try? JSONDecoder().decode([String: Entry].self, from: $0) } ?? [:]
+        var loaded: [String: Entry] = [:]
+        if let fileURL = fileURL, let data = try? Data(contentsOf: fileURL) {
+            do {
+                loaded = try JSONDecoder().decode([String: Entry].self, from: data)
+            } catch {
+                OSLog(category: "BolusOriginStore").error("Discarding unreadable bolus origin file: %{public}@", String(describing: error))
+            }
+        }
         let cutoff = Date().addingTimeInterval(-Self.maxAge)
         entries = loaded.filter { $0.value.createdAt > cutoff }
     }
 
-    private static var defaultFileURL: URL? {
+    public static var defaultFileURL: URL? {
         FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?
             .appendingPathComponent("bolus_origins.json")
     }
@@ -113,7 +128,11 @@ public final class BolusOriginStore {
     private func persist() {
         let cutoff = Date().addingTimeInterval(-Self.maxAge)
         entries = entries.filter { $0.value.createdAt > cutoff }
-        guard let fileURL = fileURL, let data = try? JSONEncoder().encode(entries) else { return }
-        try? data.write(to: fileURL, options: .atomic)
+        guard let fileURL = fileURL else { return }
+        do {
+            try JSONEncoder().encode(entries).write(to: fileURL, options: .atomic)
+        } catch {
+            log.error("Failed to persist bolus origins: %{public}@", String(describing: error))
+        }
     }
 }

--- a/LoopKit/InsulinKit/DoseEntry.swift
+++ b/LoopKit/InsulinKit/DoseEntry.swift
@@ -22,6 +22,9 @@ public struct DoseEntry: TimelineValue, Equatable {
     public let automatic: Bool?
     public let manuallyEntered: Bool
     public internal(set) var syncIdentifier: String?
+    /// An opaque, caller-supplied reference echoed back from the bolus request that produced this dose, or nil.
+    /// The pump manager does not interpret it; it lets the caller correlate a reported dose with its request.
+    public let bolusReference: UUID?
     public let isMutable: Bool
     public let wasProgrammedByPumpUI: Bool
 
@@ -37,7 +40,7 @@ public struct DoseEntry: TimelineValue, Equatable {
     }
 
     // If the insulin model field is nil, it's assumed that the model is the type of insulin the pump dispenses
-    public init(type: DoseType, startDate: Date, endDate: Date? = nil, value: Double, unit: DoseUnit, deliveredUnits: Double? = nil, description: String? = nil, syncIdentifier: String? = nil, scheduledBasalRate: HKQuantity? = nil, insulinType: InsulinType? = nil, automatic: Bool? = nil, manuallyEntered: Bool = false, isMutable: Bool = false, wasProgrammedByPumpUI: Bool = false) {
+    public init(type: DoseType, startDate: Date, endDate: Date? = nil, value: Double, unit: DoseUnit, deliveredUnits: Double? = nil, description: String? = nil, syncIdentifier: String? = nil, scheduledBasalRate: HKQuantity? = nil, insulinType: InsulinType? = nil, automatic: Bool? = nil, manuallyEntered: Bool = false, isMutable: Bool = false, wasProgrammedByPumpUI: Bool = false, bolusReference: UUID? = nil) {
         self.type = type
         self.startDate = startDate
         self.endDate = endDate ?? startDate
@@ -52,6 +55,7 @@ public struct DoseEntry: TimelineValue, Equatable {
         self.manuallyEntered = manuallyEntered
         self.isMutable = isMutable
         self.wasProgrammedByPumpUI = wasProgrammedByPumpUI
+        self.bolusReference = bolusReference
     }
 }
 
@@ -167,6 +171,7 @@ extension DoseEntry {
             "description: \(optionalString(description))",
             "scheduledBasalRate: \(optionalString(scheduledBasalRate))",
             "syncIdentifier: \(optionalString(syncIdentifier))",
+            "bolusReference: \(optionalString(bolusReference))",
         ].joined(separator: "\n")
     }
 }
@@ -188,6 +193,7 @@ extension DoseEntry: Codable {
             self.scheduledBasalRate = HKQuantity(unit: HKUnit(from: scheduledBasalRateUnit), doubleValue: scheduledBasalRate)
         }
         self.automatic = try container.decodeIfPresent(Bool.self, forKey: .automatic)
+        self.bolusReference = try container.decodeIfPresent(UUID.self, forKey: .bolusReference)
         self.manuallyEntered = try container.decodeIfPresent(Bool.self, forKey: .manuallyEntered) ?? false
         self.isMutable = try container.decodeIfPresent(Bool.self, forKey: .isMutable) ?? false
         self.wasProgrammedByPumpUI = try container.decodeIfPresent(Bool.self, forKey: .wasProgrammedByPumpUI) ?? false
@@ -209,6 +215,7 @@ extension DoseEntry: Codable {
             try container.encode(DoseEntry.unitsPerHour.unitString, forKey: .scheduledBasalRateUnit)
         }
         try container.encodeIfPresent(automatic, forKey: .automatic)
+        try container.encodeIfPresent(bolusReference, forKey: .bolusReference)
         if manuallyEntered {
             try container.encode(manuallyEntered, forKey: .manuallyEntered)
         }
@@ -233,6 +240,7 @@ extension DoseEntry: Codable {
         case scheduledBasalRateUnit
         case insulinType
         case automatic
+        case bolusReference
         case manuallyEntered
         case isMutable
         case wasProgrammedByPumpUI
@@ -266,6 +274,7 @@ extension DoseEntry: RawRepresentable {
         self.description = rawValue["description"] as? String
         self.insulinType = (rawValue["insulinType"] as? InsulinType.RawValue).flatMap { InsulinType(rawValue: $0) }
         self.automatic = rawValue["automatic"] as? Bool
+        self.bolusReference = (rawValue["bolusReference"] as? String).flatMap { UUID(uuidString: $0) }
         self.syncIdentifier = rawValue["syncIdentifier"] as? String
         self.scheduledBasalRate = (rawValue["scheduledBasalRate"] as? Double).flatMap { HKQuantity(unit: .internationalUnitsPerHour, doubleValue: $0) }
         self.isMutable = rawValue["isMutable"] as? Bool ?? false
@@ -288,6 +297,7 @@ extension DoseEntry: RawRepresentable {
         rawValue["description"] = description
         rawValue["insulinType"] = insulinType?.rawValue
         rawValue["automatic"] = automatic
+        rawValue["bolusReference"] = bolusReference?.uuidString
         rawValue["syncIdentifier"] = syncIdentifier
         rawValue["scheduledBasalRate"] = scheduledBasalRate?.doubleValue(for: .internationalUnitsPerHour)
 

--- a/LoopKit/Notification/LoopNotificationUserInfoKey.swift
+++ b/LoopKit/Notification/LoopNotificationUserInfoKey.swift
@@ -10,6 +10,7 @@ public enum LoopNotificationUserInfoKey: String {
     case bolusAmount
     case bolusStartDate
     case bolusActivationType
+    case bolusOrigin
     case alertTypeID
     case managerIDForAlert
     case missedMealTime

--- a/MockKit/MockPumpManager.swift
+++ b/MockKit/MockPumpManager.swift
@@ -466,6 +466,10 @@ public final class MockPumpManager: TestingPumpManager {
     }
 
     public func enactBolus(units: Double, activationType: BolusActivationType, completion: @escaping (PumpManagerError?) -> Void) {
+        enactBolus(units: units, activationType: activationType, bolusReference: nil, completion: completion)
+    }
+
+    public func enactBolus(units: Double, activationType: BolusActivationType, bolusReference: UUID?, completion: @escaping (PumpManagerError?) -> Void) {
 
         logDeviceCommunication("enactBolus(\(units), \(activationType))")
 
@@ -505,7 +509,7 @@ public final class MockPumpManager: TestingPumpManager {
             }
             
             
-            let bolus = UnfinalizedDose(bolusAmount: units, startTime: Date(), duration: .minutes(units / type(of: self).deliveryUnitsPerMinute), insulinType: state.insulinType, automatic: activationType.isAutomatic)
+            let bolus = UnfinalizedDose(bolusAmount: units, startTime: Date(), duration: .minutes(units / type(of: self).deliveryUnitsPerMinute), insulinType: state.insulinType, automatic: activationType.isAutomatic, bolusReference: bolusReference)
             state.unfinalizedBolus = bolus
             
             logDeviceComms(.receive, message: "Bolus accepted")

--- a/MockKit/UnfinalizedDose.swift
+++ b/MockKit/UnfinalizedDose.swift
@@ -40,6 +40,7 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
     var duration: TimeInterval
     let insulinType: InsulinType?
     let automatic: Bool?
+    let bolusReference: UUID?
 
     var finishTime: Date {
         get {
@@ -82,7 +83,7 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         return units
     }
 
-    init(bolusAmount: Double, startTime: Date, duration: TimeInterval, insulinType: InsulinType? = nil, automatic: Bool = false) {
+    init(bolusAmount: Double, startTime: Date, duration: TimeInterval, insulinType: InsulinType? = nil, automatic: Bool = false, bolusReference: UUID? = nil) {
         self.doseType = .bolus
         self.units = bolusAmount
         self.startTime = startTime
@@ -90,6 +91,7 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         self.scheduledUnits = nil
         self.insulinType = insulinType
         self.automatic = automatic
+        self.bolusReference = bolusReference
     }
 
     init(tempBasalRate: Double, startTime: Date, duration: TimeInterval, insulinType: InsulinType? = nil) {
@@ -100,6 +102,7 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         self.scheduledUnits = nil
         self.insulinType = insulinType
         self.automatic = true
+        self.bolusReference = nil
     }
 
     init(suspendStartTime: Date, automatic: Bool? = nil) {
@@ -109,6 +112,7 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         self.duration = 0
         self.insulinType = nil
         self.automatic = automatic
+        self.bolusReference = nil
     }
 
     init(resumeStartTime: Date, insulinType: InsulinType? = nil, automatic: Bool? = nil) {
@@ -118,6 +122,7 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         self.duration = 0
         self.insulinType = insulinType
         self.automatic = automatic
+        self.bolusReference = nil
     }
 
     public mutating func cancel(at date: Date) {
@@ -214,6 +219,7 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         }
         
         self.automatic = rawValue["automatic"] as? Bool
+        self.bolusReference = (rawValue["bolusReference"] as? String).flatMap { UUID(uuidString: $0) }
     }
 
     public var rawValue: RawValue {
@@ -240,6 +246,10 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
             rawValue["automatic"] = automatic
         }
 
+        if let bolusReference = bolusReference {
+            rawValue["bolusReference"] = bolusReference.uuidString
+        }
+
         return rawValue
     }
 }
@@ -261,7 +271,7 @@ extension NewPumpEvent {
             case .basal:
                 return nil
             case .bolus:
-                var newDose = UnfinalizedDose(bolusAmount: dose.programmedUnits, startTime: dose.startDate, duration: duration, insulinType: dose.insulinType ?? defaultInsulinType, automatic: dose.automatic ?? false)
+                var newDose = UnfinalizedDose(bolusAmount: dose.programmedUnits, startTime: dose.startDate, duration: duration, insulinType: dose.insulinType ?? defaultInsulinType, automatic: dose.automatic ?? false, bolusReference: dose.bolusReference)
                 if let delivered = dose.deliveredUnits {
                     newDose.scheduledUnits = dose.programmedUnits
                     newDose.units = delivered
@@ -283,7 +293,7 @@ extension DoseEntry {
     init (_ dose: UnfinalizedDose) {
         switch dose.doseType {
         case .bolus:
-            self = DoseEntry(type: .bolus, startDate: dose.startTime, endDate: dose.finishTime, value: dose.scheduledUnits ?? dose.units, unit: .units, deliveredUnits: dose.finalizedUnits, insulinType: dose.insulinType, automatic: dose.automatic, isMutable: dose.isMutable)
+            self = DoseEntry(type: .bolus, startDate: dose.startTime, endDate: dose.finishTime, value: dose.scheduledUnits ?? dose.units, unit: .units, deliveredUnits: dose.finalizedUnits, insulinType: dose.insulinType, automatic: dose.automatic, isMutable: dose.isMutable, bolusReference: dose.bolusReference)
         case .tempBasal:
             self = DoseEntry(type: .tempBasal, startDate: dose.startTime, endDate: dose.finishTime, value: dose.scheduledTempRate ?? dose.rate, unit: .unitsPerHour, deliveredUnits: dose.finalizedUnits, insulinType: dose.insulinType, isMutable: dose.isMutable)
         case .suspend:


### PR DESCRIPTION
Adds an optional UUID bolusReference to enactBolus and DoseEntry that the pump echoes back on the reported dose, so a caller can correlate a delivered dose with its request. A default protocol method keeps existing pump managers unchanged; MockKit persists and echoes it as a reference implementation.

Also adds BolusOriginStore (with a BolusOrigin enum) that records where a bolus came from, keyed by the request reference or the reported syncIdentifier, file-backed so it survives an app restart while a bolus is in flight.

Related PRs: loopandlearn/OmnipodKit#102 (pod echoes the reference), LoopKit/Loop#2455 and nightscout/Trio#1252 (apps), LoopKit/NightscoutKit#3 and LoopKit/NightscoutService#27 (upload).