### PR TITLE
Add PumpManager.setBLEHeartbeatRequest with CGM reading schedule (non-breaking)

### DIFF
--- a/LoopKit/DeviceManager/CGMManager.swift
+++ b/LoopKit/DeviceManager/CGMManager.swift
@@ -200,6 +200,13 @@ public extension CGMManager {
             }
         }
     }
+
+    /// The expected interval between glucose readings from this CGM. Used to schedule a pump-provided
+    /// BLE heartbeat (see `PumpManager.setBLEHeartbeatRequest(_:)`). Defaults to 5 minutes, which matches
+    /// virtually every CGM; a source with a different cadence may override.
+    var expectedGlucoseSampleInterval: TimeInterval {
+        return .minutes(5)
+    }
 }
 
 

--- a/LoopKit/DeviceManager/PumpManager.swift
+++ b/LoopKit/DeviceManager/PumpManager.swift
@@ -21,6 +21,23 @@ public enum AutomatedTreatmentState: Equatable {
     case minimumDelivery
 }
 
+/// Describes a request that the pump provide its own periodic BLE heartbeat (used when the CGM cannot
+/// wake the app, e.g. a network/remote CGM). Rather than a bare "provide a heartbeat" flag, it tells the
+/// pump *when* the last CGM reading landed and how often readings are expected, so the pump can schedule
+/// its next heartbeat to arrive just *after* the next reading is due — see `setBLEHeartbeatRequest(_:)`.
+public struct PumpHeartbeatRequest: Equatable {
+    /// The date of the most recent CGM reading, if any. `nil` when no reading has been received yet.
+    public let lastCGMReadingDate: Date?
+
+    /// The expected interval between CGM readings (e.g. 5 minutes for most CGMs).
+    public let expectedCGMReadingInterval: TimeInterval
+
+    public init(lastCGMReadingDate: Date?, expectedCGMReadingInterval: TimeInterval) {
+        self.lastCGMReadingDate = lastCGMReadingDate
+        self.expectedCGMReadingInterval = expectedCGMReadingInterval
+    }
+}
+
 public protocol PumpManagerStatusObserver: AnyObject {
     func pumpManager(_ pumpManager: PumpManager, didUpdate status: PumpManagerStatus, oldStatus: PumpManagerStatus)
 }
@@ -167,6 +184,18 @@ public protocol PumpManager: DeviceManager {
     /// The manager may choose to still enable its own heartbeat even if `mustProvideBLEHeartbeat` is false
     func setMustProvideBLEHeartbeat(_ mustProvideBLEHeartbeat: Bool)
 
+    /// Loop calls this to tell the pump whether it must provide its own periodic BLE heartbeat, and — when
+    /// it must — when the last CGM reading landed and how often readings are expected. `request == nil`
+    /// means no pump heartbeat is required (the CGM wakes the app itself). When non-nil, the pump should
+    /// schedule its next heartbeat to fire no earlier than
+    /// `lastCGMReadingDate + expectedCGMReadingInterval` (plus a small buffer, since the heartbeat usually
+    /// drives fetching a remote CGM value that then needs time to be stored). The manager may still run its
+    /// own heartbeat when `request` is nil.
+    ///
+    /// A default implementation bridges to `setMustProvideBLEHeartbeat(_:)` for managers that don't need the
+    /// timing detail, so existing PumpManagers need not implement this.
+    func setBLEHeartbeatRequest(_ request: PumpHeartbeatRequest?)
+
     /// Returns a dose estimator for the current bolus, if one is in progress
     func createBolusProgressReporter(reportingOn dispatchQueue: DispatchQueue) -> DoseProgressReporter?
 
@@ -241,6 +270,11 @@ public protocol PumpManager: DeviceManager {
 
 
 public extension PumpManager {
+    /// Default bridge for managers that only need the boolean "must provide a heartbeat" signal.
+    func setBLEHeartbeatRequest(_ request: PumpHeartbeatRequest?) {
+        setMustProvideBLEHeartbeat(request != nil)
+    }
+
     func roundToSupportedBasalRate(unitsPerHour: Double) -> Double {
         return supportedBasalRates.filter({$0 <= unitsPerHour}).max() ?? 0
     }


### PR DESCRIPTION
## Summary
Adds a richer, **non-breaking** path alongside `setMustProvideBLEHeartbeat`: instead of a bare boolean, Loop can tell the pump *when* the last CGM reading landed and *how often* readings are expected, so a pump that provides its own BLE heartbeat can schedule its next wake to arrive just after the next reading is due.

- `PumpHeartbeatRequest { lastCGMReadingDate, expectedCGMReadingInterval }`
- `PumpManager.setBLEHeartbeatRequest(_:)` — a protocol requirement **with a default implementation** that bridges to `setMustProvideBLEHeartbeat(_:)`. **No existing PumpManager needs changes**: Minimed, Medtrum, MockKit, etc. inherit the default and behave exactly as before (they only implement the bool method). Only OmnipodKit overrides it.
- `CGMManager.expectedGlucoseSampleInterval` (extension default, 5 min).

Verified non-breaking: the full LoopWorkspace (every pump/CGM plugin) builds against this.

## ⚠️ Coupling — must merge together
This is consumed by the coupled **Loop** and **OmnipodKit** PRs; both fail to compile without it. Merge together. (Cross-links below.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Tbv6GBAMmGATWp6zwBDy7


### Coupled PRs — merge together (three-way dependency)
- **LoopKit** LoopKit/LoopKit#596 — `PumpManager.setBLEHeartbeatRequest` protocol API
- **Loop** LoopKit/Loop#2461 — DeviceDataManager wiring + manager-state preservation
- **OmnipodKit** loopkitdev/OmnipodKit#4 — heartbeat / connection-policy implementation

Loop and OmnipodKit will not compile without the LoopKit protocol change; land all three together and bump the LoopWorkspace next-dev submodule pins in one commit.
