### PR TITLE
Fix intermittent testObserverQueryStartup failures on dev

### DIFF
--- a/LoopKitHostedTests/CarbStoreHKQueryTests.swift
+++ b/LoopKitHostedTests/CarbStoreHKQueryTests.swift
@@ -77,7 +77,7 @@ class CarbStoreHKQueryTests: CarbStoreHKQueryTestsBase {
         mockHealthStore.authorizationStatus = .sharingAuthorized
         hkSampleStore.authorizationIsDetermined()
 
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertNotNil(mockHealthStore.observerQuery)
 
@@ -102,7 +102,7 @@ class CarbStoreHKQueryTests: CarbStoreHKQueryTestsBase {
         mockAnchoredObjectQuery.resultsHandler?(mockAnchoredObjectQuery, [], [], currentAnchor, nil)
 
         // Wait for observerQueryCompletionExpectation
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertNotNil(hkSampleStore.queryAnchor)
 
@@ -128,7 +128,7 @@ class CarbStoreHKQueryTests: CarbStoreHKQueryTestsBase {
         newSampleStore.authorizationIsDetermined()
 
         // Wait for observerQueryCompletionExpectation
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         mockHealthStore.anchorQueryStartedExpectation = expectation(description: "new anchored object query started")
 
@@ -138,7 +138,7 @@ class CarbStoreHKQueryTests: CarbStoreHKQueryTestsBase {
         mockObserverQuery2.updateHandler?(mockObserverQuery2, {}, nil)
 
         // Wait for anchorQueryStartedExpectation
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         // Assert new carb store is querying with the last anchor that our HealthKit mock returned
         let mockAnchoredObjectQuery2 = mockHealthStore.anchoredObjectQuery as! MockHKAnchoredObjectQuery

--- a/LoopKitHostedTests/CarbStoreHKQueryTests.swift
+++ b/LoopKitHostedTests/CarbStoreHKQueryTests.swift
@@ -61,7 +61,7 @@ class CarbStoreHKQueryTestsAuthorized: CarbStoreHKQueryTestsBase {
 
         mockHealthStore.observerQueryStartedExpectation = expectation(description: "observer query started")
 
-        waitForExpectations(timeout: 2)
+        waitForExpectations(timeout: 30)
 
         XCTAssertNotNil(mockHealthStore.observerQuery)
     }

--- a/LoopKitHostedTests/CarbStoreHKQueryTests.swift
+++ b/LoopKitHostedTests/CarbStoreHKQueryTests.swift
@@ -59,9 +59,15 @@ class CarbStoreHKQueryTestsAuthorized: CarbStoreHKQueryTestsBase {
         // Check that an observer query is registered when authorization is already determined.
         XCTAssertFalse(hkSampleStore.authorizationRequired);
 
-        mockHealthStore.observerQueryStartedExpectation = expectation(description: "observer query started")
-
-        waitForExpectations(timeout: 30)
+        // The store is created already authorized in setUp, so the observer query may start
+        // before this test body runs. HKHealthStoreMock drops the fulfillment when the query
+        // starts before observerQueryStartedExpectation is assigned, so waiting on that
+        // expectation times out no matter how generous the timeout. Poll the recorded query
+        // instead -- that is order-independent.
+        let observerQueryStarted = XCTNSPredicateExpectation(
+            predicate: NSPredicate { [weak self] _, _ in self?.mockHealthStore.observerQuery != nil },
+            object: nil)
+        wait(for: [observerQueryStarted], timeout: 30)
 
         XCTAssertNotNil(mockHealthStore.observerQuery)
     }

--- a/LoopKitHostedTests/GlucoseStoreTests.swift
+++ b/LoopKitHostedTests/GlucoseStoreTests.swift
@@ -124,7 +124,7 @@ class GlucoseStoreTestsAuthorized: GlucoseStoreTestsBase {
 
         mockHealthStore.observerQueryStartedExpectation = expectation(description: "observer query started")
 
-        waitForExpectations(timeout: 2)
+        waitForExpectations(timeout: 30)
 
         XCTAssertNotNil(hkSampleStore.observerQuery)
     }

--- a/LoopKitHostedTests/GlucoseStoreTests.swift
+++ b/LoopKitHostedTests/GlucoseStoreTests.swift
@@ -122,9 +122,15 @@ class GlucoseStoreTestsAuthorized: GlucoseStoreTestsBase {
         // Check that an observer query is registered when authorization is already determined.
         XCTAssertFalse(hkSampleStore.authorizationRequired);
 
-        mockHealthStore.observerQueryStartedExpectation = expectation(description: "observer query started")
-
-        waitForExpectations(timeout: 30)
+        // The store is created already authorized in setUp, so the observer query may start
+        // before this test body runs. HKHealthStoreMock drops the fulfillment when the query
+        // starts before observerQueryStartedExpectation is assigned, so waiting on that
+        // expectation times out no matter how generous the timeout. Poll the recorded query
+        // instead -- that is order-independent.
+        let observerQueryStarted = XCTNSPredicateExpectation(
+            predicate: NSPredicate { [weak self] _, _ in self?.mockHealthStore.observerQuery != nil },
+            object: nil)
+        wait(for: [observerQueryStarted], timeout: 30)
 
         XCTAssertNotNil(hkSampleStore.observerQuery)
     }

--- a/LoopKitHostedTests/GlucoseStoreTests.swift
+++ b/LoopKitHostedTests/GlucoseStoreTests.swift
@@ -106,7 +106,7 @@ class GlucoseStoreTestsAuthorizationRequired: GlucoseStoreTestsBase {
         mockHealthStore.authorizationStatus = .sharingAuthorized
         hkSampleStore.authorizationIsDetermined()
 
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertNotNil(hkSampleStore.observerQuery);
     }
@@ -140,7 +140,7 @@ class GlucoseStoreTestSharingUndetermined: GlucoseStoreTestsBase {
         mockHealthStore.authorizationStatus = .sharingAuthorized
         hkSampleStore.authorizationIsDetermined()
 
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertNotNil(mockHealthStore.observerQuery)
 
@@ -165,7 +165,7 @@ class GlucoseStoreTestSharingUndetermined: GlucoseStoreTestsBase {
         mockAnchoredObjectQuery.resultsHandler?(mockAnchoredObjectQuery, [], [], currentAnchor, nil)
 
         // Wait for observerQueryCompletionExpectation
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertNotNil(hkSampleStore.queryAnchor)
 
@@ -188,7 +188,7 @@ class GlucoseStoreTestSharingUndetermined: GlucoseStoreTestsBase {
         newSampleStore.authorizationIsDetermined()
 
         // Wait for observerQueryCompletionExpectation
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         mockHealthStore.anchorQueryStartedExpectation = expectation(description: "new anchored object query started")
 
@@ -198,7 +198,7 @@ class GlucoseStoreTestSharingUndetermined: GlucoseStoreTestsBase {
         mockObserverQuery2.updateHandler?(mockObserverQuery2, {}, nil)
 
         // Wait for anchorQueryStartedExpectation
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         // Assert new carb store is querying with the last anchor that our HealthKit mock returned
         let mockAnchoredObjectQuery2 = mockHealthStore.anchoredObjectQuery as! MockHKAnchoredObjectQuery

--- a/LoopKitHostedTests/InsulinDeliveryStoreTests.swift
+++ b/LoopKitHostedTests/InsulinDeliveryStoreTests.swift
@@ -97,9 +97,15 @@ class InsulinDeliveryStoreTestsAuthorized: InsulinDeliveryStoreTestsBase {
         // Check that an observer query is registered when authorization is already determined.
         XCTAssertFalse(hkSampleStore.authorizationRequired);
 
-        mockHealthStore.observerQueryStartedExpectation = expectation(description: "observer query started")
-
-        waitForExpectations(timeout: 30)
+        // The store is created already authorized in setUp, so the observer query may start
+        // before this test body runs. HKHealthStoreMock drops the fulfillment when the query
+        // starts before observerQueryStartedExpectation is assigned, so waiting on that
+        // expectation times out no matter how generous the timeout. Poll the recorded query
+        // instead -- that is order-independent.
+        let observerQueryStarted = XCTNSPredicateExpectation(
+            predicate: NSPredicate { [weak self] _, _ in self?.mockHealthStore.observerQuery != nil },
+            object: nil)
+        wait(for: [observerQueryStarted], timeout: 30)
 
         XCTAssertNotNil(mockHealthStore.observerQuery)
     }

--- a/LoopKitHostedTests/InsulinDeliveryStoreTests.swift
+++ b/LoopKitHostedTests/InsulinDeliveryStoreTests.swift
@@ -99,7 +99,7 @@ class InsulinDeliveryStoreTestsAuthorized: InsulinDeliveryStoreTestsBase {
 
         mockHealthStore.observerQueryStartedExpectation = expectation(description: "observer query started")
 
-        waitForExpectations(timeout: 2)
+        waitForExpectations(timeout: 30)
 
         XCTAssertNotNil(mockHealthStore.observerQuery)
     }
@@ -844,7 +844,7 @@ class InsulinDeliveryStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testDoseEmptyWithMissingQueryAnchor() {
@@ -862,7 +862,7 @@ class InsulinDeliveryStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testDoseEmptyWithNonDefaultQueryAnchor() {
@@ -880,7 +880,7 @@ class InsulinDeliveryStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testDoseDataWithUnusedQueryAnchor() {
@@ -907,7 +907,7 @@ class InsulinDeliveryStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testDoseDataWithStaleQueryAnchor() {
@@ -932,7 +932,7 @@ class InsulinDeliveryStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testDoseDataWithCurrentQueryAnchor() {
@@ -954,7 +954,7 @@ class InsulinDeliveryStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testDoseDataWithLimitCoveredByData() {
@@ -982,7 +982,7 @@ class InsulinDeliveryStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     private func addDoseData(_ doseData: [DoseDatum]) {

--- a/LoopKitHostedTests/InsulinDeliveryStoreTests.swift
+++ b/LoopKitHostedTests/InsulinDeliveryStoreTests.swift
@@ -118,7 +118,7 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
         mockHealthStore.authorizationStatus = .sharingAuthorized
         hkSampleStore.authorizationIsDetermined()
 
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertNotNil(mockHealthStore.observerQuery)
 
@@ -143,7 +143,7 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
         mockAnchoredObjectQuery.resultsHandler?(mockAnchoredObjectQuery, [], [], currentAnchor, nil)
 
         // Wait for observerQueryCompletionExpectation
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertNotNil(hkSampleStore.queryAnchor)
 
@@ -166,7 +166,7 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
         newSampleStore.authorizationIsDetermined()
 
         // Wait for observerQueryCompletionExpectation
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         mockHealthStore.anchorQueryStartedExpectation = expectation(description: "new anchored object query started")
 
@@ -176,7 +176,7 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
         mockObserverQuery2.updateHandler?(mockObserverQuery2, {}, nil)
 
         // Wait for anchorQueryStartedExpectation
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         // Assert new carb store is querying with the last anchor that our HealthKit mock returned
         let mockAnchoredObjectQuery2 = mockHealthStore.anchoredObjectQuery as! MockHKAnchoredObjectQuery

--- a/LoopKitTests/CarbStoreTests.swift
+++ b/LoopKitTests/CarbStoreTests.swift
@@ -127,7 +127,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
             }
         }
 
-        wait(for: [getCarbEntriesCompletion], timeout: 2, enforceOrder: true)
+        wait(for: [getCarbEntriesCompletion], timeout: 30, enforceOrder: true)
     }
 
     // MARK: -

--- a/LoopKitTests/CarbStoreTests.swift
+++ b/LoopKitTests/CarbStoreTests.swift
@@ -855,7 +855,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
             }
         }
 
-        wait(for: [getSyncCarbObjectsCompletion], timeout: 2, enforceOrder: true)
+        wait(for: [getSyncCarbObjectsCompletion], timeout: 30, enforceOrder: true)
     }
 
     func testSetSyncCarbObjects() {
@@ -941,7 +941,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
             }
         }
 
-        wait(for: [getCarbEntriesCompletion], timeout: 2, enforceOrder: true)
+        wait(for: [getCarbEntriesCompletion], timeout: 30, enforceOrder: true)
     }
 
     // MARK: -
@@ -1065,7 +1065,7 @@ class CarbStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testEmptyWithMissingQueryAnchor() {
@@ -1084,7 +1084,7 @@ class CarbStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testEmptyWithNonDefaultQueryAnchor() {
@@ -1103,7 +1103,7 @@ class CarbStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testDataWithUnusedQueryAnchor() {
@@ -1130,7 +1130,7 @@ class CarbStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testDataWithStaleQueryAnchor() {
@@ -1155,7 +1155,7 @@ class CarbStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testDataWithCurrentQueryAnchor() {
@@ -1178,7 +1178,7 @@ class CarbStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testDataWithLimitZero() {
@@ -1201,7 +1201,7 @@ class CarbStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testDataWithLimitCoveredByData() {
@@ -1228,7 +1228,7 @@ class CarbStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     private func addData(withSyncIdentifiers syncIdentifiers: [String]) {

--- a/LoopKitTests/DoseStoreTests.swift
+++ b/LoopKitTests/DoseStoreTests.swift
@@ -73,7 +73,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             }
             queryFinishedExpectation.fulfill()
         }
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
     }
 
     func testGetNormalizedDoseEntriesUsingReservoir() {
@@ -97,7 +97,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             storageExpectations.fulfill()
         }
         
-        waitForExpectations(timeout: 2)
+        waitForExpectations(timeout: 30)
 
         let queryFinishedExpectation = expectation(description: "query finished")
 
@@ -110,7 +110,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             }
             queryFinishedExpectation.fulfill()
         }
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
     }
 
     func testMutableDosesIncludedInIOB() {
@@ -148,7 +148,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             storageExpectations.fulfill()
         }
 
-        waitForExpectations(timeout: 2)
+        waitForExpectations(timeout: 30)
 
         let queryFinishedExpectation = expectation(description: "query finished")
 
@@ -161,7 +161,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             }
             queryFinishedExpectation.fulfill()
         }
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
     }
 
     
@@ -246,7 +246,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             test_currentDate: f("2018-12-12 18:07:14 +0000")
         )
 
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         // 2. Add a temp basal which has already ended. It should be saved to Health
         let pumpEvents1 = [
@@ -274,7 +274,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             XCTAssertNil(error)
             addPumpEvents1.fulfill()
         }
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertEqual(f("2018-12-12 18:05:58 +0000"), doseStore.insulinDeliveryStore.test_lastImmutableBasalEndDate)
 
@@ -305,7 +305,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             XCTAssertNil(error)
             addPumpEvents2.fulfill()
         }
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertEqual(f("2018-12-12 18:05:58 +0000"), doseStore.insulinDeliveryStore.test_lastImmutableBasalEndDate)
 
@@ -328,7 +328,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             XCTAssertNil(error)
             addPumpEvents3.fulfill()
         }
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertEqual(f("2018-12-12 18:05:58 +0000"), doseStore.insulinDeliveryStore.test_lastImmutableBasalEndDate)
     }
@@ -368,7 +368,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             test_currentDate: f("2018-11-29 11:04:27 +0000")
         )
 
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         doseStore.pumpRecordsBasalProfileStartEvents = false
 
@@ -389,7 +389,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             XCTAssertNil(error)
             addPumpEvents1.fulfill()
         }
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertEqual(f("2018-11-29 10:54:28 +0000"), doseStore.insulinDeliveryStore.test_lastImmutableBasalEndDate)
         XCTAssertEqual(f("2018-11-29 10:59:28 +0000"), doseStore.pumpEventQueryAfterDate)
@@ -409,7 +409,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             XCTAssertNil(error)
             addPumpEvents2.fulfill()
         }
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertEqual(f("2018-11-29 10:54:28 +0000"), doseStore.insulinDeliveryStore.test_lastImmutableBasalEndDate)
         XCTAssertEqual(f("2018-11-29 10:59:28 +0000"), doseStore.pumpEventQueryAfterDate)
@@ -448,7 +448,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             XCTAssertNil(error)
             addPumpEvents3.fulfill()
         }
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertEqual(f("2018-11-29 11:09:27 +0000"), doseStore.insulinDeliveryStore.test_lastImmutableBasalEndDate)
         XCTAssertEqual(f("2018-11-29 11:09:27 +0000"), doseStore.pumpEventQueryAfterDate)
@@ -481,7 +481,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             XCTAssertNil(error)
             addPumpEvents4.fulfill()
         }
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertEqual(f("2018-11-29 11:14:28 +0000"), doseStore.pumpEventQueryAfterDate)
         XCTAssertEqual(f("2018-11-29 11:14:28 +0000"), doseStore.insulinDeliveryStore.test_lastImmutableBasalEndDate)
@@ -505,7 +505,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             XCTAssertNil(error)
             addPumpEvents5.fulfill()
         }
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertEqual(f("2018-11-29 11:14:28 +0000"), doseStore.pumpEventQueryAfterDate)
         XCTAssertEqual(f("2018-11-29 11:14:28 +0000"), doseStore.insulinDeliveryStore.test_lastImmutableBasalEndDate)
@@ -585,7 +585,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             }
         }
 
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertEqual(f("2018-12-12 18:05:00 +0000"), doseStore.insulinDeliveryStore.test_lastImmutableBasalEndDate)
 
@@ -647,7 +647,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             }
         }
 
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
     }
 
     func testUnfinalizedTempBasalCrossingScheduleChange() {
@@ -677,7 +677,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
         )
 
         // Wait for dose store to initialize
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         doseStore.insulinDeliveryStore.test_lastImmutableBasalEndDate = doseStart //.addingTimeInterval(.minutes(-2))
 
@@ -707,7 +707,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             }
         }
 
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
     }
 
 
@@ -735,7 +735,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             test_currentDate: f("2018-12-12 18:07:14 +0000")
         )
 
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         // 2. Add a temp basal which has already ended. It should persist in InsulinDeliveryStore.
         let pumpEvents1 = [
@@ -784,7 +784,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             }
         }
 
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertEqual(f("2018-12-12 18:05:00 +0000"), doseStore.insulinDeliveryStore.test_lastImmutableBasalEndDate)
 
@@ -843,7 +843,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             }
         }
 
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertEqual(f("2018-12-12 18:05:00 +0000"), doseStore.insulinDeliveryStore.test_lastImmutableBasalEndDate)
 
@@ -900,7 +900,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             }
         }
 
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertEqual(f("2018-12-12 18:05:00 +0000"), doseStore.insulinDeliveryStore.test_lastImmutableBasalEndDate)
 
@@ -977,7 +977,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             }
         }
 
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertEqual(f("2018-12-12 18:15:00 +0000"), doseStore.insulinDeliveryStore.test_lastImmutableBasalEndDate)
 
@@ -988,7 +988,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             addPumpEvents5.fulfill();
         }
 
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertEqual(f("2018-12-12 18:05:00 +0000"), doseStore.insulinDeliveryStore.test_lastImmutableBasalEndDate)
 
@@ -1068,7 +1068,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             }
         }
 
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
         XCTAssertEqual(f("2018-12-12 18:40:00 +0000"), doseStore.insulinDeliveryStore.test_lastImmutableBasalEndDate)
     }

--- a/LoopKitTests/DoseStoreTests.swift
+++ b/LoopKitTests/DoseStoreTests.swift
@@ -534,7 +534,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
             // Set the current date
             test_currentDate: f("2018-12-12 18:07:14 +0000")
         )
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 30)
 
 
         // 2. Add a temp basal which has already ended. It should persist in InsulinDeliveryStore.
@@ -1170,7 +1170,7 @@ class DoseStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     func testPumpEventEmptyWithMissingQueryAnchor() {
@@ -1187,7 +1187,7 @@ class DoseStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     func testPumpEventEmptyWithNonDefaultQueryAnchor() {
@@ -1204,7 +1204,7 @@ class DoseStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     func testPumpEventDataWithUnusedQueryAnchor() {
@@ -1226,7 +1226,7 @@ class DoseStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     func testPumpEventDataWithStaleQueryAnchor() {
@@ -1248,7 +1248,7 @@ class DoseStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     func testPumpEventDataWithCurrentQueryAnchor() {
@@ -1269,7 +1269,7 @@ class DoseStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     func testPumpEventDataWithLimitCoveredByData() {
@@ -1292,7 +1292,7 @@ class DoseStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     private func addPumpEventData(withSyncIdentifiers syncIdentifiers: [String]) {

--- a/LoopKitTests/DosingDecisionStoreTests.swift
+++ b/LoopKitTests/DosingDecisionStoreTests.swift
@@ -61,7 +61,7 @@ class DosingDecisionStorePersistenceTests: PersistenceControllerTestCase, Dosing
             storeDosingDecisionCompletion.fulfill()
         }
 
-        wait(for: [storeDosingDecisionHandler, storeDosingDecisionCompletion], timeout: 2, enforceOrder: true)
+        wait(for: [storeDosingDecisionHandler, storeDosingDecisionCompletion], timeout: 30, enforceOrder: true)
     }
 
     func testStoreDosingDecisionMultiple() {
@@ -93,7 +93,7 @@ class DosingDecisionStorePersistenceTests: PersistenceControllerTestCase, Dosing
             storeDosingDecisionCompletion2.fulfill()
         }
 
-        wait(for: [storeDosingDecisionHandler1, storeDosingDecisionCompletion1, storeDosingDecisionHandler2, storeDosingDecisionCompletion2], timeout: 2, enforceOrder: true)
+        wait(for: [storeDosingDecisionHandler1, storeDosingDecisionCompletion1, storeDosingDecisionHandler2, storeDosingDecisionCompletion2], timeout: 30, enforceOrder: true)
     }
 
     func testDosingDecisionObjectEncodable() throws {
@@ -462,7 +462,7 @@ class DosingDecisionStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testEmptyWithMissingQueryAnchor() {
@@ -479,7 +479,7 @@ class DosingDecisionStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testEmptyWithNonDefaultQueryAnchor() {
@@ -496,7 +496,7 @@ class DosingDecisionStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testDataWithUnusedQueryAnchor() {
@@ -518,7 +518,7 @@ class DosingDecisionStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testDataWithStaleQueryAnchor() {
@@ -540,7 +540,7 @@ class DosingDecisionStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testDataWithCurrentQueryAnchor() {
@@ -561,7 +561,7 @@ class DosingDecisionStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testDataWithLimitZero() {
@@ -582,7 +582,7 @@ class DosingDecisionStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testDataWithLimitCoveredByData() {
@@ -605,7 +605,7 @@ class DosingDecisionStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     private func addData(withSyncIdentifiers syncIdentifiers: [UUID]) {

--- a/LoopKitTests/GlucoseStoreTests.swift
+++ b/LoopKitTests/GlucoseStoreTests.swift
@@ -57,7 +57,7 @@ class GlucoseStoreTests: PersistenceControllerTestCase {
             }
             storeCompletion.fulfill()
         }
-        wait(for: [storeCompletion], timeout: 2)
+        wait(for: [storeCompletion], timeout: 30)
         XCTAssertEqual(storedQuantity, self.glucoseStore.latestGlucose?.quantity)
 
         let purgeCompletion = expectation(description: "Storage completion")
@@ -69,7 +69,7 @@ class GlucoseStoreTests: PersistenceControllerTestCase {
             }
             purgeCompletion.fulfill()
         }
-        wait(for: [purgeCompletion], timeout: 2)
+        wait(for: [purgeCompletion], timeout: 30)
         XCTAssertNil(self.glucoseStore.latestGlucose)
     }
 }
@@ -159,7 +159,7 @@ class GlucoseStoreRemoteDataServiceQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     func testEmptyWithMissingQueryAnchor() {
@@ -176,7 +176,7 @@ class GlucoseStoreRemoteDataServiceQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     func testEmptyWithNonDefaultQueryAnchor() {
@@ -193,7 +193,7 @@ class GlucoseStoreRemoteDataServiceQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     func testDataWithUnusedQueryAnchor() {
@@ -216,7 +216,7 @@ class GlucoseStoreRemoteDataServiceQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     func testDataWithStaleQueryAnchor() {
@@ -239,7 +239,7 @@ class GlucoseStoreRemoteDataServiceQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     func testDataWithCurrentQueryAnchor() {
@@ -260,7 +260,7 @@ class GlucoseStoreRemoteDataServiceQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testDataWithLimitZero() {
@@ -281,7 +281,7 @@ class GlucoseStoreRemoteDataServiceQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
 
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
 
     func testDataWithLimitCoveredByData() {
@@ -306,7 +306,7 @@ class GlucoseStoreRemoteDataServiceQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     private func addData(withSyncIdentifiers syncIdentifiers: [String]) {

--- a/LoopKitTests/SettingsStoreTests.swift
+++ b/LoopKitTests/SettingsStoreTests.swift
@@ -93,7 +93,7 @@ class SettingsStorePersistenceTests: PersistenceControllerTestCase, SettingsStor
             storeSettingsCompletion2.fulfill()
         }
         
-        wait(for: [storeSettingsHandler1, storeSettingsCompletion1, storeSettingsHandler2, storeSettingsCompletion2], timeout: 2, enforceOrder: true)
+        wait(for: [storeSettingsHandler1, storeSettingsCompletion1, storeSettingsHandler2, storeSettingsCompletion2], timeout: 30, enforceOrder: true)
     }
     
     // MARK: -

--- a/LoopKitTests/SettingsStoreTests.swift
+++ b/LoopKitTests/SettingsStoreTests.swift
@@ -61,7 +61,7 @@ class SettingsStorePersistenceTests: PersistenceControllerTestCase, SettingsStor
             storeSettingsCompletion.fulfill()
         }
         
-        wait(for: [storeSettingsHandler, storeSettingsCompletion], timeout: 2, enforceOrder: true)
+        wait(for: [storeSettingsHandler, storeSettingsCompletion], timeout: 30, enforceOrder: true)
     }
     
     func testStoreSettingsMultiple() {
@@ -468,7 +468,7 @@ class SettingsStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     func testEmptyWithMissingQueryAnchor() {
@@ -485,7 +485,7 @@ class SettingsStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     func testEmptyWithNonDefaultQueryAnchor() {
@@ -502,7 +502,7 @@ class SettingsStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     func testDataWithUnusedQueryAnchor() {
@@ -524,7 +524,7 @@ class SettingsStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     func testDataWithStaleQueryAnchor() {
@@ -546,7 +546,7 @@ class SettingsStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     func testDataWithCurrentQueryAnchor() {
@@ -567,7 +567,7 @@ class SettingsStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     func testDataWithLimitZero() {
@@ -588,7 +588,7 @@ class SettingsStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     func testDataWithLimitCoveredByData() {
@@ -611,7 +611,7 @@ class SettingsStoreQueryTests: PersistenceControllerTestCase {
             self.completion.fulfill()
         }
         
-        wait(for: [completion], timeout: 2, enforceOrder: true)
+        wait(for: [completion], timeout: 30, enforceOrder: true)
     }
     
     private func addData(withSyncIdentifiers syncIdentifiers: [UUID]) {


### PR DESCRIPTION
## Problem

LoopWorkspace CI on `update_dev_to_3.14.5` fails in **Run Tests** with a single failure:

```
CarbStoreHKQueryTestsAuthorized.testObserverQueryStartup
✖ Asynchronous wait failed: Exceeded timeout of 2 seconds,
  with unfulfilled expectations: "observer query started"
```

Which class loses varies per run — the three sibling `testObserverQueryStartup` variants passed in ~0.07s each in the same job.

## Root cause

The `*Authorized` subclasses set `.sharingAuthorized` **before** `super.setUp()`, so the store is already authorized when it is constructed and `HealthKitSampleStore` can start its observer query during `setUp` — before the test body runs.

`HKHealthStoreMock.execute` fulfills through an optional:

```swift
observerQuery = q
observerQueryStartedExpectation?.fulfill()   // dropped when not yet assigned
```

If the query starts before the expectation is assigned, the fulfillment is dropped and the wait can never succeed. **This is an ordering bug, not a slow test** — no timeout value fixes it.

## Commits

**1. Cherry-pick `e5e1e7d9` "More circleci failures. (#598)"** — never reached the dev lineage (`a5beee96` is not a descendant). Conflict in `DoseStoreTests.swift` resolved to dev's synchronous `waitForExpectations(timeout: 30)`; next-dev's `await fulfillment(...)` won't compile there because `testAddPumpEventsProgrammedByPumpUI` is not `async` on this branch.

**2. Sweep 70 remaining 2s/3s waits to 30s** across 8 files that #598 didn't reach. All are waits on async store operations. Neither test target contains inverted expectations, so a longer timeout cannot turn a passing test into a failing one. The lone 1.0s wait in `CoreDataMigrationTests` is fulfilled inside `performAndWait` before the wait begins and cannot flake, so it's left alone.

**3. Fix the actual race** — the three `*Authorized` startup tests now wait on the mock's recorded query, which is order-independent:

```swift
let observerQueryStarted = XCTNSPredicateExpectation(
    predicate: NSPredicate { [weak self] _, _ in self?.mockHealthStore.observerQuery != nil },
    object: nil)
wait(for: [observerQueryStarted], timeout: 30)
```

Commits 1–2 alone are **not sufficient**: with a 30s timeout, `InsulinDeliveryStoreTestsAuthorized` still failed after the full 30 seconds locally. Commit 3 is the fix; 1–2 keep dev aligned with next-dev and remove the other short timeouts.

### Why not fix the mock

Fulfilling on assignment when a query already exists would break tests that assign a fresh expectation to await a **new** observer query while an earlier one is still recorded (`GlucoseStoreTests.swift:185`, "new observer query started") — they would pass without a new query ever starting.

## Verification

Run in a worktree at LoopWorkspace `cc2c930` (the CI-failing rev), using CI's exact command.

- **Before:** `InsulinDeliveryStoreTestsAuthorized.testObserverQueryStartup` failed after the full 30s timeout
- **After:** 12 consecutive runs of the three affected classes — 0 failures
- **Full suite:** `** TEST SUCCEEDED **`, exit 0, no failures

## Note for next-dev

next-dev received only the timeout bump, so **the same latent race is still there**. It flakes less, not never. Worth porting commit 3 separately.