### PR TITLE
Unbreak LoopKit CI on next-dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 
 jobs:
   test:
-    working_directory: *project_directory
+    working_directory: ~/project
     resource_class: m4pro.medium
     macos:
       xcode: "26.1.1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,29 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Check out LoopAlgorithm
+          command: |
+            git clone --depth 1 --branch main https://github.com/LoopKit/LoopAlgorithm.git LoopAlgorithm
+      - run:
+          name: Generate CI workspace
+          command: |
+            # LoopKit.xcodeproj takes LoopAlgorithm as a package supplied by the ENCLOSING
+            # workspace -- that is how LoopWorkspace provides it, as a local package folder --
+            # so its product dependency deliberately carries no package reference of its own and
+            # cannot resolve when the project is built standalone. Build through a workspace that
+            # supplies the same local package rather than adding a second, remote pin here.
+            mkdir -p CI.xcworkspace
+            printf '%s\n' \
+              '<?xml version="1.0" encoding="UTF-8"?>' \
+              '<Workspace version = "1.0">' \
+              '   <FileRef location = "group:LoopKit.xcodeproj"></FileRef>' \
+              '   <FileRef location = "group:LoopAlgorithm"></FileRef>' \
+              '</Workspace>' \
+              > CI.xcworkspace/contents.xcworkspacedata
+      - run:
           name: Test
           command: |
-            set -o pipefail && xcodebuild -project LoopKit.xcodeproj -scheme Shared build -destination 'name=iPhone 17' test | xcpretty
+            set -o pipefail && xcodebuild -workspace CI.xcworkspace -scheme Shared build -destination 'name=iPhone 17' test | xcpretty
       - store_test_results:
           path: test_output
   package:

--- a/LoopKit/TestingDate.swift
+++ b/LoopKit/TestingDate.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2025 LoopKit Authors. All rights reserved.
 //
 
+import Foundation
 
 public enum TestingDate {
 

--- a/LoopKitUI/Views/ChartPointsScatterBorderedCirclesLayer.swift
+++ b/LoopKitUI/Views/ChartPointsScatterBorderedCirclesLayer.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2025 LoopKit Authors. All rights reserved.
 //
 
+import UIKit
 import SwiftCharts
 
 class ChartPointsScatterBorderedCirclesLayer<T: ChartPoint>: ChartPointsScatterCirclesLayer<T> {

--- a/LoopKitUI/Views/GlucoseHistoryLayer.swift
+++ b/LoopKitUI/Views/GlucoseHistoryLayer.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2025 LoopKit Authors. All rights reserved.
 //
 
+import UIKit
 import SwiftCharts
 
 class GlucoseHistoryLayer<T: ChartPoint>: ChartPointsScatterCirclesLayer<T> {

--- a/LoopKitUI/Views/ManualBolusDoseChartLayer.swift
+++ b/LoopKitUI/Views/ManualBolusDoseChartLayer.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2025 LoopKit Authors. All rights reserved.
 //
 
+import UIKit
 import SwiftCharts
 
 class ManualBolusDoseChartLayer<T: ChartPoint>: ChartPointsScatterLayer<T> {


### PR DESCRIPTION
LoopKit CI is broken on `next-dev` in three independent ways, all introduced by tidepool sync merges. `dev` is unaffected and green throughout (builds 398–401), so this is a `next-dev`-only regression.

## 1. The config does not parse

```
Unable to parse YAML: found undefined alias project_directory
in 'string', line 9, column 24:
        working_directory: *project_directory
```

Every pipeline since 2026-03-10 has died here, before running anything.

The `8abb5929` sync merge combined the two sides badly. Its parents:

```
8abb5929^1 (DIY)       no Variables block, and no working_directory line
8abb5929^2 (tidepool)  project_directory: &project_directory ~/project
                       ...
                       working_directory: *project_directory
```

It kept tidepool's **use** of the alias and DIY's **absence of the definition**. There is one use site, so the value is inlined rather than restoring the `Variables` block — which also avoids depending on CircleCI tolerating an unknown top-level key that exists only to host an anchor.

## 2. `TestingDate.swift` has no imports

```
LoopKit/TestingDate.swift:14:16: error: cannot find type 'Date' in scope
```

The file uses `Date` and `TimeInterval` but imports nothing. It builds inside LoopWorkspace only because Xcode compiles the module in batch mode, where a sibling file's import happens to satisfy the lookup — `swiftc -typecheck` on the file alone fails. The `package` job compiles it through `Package.swift` and does not get that accident.

It arrived on `next-dev` with `e0a822df` (LOOP-5439, #704) and does not exist on `dev`.

## 3. `test` cannot resolve LoopAlgorithm

```
Testing failed: Missing package product 'LoopAlgorithm'
```

The job built `LoopKit.xcodeproj` standalone. But LoopKit takes LoopAlgorithm as a package supplied by the **enclosing workspace** — LoopWorkspace adds it as a local package folder (`contents.xcworkspacedata` carries `location = "group:LoopAlgorithm"`, backed by a submodule), and the project's `XCSwiftPackageProductDependency` deliberately carries no `package =` of its own. That is the correct shape for a workspace-supplied local package, not a defect.

So CI now gets the same arrangement: clone LoopAlgorithm beside the checkout, build through a generated two-item workspace.

The alternative — adding an `XCRemoteSwiftPackageReference` to `LoopKit.xcodeproj` — was considered and rejected. It would leave LoopWorkspace with two packages named LoopAlgorithm, the submodule and a GitHub checkout, risking silent divergence from the one Loop actually builds against.

On `dev` this job passes because LoopKit there has no LoopAlgorithm dependency at all.

## Verification

Reproduced the CI layout exactly — LoopAlgorithm beside `LoopKit.xcodeproj`, the same generated workspace, the same `xcodebuild` invocation:

- no `Missing package product` error
- `LoopKitTests.xctest` and `LoopKitHostedTests.xctest` both pass
- `** TEST SUCCEEDED **`

The generate step was also extracted from the parsed YAML and run verbatim through bash to confirm it emits the workspace file that was tested.

## Caveat

The clone tracks LoopAlgorithm `main`, not a pinned revision. LoopKit's repository has no knowledge of the submodule pin, and `Package.swift` already depends on the same branch, so CI can drift from the revision LoopWorkspace builds against. Worth knowing if a LoopAlgorithm change ever breaks LoopKit CI without any LoopKit commit.
