### PR TITLE
Survive a persistent store that fails to load

### DIFF
--- a/LoopKit/DosingDecisionStore.swift
+++ b/LoopKit/DosingDecisionStore.swift
@@ -43,6 +43,15 @@ public class DosingDecisionStore {
     }
 
     public func storeDosingDecision(_ dosingDecision: StoredDosingDecision) async {
+        // See SettingsStore.storeSettings: inserting into a stack that failed to load traps in
+        // DosingDecisionObject.awakeFromInsert on a nil modificationCounter.
+        do {
+            try await store.waitUntilReady()
+        } catch {
+            log.error("Not storing dosing decision, persistent store unavailable: %{public}@", String(describing: error))
+            return
+        }
+
         if let data = self.encodeDosingDecision(dosingDecision) {
             self.store.managedObjectContext.performAndWait {
                 let object = DosingDecisionObject(context: self.store.managedObjectContext)

--- a/LoopKit/Persistence/PersistenceController.swift
+++ b/LoopKit/Persistence/PersistenceController.swift
@@ -90,8 +90,29 @@ public final class PersistenceController {
         }
     }
 
+    /// Waits for the persistent stack to finish loading.
+    ///
+    /// - Throws: `PersistenceControllerError` if the stack failed to load.
+    func waitUntilReady() async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            onReady { error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
     // Cache model
     private static var cachedModel: NSManagedObjectModel?
+
+    /// How many times a writable store retries when another process holds it. Delays are
+    /// cumulative (0.5s, 1.0s, 1.5s), so a wedged store costs at most ~3s before giving up.
+    private static let busyStoreRetryCount = 3
+
+    private static let busyStoreRetryDelay: TimeInterval = 0.5
 
     private static func model() throws -> NSManagedObjectModel {
         if cachedModel == nil {
@@ -208,24 +229,56 @@ public final class PersistenceController {
 
             let storeURL = directoryURL.appendingPathComponent("Model.sqlite")
 
-            var options: [AnyHashable : Any] = [
-                NSMigratePersistentStoresAutomaticallyOption: true,
-                NSInferMappingModelAutomaticallyOption: true
-            ]
-            
+            var options: [AnyHashable : Any] = [:]
+
+            if self.isReadOnly {
+                // A read-only opener -- in practice an app extension sharing the container app's
+                // store -- must never migrate. Two processes racing a migration is what produces
+                // SQLITE_BUSY "Failed to replace destination database": one builds the migrated
+                // copy in a temp file and cannot swap it into place because the other holds the
+                // store open. Open read-only and fail fast instead of joining the race. If the
+                // store needs migrating, the extension gets no data until the container app has
+                // done it -- which is the correct outcome, and better than the alternatives.
+                options[NSReadOnlyPersistentStoreOption] = true
+                options[NSMigratePersistentStoresAutomaticallyOption] = false
+                options[NSInferMappingModelAutomaticallyOption] = false
+            } else {
+                options[NSMigratePersistentStoresAutomaticallyOption] = true
+                options[NSInferMappingModelAutomaticallyOption] = true
+            }
+
 #if os(iOS)
             options[NSPersistentStoreFileProtectionKey] = FileProtectionType.completeUntilFirstUserAuthentication
 #endif
 
-            do {
-                try coordinator.addPersistentStore(ofType: NSSQLiteStoreType,
-                    configurationName: nil,
-                    at: storeURL,
-                    options: options
-                )
-            } catch let storeError as NSError {
-                self.log.error("Failed to initialize persistenceController: %{public}@", storeError)
-                error = .coreDataError(storeError)
+            // Retry a busy store. Read-only openers still hold shared locks, so making them
+            // fail fast narrows the window without closing it -- and the writer is the one
+            // process that has to win eventually. Read-only openers do not retry: there is
+            // nothing for them to wait for that a retry would fix.
+            var attempt = 0
+            while true {
+                do {
+                    try coordinator.addPersistentStore(ofType: NSSQLiteStoreType,
+                        configurationName: nil,
+                        at: storeURL,
+                        options: options
+                    )
+                    break
+                } catch let storeError as NSError {
+                    guard !self.isReadOnly,
+                          storeError.isPersistentStoreBusy,
+                          attempt < PersistenceController.busyStoreRetryCount
+                    else {
+                        self.log.error("Failed to initialize persistenceController: %{public}@", storeError)
+                        error = .coreDataError(storeError)
+                        break
+                    }
+                    attempt += 1
+                    let delay = PersistenceController.busyStoreRetryDelay * Double(attempt)
+                    self.log.default("Persistent store busy, retrying in %{public}.1fs (attempt %{public}d of %{public}d)",
+                                     delay, attempt, PersistenceController.busyStoreRetryCount)
+                    Thread.sleep(forTimeInterval: delay)
+                }
             }
 
             self.queue.async {
@@ -317,4 +370,15 @@ fileprivate extension FileManager {
         }
     }
  
+}
+
+
+fileprivate extension NSError {
+    /// True when Core Data could not open the store because another process holds it, rather than
+    /// because the store is missing or damaged. Only these are worth retrying.
+    var isPersistentStoreBusy: Bool {
+        guard domain == NSSQLiteErrorDomain else { return false }
+        // SQLITE_BUSY (5) and SQLITE_LOCKED (6).
+        return code == 5 || code == 6
+    }
 }

--- a/LoopKit/SettingsStore.swift
+++ b/LoopKit/SettingsStore.swift
@@ -72,6 +72,21 @@ public class SettingsStore {
     }
     
     public func storeSettings(_ settings: StoredSettings, completion: @escaping (Error?) -> Void) {
+        // Never insert into a stack that failed to load. Its coordinator has no persistent store,
+        // so SettingsObject.awakeFromInsert -> updateModificationCounter finds a nil
+        // modificationCounter and traps on the force-unwrap. Report the failure instead. Every
+        // other store that writes this stack already gates on onReady.
+        store.onReady { readyError in
+            if let readyError = readyError {
+                self.log.error("Not storing settings, persistent store unavailable: %{public}@", String(describing: readyError))
+                completion(readyError)
+                return
+            }
+            self.storeSettingsWhenReady(settings, completion: completion)
+        }
+    }
+
+    private func storeSettingsWhenReady(_ settings: StoredSettings, completion: @escaping (Error?) -> Void) {
         dataAccessQueue.async {
             var error: Error?
 


### PR DESCRIPTION
A launch crash traced back to a Core Data migration losing a race with the widget extension. The crash is in `SettingsObject.awakeFromInsert`, but the cause is several layers down.

## The chain

From a sysdiagnose, main app PID 4719 — the same PID as the crashed process:

```
21:28:12  4719  Loop   Failed to initialize persistenceController: Error Domain=NSSQLiteErrorDomain
                       Code=5 NSFilePath=.../com.loopkit.LoopKit/Model.sqlite
                       Source database Path=.../.Model.sqlite.migrationdestination_41b5a6b5...
                       reason=Failed to replace destination database
```

Code 5 is `SQLITE_BUSY`. A lightweight migration built the migrated copy in a temp file and then could not swap it over `Model.sqlite`, because another process held the shared App Group store open. That process is in the log too, 293ms later:

```
21:37:01.560  4734  Loop                   Code=5    Failed to replace destination database
21:37:01.853  4738  Loop Widget Extension  Code=256, NSSQLiteErrorDomain=3850
```

3850 decodes as `SQLITE_IOERR_LOCK` (`10 | (15<<8)`). It is a race, not a deterministic failure — a later launch got through and reached `PersistenceController save`.

From there:

1. `initializeStack` assigns the coordinator (line 201) **before** adding the store (line 221), so a throw leaves a live coordinator holding zero persistent stores.
2. In that state `NSManagedObjectContext.modificationCounter` returns `nil` — its only nil path is `persistentStores.first` being absent.
3. `SettingsStore.storeSettings` inserts anyway.
4. `SettingsObject.awakeFromInsert` → `updateModificationCounter` → `setPrimitiveValue(managedObjectContext!.modificationCounter!, …)` traps.

Confirmed in the debugger: `po managedObjectContext!.modificationCounter` prints `nil` without crashing, so it is the second force-unwrap, and the context dump shows `_persistentStoreIdentifiers = 0x0`.

## Changes

**Honour `isReadOnly` when opening the store.** `controllerInAppGroupDirectory` already computes it correctly — `isReadOnly || Bundle.main.isAppExtension` — but it only ever reached `saveInternal`'s guard. The store itself was opened read-write with `NSMigratePersistentStoresAutomaticallyOption: true` unconditionally, so an app extension was free to migrate a store the container app owns. Read-only openers now pass `NSReadOnlyPersistentStoreOption` and disable migration, so they fail fast instead of joining the race.

The tradeoff is deliberate: if the store needs migrating, the extension gets no data until the container app has done it. That is the correct outcome, and better than two processes racing a migration.

**Retry a writable store on `SQLITE_BUSY`/`SQLITE_LOCKED`** — three attempts with cumulative backoff, ~3s worst case, on the private context queue. Read-only openers still hold shared locks, so making them fail fast narrows the window without closing it, and the writer is the one process that has to win eventually. Read-only openers do not retry; there is nothing a retry would fix for them.

**Gate the two ungated writers on the stack being ready.** These were the only two writers of this stack that did not wait:

| store | before |
|---|---|
| CarbStore, DoseStore, InsulinDeliveryStore, GlucoseStore, CgmEventStore | already gate on `onReady` |
| **SettingsStore**, **DosingDecisionStore** | straight to `managedObjectContext.performAndWait` |

Settings now reports the failure through its existing completion handler rather than inserting into a coordinator with no store. A small `waitUntilReady()` async wrapper around `onReady` is added for the `async` call site.

Note this is about the stack having *failed*, not about a timing window: `initializeStack` runs via `managedObjectContext.perform` from `init`, so it is first in the private queue's FIFO and later `performAndWait` calls serialise behind it.

## Why this is not just a development-branch problem

Any release that changes the model migrates on first launch after upgrade — which is exactly when the widget is most likely to be running and holding the store. Every user with the widget installed rolls these dice on upgrade day, and today's failure mode is a crash loop rather than a degraded launch. The ready-gate is the part I would want in even if the other two land later.

## Left alone

The seven `updateModificationCounter()` force-unwraps (`SettingsObject`, `DosingDecisionObject`, `PumpEvent`, `CachedInsulinDeliveryObject`, `CachedGlucoseObject`, `DeviceLogEntry`, `CgmEvent`) are unchanged. With every writer of this stack now gated, they should be unreachable. Softening them is also not free: `modificationCounter` drives the sync anchors (`modificationCounter > %d`), so silently leaving it at 0 would make an object invisible to anchored queries — trading a crash for silent sync loss. If they are hardened later it should be with a loud log, not a quiet `guard`.

`PersistentDeviceLog` is untouched — it uses a separate `NSPersistentContainer` ("DeviceLog"), not this store.

## Testing

`SettingsStore`, `DosingDecisionStore`, `PersistenceController` and the Core Data object suites all pass — 51 tests. The migration race itself is timing-dependent and was not reproduced synthetically.
