### PR TITLE
CheckmarkListItem: opt out of iOS 26 Liquid Glass button styling

### DIFF
--- a/LoopKitUI/Views/CheckmarkListItem.swift
+++ b/LoopKitUI/Views/CheckmarkListItem.swift
@@ -54,6 +54,12 @@ public struct CheckmarkListItem<LeadingView: View>: View {
             Button(action: { self.isSelected = true }) {
                 content
             }
+            // Opt out of iOS 26 Liquid Glass's default button styling, which otherwise
+            // wraps each row's custom label in a tinted Capsule background (ballooning into
+            // ovals on the tall multi-line rows) and accent-tints all the text. .plain keeps
+            // the row a borderless tappable item; the checkmark stays accent-colored via its
+            // own foregroundColor.
+            .buttonStyle(.plain)
         } else {
             content
         }


### PR DESCRIPTION
## Problem

On next-dev with the Liquid Glass (iOS 26) migration, the "Share Data" usage-preference screen renders with distorted layout: every row's text is accent-blue and each option sits in an oval "blob" background (worse on the tall multi-line rows).

Root cause is in `CheckmarkListItem`: each row is a plain `Button { customLabel }` with **no** `.buttonStyle`. Pre-iOS-26 that rendered borderless; under iOS 26 a custom-label `Button` adopts the new default **glass** style — a tinted Capsule background + accent-tinted label. A Capsule's corner radius is half its height, so the tall multi-line rows balloon into ovals (short rows look like rounded rects), and all the text turns blue.

## Fix

Add `.buttonStyle(.plain)` to the row button. Rows render as borderless tappable items again (label in its own colors, no background); the selection checkmark stays accent-colored via its own `.foregroundColor`. One line, fixes every `CheckmarkListItem` usage — the Share Data screen and others.

Compile-verified (Loop scheme, iPhone 17 sim). Worth an on-device eyeball since it's a visual fix.

## Note

This is the general iOS-26 pattern — any `Button { customLabel }` without an explicit `.buttonStyle` now picks up glass styling. Other such spots across Loop may show similar artifacts; this PR only covers `CheckmarkListItem`.
