### PR TITLE
Add PumpManager.setBLEHeartbeatRequest with CGM reading schedule (dev backport)

### DIFF
--- a/LoopKit/DeviceManager/CGMManager.swift
+++ b/LoopKit/DeviceManager/CGMManager.swift
@@ -165,6 +165,22 @@ public protocol CGMManager: DeviceManager {
     func delete(completion: @escaping () -> Void)
 }
 
+public extension CGMManager {
+    func fetchNewDataIfNeeded() async -> CGMReadingResult {
+        await withCheckedContinuation { continuation in
+            fetchNewDataIfNeeded { result in
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
+    /// The expected interval between glucose readings from this CGM. Used to schedule a pump-provided
+    /// BLE heartbeat (see `PumpManager.setBLEHeartbeatRequest(_:)`). Defaults to 5 minutes, which matches
+    /// virtually every CGM; a source with a different cadence may override.
+    var expectedGlucoseSampleInterval: TimeInterval {
+        return .minutes(5)
+    }
+}
 
 public extension CGMManager {
     var appURL: URL? {

--- a/LoopKit/DeviceManager/PumpManager.swift
+++ b/LoopKit/DeviceManager/PumpManager.swift
@@ -13,6 +13,23 @@ public enum PumpManagerResult<T> {
     case failure(PumpManagerError)
 }
 
+/// Describes a request that the pump provide its own periodic BLE heartbeat (used when the CGM cannot
+/// wake the app, e.g. a network/remote CGM). Rather than a bare "provide a heartbeat" flag, it tells the
+/// pump *when* the last CGM reading landed and how often readings are expected, so the pump can schedule
+/// its next heartbeat to arrive just *after* the next reading is due — see `setBLEHeartbeatRequest(_:)`.
+public struct PumpHeartbeatRequest: Equatable {
+    /// The date of the most recent CGM reading, if any. `nil` when no reading has been received yet.
+    public let lastCGMReadingDate: Date?
+
+    /// The expected interval between CGM readings (e.g. 5 minutes for most CGMs).
+    public let expectedCGMReadingInterval: TimeInterval
+
+    public init(lastCGMReadingDate: Date?, expectedCGMReadingInterval: TimeInterval) {
+        self.lastCGMReadingDate = lastCGMReadingDate
+        self.expectedCGMReadingInterval = expectedCGMReadingInterval
+    }
+}
+
 public protocol PumpManagerStatusObserver: AnyObject {
     func pumpManager(_ pumpManager: PumpManager, didUpdate status: PumpManagerStatus, oldStatus: PumpManagerStatus)
 }
@@ -154,6 +171,18 @@ public protocol PumpManager: DeviceManager {
     /// The manager may choose to still enable its own heartbeat even if `mustProvideBLEHeartbeat` is false
     func setMustProvideBLEHeartbeat(_ mustProvideBLEHeartbeat: Bool)
 
+    /// Loop calls this to tell the pump whether it must provide its own periodic BLE heartbeat, and — when
+    /// it must — when the last CGM reading landed and how often readings are expected. `request == nil`
+    /// means no pump heartbeat is required (the CGM wakes the app itself). When non-nil, the pump should
+    /// schedule its next heartbeat to fire no earlier than
+    /// `lastCGMReadingDate + expectedCGMReadingInterval` (plus a small buffer, since the heartbeat usually
+    /// drives fetching a remote CGM value that then needs time to be stored). The manager may still run its
+    /// own heartbeat when `request` is nil.
+    ///
+    /// A default implementation bridges to `setMustProvideBLEHeartbeat(_:)` for managers that don't need the
+    /// timing detail, so existing PumpManagers need not implement this.
+    func setBLEHeartbeatRequest(_ request: PumpHeartbeatRequest?)
+
     /// Returns a dose estimator for the current bolus, if one is in progress
     func createBolusProgressReporter(reportingOn dispatchQueue: DispatchQueue) -> DoseProgressReporter?
 
@@ -228,6 +257,11 @@ public protocol PumpManager: DeviceManager {
 
 
 public extension PumpManager {
+    /// Default bridge for managers that only need the boolean "must provide a heartbeat" signal.
+    func setBLEHeartbeatRequest(_ request: PumpHeartbeatRequest?) {
+        setMustProvideBLEHeartbeat(request != nil)
+    }
+
     func roundToSupportedBasalRate(unitsPerHour: Double) -> Double {
         return supportedBasalRates.filter({$0 <= unitsPerHour}).max() ?? 0
     }


### PR DESCRIPTION
### Summary

Backports the LoopKit heartbeat API to the **dev** line. This is the dev counterpart of #596 (which landed on `next-dev`), enabling a PumpManager to schedule a pump-provided BLE heartbeat from the CGM reading cadence — needed so the OmnipodKit connect-on-demand / CGM-aligned heartbeat work (loopandlearn `ble-heartbeat`) can build and land on dev.

### Changes (additive, source-compatible)

`PumpManager.swift`
- `PumpHeartbeatRequest` — carries the last CGM reading date + expected reading interval, so the pump can time its next heartbeat to arrive just after the next reading is due.
- `PumpManager.setBLEHeartbeatRequest(_:)` protocol requirement, with a default extension implementation that bridges to `setMustProvideBLEHeartbeat(_:)`. Existing PumpManagers need not implement it.

`CGMManager.swift`
- `fetchNewDataIfNeeded()` async wrapper and `expectedGlucoseSampleInterval` (defaults to 5 min), used to schedule the pump heartbeat.

### Notes on the dev port

Same change as #596, adapted for the dev line. The dev port omits the `AutomatedTreatmentState` enum that sat adjacent to the new type on next-dev (a separate next-dev feature not present on dev). No other differences.

### Testing

Verified in a `LoopKit/LoopWorkspace@dev` workspace with OmnipodKit swapped to loopandlearn `ble-heartbeat`:
- **Build SUCCEEDED** — 0 errors (without this API, the OmnipodKit heartbeat code fails with `cannot find type 'PumpHeartbeatRequest'`).
- **OmniTests: 189 tests, 3 skipped, 0 failures.**