### PR TITLE
Fix infinite loop applying an override that ends on an entry boundary

### DIFF
--- a/LoopKit/TemporaryScheduleOverride.swift
+++ b/LoopKit/TemporaryScheduleOverride.swift
@@ -724,8 +724,17 @@ extension Array where Element == TemporaryScheduleOverride {
             while presetIndex < self.count {
                 let preset = self[presetIndex]
 
-                // Skip presets that end before this sensitivity period
-                if preset.actualEndDate < start {
+                // Skip presets that end before -- or exactly at -- the point we have
+                // advanced to. `isActive(at:)` tests a DateInterval, which is CLOSED at
+                // both ends, so a preset is still "active" at its own actualEndDate. With
+                // a strict `<` here, a preset ending exactly at `start` fell through to
+                // the active branch below, where `end` computes back to `start`: the
+                // preset index did not advance, `start` did not advance, and the loop did
+                // not break, so it appended a zero-length entry per pass until allocation
+                // failed. Reached in the field while recommending a manual bolus, which
+                // truncates the active override to end exactly at the dose time.
+                // A preset ending at `start` has no remaining duration to contribute.
+                if preset.actualEndDate <= start {
                     presetIndex += 1
                     continue
                 }

--- a/LoopKitTests/TemporaryScheduleOverrideTests.swift
+++ b/LoopKitTests/TemporaryScheduleOverrideTests.swift
@@ -483,6 +483,68 @@ class TemporaryScheduleOverrideTests: XCTestCase {
         XCTAssertEqual(expectedValues, values)
     }
 
+    /// An override whose end lands exactly on the end of a timeline entry it is
+    /// active over used to spin forever in `apply(over:transform:)`: the preset
+    /// index never advanced, `start` never advanced, and the loop never broke, so
+    /// it appended a zero-length entry per pass until allocation failed. Seen in
+    /// the field as a crash in `swift_abortAllocationFailure` under
+    /// `Array.append` while recommending a manual bolus -- that path truncates
+    /// the active override to end exactly at the dose time.
+    func testTimelineApplicationWithOverrideEndingExactlyAtEntryEnd() {
+        let timeline = [
+            AbsoluteScheduleValue(startDate: .t(1), endDate: .t(2), value: 50.0),
+            AbsoluteScheduleValue(startDate: .t(2), endDate: .t(3), value: 120.0),
+        ]
+
+        let overrides: [TemporaryScheduleOverride] = [
+            .custom(scale: 0.5, start: .t(1), end: .t(2))
+        ]
+
+        let applied = overrides.applySensitivity(over: timeline)
+
+        XCTAssertEqual([Date.t(1), .t(2)], applied.map { $0.startDate })
+        XCTAssertEqual([Date.t(2), .t(3)], applied.map { $0.endDate })
+        XCTAssertEqual([100.0, 120.0], applied.map { $0.value })
+    }
+
+    /// Same boundary condition on the basal path, which is where the field crash
+    /// was reported (`applyBasal` -> `apply` -> `Array.append`).
+    func testBasalApplicationWithOverrideEndingExactlyAtEntryEnd() {
+        let timeline = [
+            AbsoluteScheduleValue(startDate: .t(1), endDate: .t(2), value: 1.0),
+            AbsoluteScheduleValue(startDate: .t(2), endDate: .t(3), value: 2.0),
+        ]
+
+        let overrides: [TemporaryScheduleOverride] = [
+            .custom(scale: 0.5, start: .t(1), end: .t(2))
+        ]
+
+        let applied = overrides.applyBasal(over: timeline)
+
+        XCTAssertEqual([Date.t(1), .t(2)], applied.map { $0.startDate })
+        XCTAssertEqual([Date.t(2), .t(3)], applied.map { $0.endDate })
+        XCTAssertEqual([0.5, 2.0], applied.map { $0.value })
+    }
+
+    /// The override covers the entry exactly AND is the only entry, so the loop
+    /// reaches `start == entry.endDate == preset.actualEndDate` with nothing
+    /// after it to advance into.
+    func testTimelineApplicationWithOverrideExactlyCoveringSoleEntry() {
+        let timeline = [
+            AbsoluteScheduleValue(startDate: .t(1), endDate: .t(2), value: 50.0),
+        ]
+
+        let overrides: [TemporaryScheduleOverride] = [
+            .custom(scale: 0.5, start: .t(1), end: .t(2))
+        ]
+
+        let applied = overrides.applySensitivity(over: timeline)
+
+        XCTAssertEqual([Date.t(1)], applied.map { $0.startDate })
+        XCTAssertEqual([Date.t(2)], applied.map { $0.endDate })
+        XCTAssertEqual([100.0], applied.map { $0.value })
+    }
+
     func testTimelineSensitivityApplicationInMiddleOfTimeRange() {
         let timeline = [
             AbsoluteScheduleValue(startDate: .t(1) , endDate: .t(3), value: 50.0),


### PR DESCRIPTION
Reported from the field as a crash while entering a manual glucose value, after a CGM sensor outage:

```
3   libswiftCore.dylib   swift::fatalErrorv(unsigned int, char const*, char*)
5   libswiftCore.dylib   swift::swift_abortAllocationFailure(unsigned long, unsigned long)
8   libswiftCore.dylib   _ArrayBuffer._consumeAndCreateNew(bufferIsUnique:minimumCapacity:growForAppend:)
10  libswiftCore.dylib   Array.append(_:)
11  LoopKit              Array<A>.apply<A>(over:transform:)
12  LoopKit              Array<A>.applyBasal(over:)
13  Loop                 LoopDataManager.fetchData(for:presumePresetEndingNow:...)
14  Loop                 LoopDataManager.recommendManualBolus(...)
```

This is not a large-data allocation. `apply(over:transform:)` spun forever and grew the result array until allocation failed.

## The loop

```swift
while presetIndex < self.count {
    let preset = self[presetIndex]

    if preset.actualEndDate < start { presetIndex += 1; continue }

    if preset.isActive(at: start) {
        let end = Swift.min(entry.endDate, preset.actualEndDate)
        result.append(…)                                   // every pass
        if entry.endDate > end { presetIndex += 1 }        // false when equal
        start = end                                         // no-op when end == start
        if preset.actualEndDate > entry.endDate { break }   // false when equal
    }
```

`isActive(at:)` tests `activeInterval`, a `DateInterval` — and `DateInterval.contains` is **closed at both ends**, so an override reports itself active at exactly its own `actualEndDate`. The skip guard used a strict `<`, so a preset ending exactly at the point the loop had advanced to fell through to the active branch instead of being skipped.

Once there, `end` computes back to `start` and all three exits fail together: the preset index does not advance, `start` does not advance, and the loop does not break. Each pass appends a zero-length `AbsoluteScheduleValue`.

## Why it is systematic, not a rare coincidence

Both boundaries are pinned to `baseTime` by the same call, so they coincide by construction rather than by luck.

`LoopDataManager.fetchData` truncates the active override to an exact instant on the manual bolus path:

```swift
if presumePresetEndingNow,
   let activeOverride = temporaryPresetsManager.activeOverride,
   let index = overrides.lastIndex(of: activeOverride) {
    overrides[index].scheduledEndDate = baseTime      // actualEndDate == baseTime
}
…
let basalWithOverrides = overrides.applyBasal(over: basal)
```

And a few lines earlier it builds the basal timeline:

```swift
let dosesEnd = max(baseTime, doses.map { $0.endDate }.max() ?? baseTime)
let rawBasal = try await settingsProvider.getBasalHistory(startDate: dosesStart, endDate: dosesEnd)
```

When no dose extends past `baseTime`, `dosesEnd == baseTime`. `getBasalHistory` delegates to `BasalRateSchedule.generateTimeline(schedules:startDate:endDate:)`, whose `while date < endDate` loop ends the final entry exactly at `endDate` — so the last basal entry ends exactly at `baseTime` as well.

Last entry `endDate` == override `actualEndDate` == `baseTime`, with the override active from before that entry began. That is precisely the state the loop cannot leave.

What normally saves it is an in-flight dose: a live temp basal pushes `dosesEnd` past `baseTime`, so the last basal entry ends later than the truncated override and the loop terminates. The crash needs looping to have stalled long enough for the last temp basal to expire.

## Field data confirming the trigger

From the reporter's issue report, the override was indefinite and long-running:

```
startDate: 2026-08-28 00:39:10 +0000
duration:  .indefinite
actualEnd: .natural
```

There was a 25-minute CGM gap, and the last temp basal expired inside it:

```
glucose    15:09:40           last reading before the gap
tempBasal  14:54:48 -> 15:24:48    expires mid-gap
glucose    15:34:40           recovery
tempBasal  15:34:50 -> 16:04:50    not issued until after recovery
```

Between 15:24:48 and 15:34:40 no dose extended past "now" — Loop had stopped looping, so nothing was renewed. That is the window in which the manual glucose was entered and the app crashed.

So the recipe is: an active override, the manual bolus screen, and no dose currently in flight. A CGM outage long enough to outlast the last temp basal is the ordinary way to arrive there.

## Fix

```diff
-if preset.actualEndDate < start {
+if preset.actualEndDate <= start {
     presetIndex += 1
     continue
 }
```

A preset ending exactly at `start` has no remaining duration to contribute, so nothing is lost by skipping it. This makes the interval half-open at the point of use and leaves `isActive(at:)` semantics untouched for its other callers — changing that would be a much wider blast radius for the same result.

## Testing

Three regression tests cover the boundary, on both `applySensitivity` and `applyBasal`, including the case where the override exactly covers the sole timeline entry.

They were verified to fail without the fix, not merely to pass with it: the sole-entry case trips xcodebuild's execution time allowance with *"exceeded execution time allowance of 1 minute. The test may have hung"*. With the fix, the full `LoopKitTests` suite is green at 472 tests.

Note the existing `testTimelineSensitivityApplicationEndingAtSameTime` does not catch this — its override starts mid-entry, so it takes the not-active branch, which does advance the preset index. The hang needs the *active* branch.
